### PR TITLE
Talkback navdrawer

### DIFF
--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
@@ -40,14 +40,15 @@ public abstract class DrawerActivity extends AppCompatActivity {
                 new AdapterView.OnItemClickListener() {
                     @Override
                     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                        Intent intent;
-                        if (position == 0) {
-                            intent = new Intent(DrawerActivity.this, EarthActivity.class);
-                        } else {
-                            intent = new Intent(DrawerActivity.this, SaturnActivity.class);
-                        }
+                        startActivity(createIntentForItem(position));
+                    }
 
-                        startActivity(intent);
+                    private Intent createIntentForItem(int position) {
+                        if (position == 0) {
+                            return new Intent(DrawerActivity.this, EarthActivity.class);
+                        } else {
+                            return new Intent(DrawerActivity.this, SaturnActivity.class);
+                        }
                     }
                 }
         );

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
@@ -2,6 +2,7 @@ package com.novoda.activitytalkbackinvestigation;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.LayoutRes;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
@@ -14,21 +15,20 @@ import android.widget.ListView;
 
 public abstract class DrawerActivity extends AppCompatActivity {
 
+    private Intent pendingNavigationClick;
+
     @Override
-    public void setContentView(int layoutResID) {
+    public void setContentView(@LayoutRes int layoutResID) {
         super.setContentView(R.layout.drawer_layout);
-
         ViewGroup contentView = (ViewGroup) findViewById(R.id.content_frame);
-
         getLayoutInflater().inflate(layoutResID, contentView);
         setupDrawer();
     }
 
-    Intent pendingNavigationClick;
-
     private void setupDrawer() {
         ListView listView = (ListView) findViewById(R.id.left_drawer);
         listView.setAdapter(createDrawerAdapter(this));
+
         final DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         listView.setOnItemClickListener(
                 new AdapterView.OnItemClickListener() {

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
@@ -1,5 +1,6 @@
 package com.novoda.activitytalkbackinvestigation;
 
+import android.content.Context;
 import android.content.Intent;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
@@ -8,6 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
 import android.widget.ListView;
 
 public abstract class DrawerActivity extends AppCompatActivity {
@@ -23,32 +25,16 @@ public abstract class DrawerActivity extends AppCompatActivity {
     }
 
     private void setupDrawer() {
-        String[] planetTitles = new String[]{"Earth", "Saturn"};
         ListView listView = (ListView) findViewById(R.id.left_drawer);
-
-        // Set the adapter for the list view
-        listView.setAdapter(
-                new ArrayAdapter<>(
-                        this,
-                        android.R.layout.simple_list_item_1,
-                        planetTitles
-                )
-        );
-
+        listView.setAdapter(createDrawerAdapter(this));
         listView.setOnItemClickListener(
                 new AdapterView.OnItemClickListener() {
+
                     @Override
                     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                        startActivity(createIntentForItem(position));
+                        startActivity(createIntentForItem(position, DrawerActivity.this));
                     }
 
-                    private Intent createIntentForItem(int position) {
-                        if (position == 0) {
-                            return new Intent(DrawerActivity.this, EarthActivity.class);
-                        } else {
-                            return new Intent(DrawerActivity.this, SaturnActivity.class);
-                        }
-                    }
                 }
         );
 
@@ -56,4 +42,21 @@ public abstract class DrawerActivity extends AppCompatActivity {
         ActionBarDrawerToggle drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, R.string.drawer_open, R.string.drawer_close);
         drawerLayout.setDrawerListener(drawerToggle);
     }
+
+    private static ListAdapter createDrawerAdapter(Context context) {
+        return new ArrayAdapter<>(
+                context,
+                android.R.layout.simple_list_item_1,
+                new String[]{"Earth", "Saturn"}
+        );
+    }
+
+    private static Intent createIntentForItem(int itemPosition, Context context) {
+        if (itemPosition == 0) {
+            return new Intent(context, EarthActivity.class);
+        } else {
+            return new Intent(context, SaturnActivity.class);
+        }
+    }
+    
 }

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
@@ -25,10 +25,10 @@ public abstract class DrawerActivity extends AppCompatActivity {
     private void setupDrawer() {
         String[] planetTitles = new String[]{"Earth", "Saturn"};
         DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
-        ListView drawerList = (ListView) findViewById(R.id.left_drawer);
+        ListView listView = (ListView) findViewById(R.id.left_drawer);
 
         // Set the adapter for the list view
-        drawerList.setAdapter(
+        listView.setAdapter(
                 new ArrayAdapter<>(
                         this,
                         android.R.layout.simple_list_item_1,
@@ -36,7 +36,7 @@ public abstract class DrawerActivity extends AppCompatActivity {
                 )
         );
 
-        drawerList.setOnItemClickListener(
+        listView.setOnItemClickListener(
                 new AdapterView.OnItemClickListener() {
                     @Override
                     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
@@ -24,22 +24,38 @@ public abstract class DrawerActivity extends AppCompatActivity {
         setupDrawer();
     }
 
+    Intent pendingNavigationClick;
+
     private void setupDrawer() {
         ListView listView = (ListView) findViewById(R.id.left_drawer);
         listView.setAdapter(createDrawerAdapter(this));
+        final DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         listView.setOnItemClickListener(
                 new AdapterView.OnItemClickListener() {
 
                     @Override
                     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                        startActivity(createIntentForItem(position, DrawerActivity.this));
+                        pendingNavigationClick = createIntentForItem(position, DrawerActivity.this);
+                        drawerLayout.closeDrawers();
                     }
 
                 }
         );
 
-        DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
-        ActionBarDrawerToggle drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, R.string.drawer_open, R.string.drawer_close);
+        ActionBarDrawerToggle drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, R.string.drawer_open, R.string.drawer_close) {
+
+            @Override
+            public void onDrawerClosed(View drawerView) {
+                super.onDrawerClosed(drawerView);
+                // waiting for the drawer to close, then navigating seems to cause issue.
+                // why wait for the drawer to close? jankiness.
+                if (pendingNavigationClick != null) {
+                    startActivity(pendingNavigationClick);
+                    pendingNavigationClick = null;
+                }
+            }
+
+        };
         drawerLayout.setDrawerListener(drawerToggle);
     }
 
@@ -58,5 +74,5 @@ public abstract class DrawerActivity extends AppCompatActivity {
             return new Intent(context, SaturnActivity.class);
         }
     }
-    
+
 }

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/DrawerActivity.java
@@ -24,7 +24,6 @@ public abstract class DrawerActivity extends AppCompatActivity {
 
     private void setupDrawer() {
         String[] planetTitles = new String[]{"Earth", "Saturn"};
-        DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         ListView listView = (ListView) findViewById(R.id.left_drawer);
 
         // Set the adapter for the list view
@@ -53,6 +52,7 @@ public abstract class DrawerActivity extends AppCompatActivity {
                 }
         );
 
+        DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         ActionBarDrawerToggle drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, R.string.drawer_open, R.string.drawer_close);
         drawerLayout.setDrawerListener(drawerToggle);
     }

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/ProHaxDrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/ProHaxDrawerActivity.java
@@ -18,6 +18,8 @@ import android.widget.ListView;
 
 public abstract class ProHaxDrawerActivity extends AppCompatActivity {
 
+    private static final String EXTRA_INTERNAL_NAV = BuildConfig.APPLICATION_ID + "EXTRA_INTERNAL_NAV";
+
     private DrawerLayout drawerLayout;
 
     @Override
@@ -26,8 +28,11 @@ public abstract class ProHaxDrawerActivity extends AppCompatActivity {
         ViewGroup contentView = (ViewGroup) findViewById(R.id.content_frame);
         getLayoutInflater().inflate(layoutResID, contentView);
         setupDrawer();
-        drawerLayout.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
-        drawerLayout.openDrawer(GravityCompat.START);
+
+        if (getIntent().getExtras() != null && getIntent().getExtras().containsKey(EXTRA_INTERNAL_NAV)) {
+            drawerLayout.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+            drawerLayout.openDrawer(GravityCompat.START);
+        }
     }
 
     @Override
@@ -80,11 +85,14 @@ public abstract class ProHaxDrawerActivity extends AppCompatActivity {
     }
 
     private static Intent createIntentForItem(int itemPosition, Context context) {
+        Intent intent;
         if (itemPosition == 0) {
-            return new Intent(context, EarthActivity.class);
+            intent = new Intent(context, EarthActivity.class);
         } else {
-            return new Intent(context, SaturnActivity.class);
+            intent = new Intent(context, SaturnActivity.class);
         }
+        intent.putExtra(EXTRA_INTERNAL_NAV, true);
+        return intent;
     }
 
     @Override

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/ProHaxDrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/ProHaxDrawerActivity.java
@@ -26,6 +26,7 @@ public abstract class ProHaxDrawerActivity extends AppCompatActivity {
         ViewGroup contentView = (ViewGroup) findViewById(R.id.content_frame);
         getLayoutInflater().inflate(layoutResID, contentView);
         setupDrawer();
+        drawerLayout.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
         drawerLayout.openDrawer(GravityCompat.START);
     }
 
@@ -37,6 +38,7 @@ public abstract class ProHaxDrawerActivity extends AppCompatActivity {
                 @Override
                 public void run() {
                     drawerLayout.closeDrawer(GravityCompat.START);
+                    drawerLayout.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
                 }
             }, 1000);
         }

--- a/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/ProHaxDrawerActivity.java
+++ b/ActivityTalkbackInvestigation/app/src/main/java/com/novoda/activitytalkbackinvestigation/ProHaxDrawerActivity.java
@@ -1,0 +1,97 @@
+package com.novoda.activitytalkbackinvestigation;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.LayoutRes;
+import android.support.v4.view.GravityCompat;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBarDrawerToggle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+
+public abstract class ProHaxDrawerActivity extends AppCompatActivity {
+
+    private DrawerLayout drawerLayout;
+
+    @Override
+    public void setContentView(@LayoutRes int layoutResID) {
+        super.setContentView(R.layout.drawer_layout);
+        ViewGroup contentView = (ViewGroup) findViewById(R.id.content_frame);
+        getLayoutInflater().inflate(layoutResID, contentView);
+        setupDrawer();
+        drawerLayout.openDrawer(GravityCompat.START);
+    }
+
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        if (drawerLayout.isDrawerOpen(GravityCompat.START)) {
+            new Handler(getMainLooper()).postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    drawerLayout.closeDrawer(GravityCompat.START);
+                }
+            }, 1000);
+        }
+    }
+
+    private void setupDrawer() {
+        ListView listView = (ListView) findViewById(R.id.left_drawer);
+        listView.setAdapter(createDrawerAdapter(this));
+
+        drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+        listView.setOnItemClickListener(
+                new AdapterView.OnItemClickListener() {
+
+                    @Override
+                    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                        startActivity(createIntentForItem(position, ProHaxDrawerActivity.this));
+                        overridePendingTransition(0, 0);
+                        new Handler(getMainLooper()).postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                drawerLayout.closeDrawer(GravityCompat.START);
+                            }
+                        }, 500);
+                    }
+
+                }
+        );
+
+        ActionBarDrawerToggle drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, R.string.drawer_open, R.string.drawer_close);
+        drawerLayout.setDrawerListener(drawerToggle);
+    }
+
+    private static ListAdapter createDrawerAdapter(Context context) {
+        return new ArrayAdapter<>(
+                context,
+                android.R.layout.simple_list_item_1,
+                new String[]{"Earth", "Saturn"}
+        );
+    }
+
+    private static Intent createIntentForItem(int itemPosition, Context context) {
+        if (itemPosition == 0) {
+            return new Intent(context, EarthActivity.class);
+        } else {
+            return new Intent(context, SaturnActivity.class);
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (drawerLayout.isDrawerOpen(GravityCompat.START)) {
+            drawerLayout.closeDrawers();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+}


### PR DESCRIPTION
@Electryc @blundell @Dorvaryn 

- We don't navigate on navigation item click for some reason (jankiness)
- We use the `onDrawerClosed` event to then actually navigate.
- Closing the open drawer will trigger an a11y event - it'll announce the drawer has been closed, and then it'll read the now visible (the old one) activity, followed by the new one.

I think this is because the messages are queued - Kelly Shuster mentioned something in her berlin talk about "polite" mode (I forget the details) where you can either mark your accessibility announcements as polite/brutal to wait til it's finished what it's saying or interrupt it. Perhaps it ought to be in brutal mode, but I don't think that's under our control.