### PR TITLE
Compare reports/Add namespaced plugin id

### DIFF
--- a/compare-reports/core/build.gradle
+++ b/compare-reports/core/build.gradle
@@ -3,12 +3,12 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.5'
+        classpath 'com.novoda:bintray-release:0.3.0'
     }
 }
 
 apply plugin: 'groovy'
-apply plugin: 'bintray-release'
+apply plugin: 'com.novoda.bintray-release'
 
 compileGroovy {
     sourceCompatibility = '1.6'

--- a/compare-reports/core/src/main/resources/META-INF/gradle-plugins/com.novoda.compare-reports.properties
+++ b/compare-reports/core/src/main/resources/META-INF/gradle-plugins/com.novoda.compare-reports.properties
@@ -1,0 +1,1 @@
+implementation-class=com.novoda.comparereports.ComparePlugin


### PR DESCRIPTION
This PR adds namespaced plugin id com.novoda.compare-reports.

The old plugin id is deprecated.
This PR also updates the bintray-release plugin to use the namespaced id.