### PR TITLE
Enews node variant

### DIFF
--- a/enews-node/.gitignore
+++ b/enews-node/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/enews-node/app.js
+++ b/enews-node/app.js
@@ -1,0 +1,19 @@
+var NewsFetcher = require('./newsFetcher.js')
+
+var token = process.env.token;
+var newsFetcher = new NewsFetcher(token);
+
+var latestDate = new Date();
+var oldestDate = new Date();
+
+oldestDate.setDate(latestDate.getDate() - 31);
+
+// node timestamps are in milliseconds, need to convert to epoch
+var latest = latestDate / 1000;
+var oldest = oldestDate / 1000;
+
+newsFetcher.getEnews(oldest, latest, function(eNews) {
+  eNews.forEach(function(each) {
+    console.log(each);
+  });
+});

--- a/enews-node/newsFetcher.js
+++ b/enews-node/newsFetcher.js
@@ -1,0 +1,72 @@
+module.exports = NewsFetcher;
+
+function NewsFetcher(token) {
+  const GENERAL_CHANNEL_ID = 'C029J9QTH'
+  const HISTORY_ENDPOINT = 'https://slack.com/api/channels.history'
+  const MESSAGE_COUNT = 1000;
+
+  var httpClient = require('request');
+
+  this.getEnews = function getEnews(oldest, latest, callback) {
+    var allEnews = [];
+    var handler = function(enews, hasMore, reducedLatest) {
+      allEnews = allEnews.concat(enews);
+      if (hasMore) {
+        getSlackHistory(createHistoryRequest(oldest, reducedLatest), handler);
+      } else {
+        callback(allEnews);
+      }
+    }
+    getSlackHistory(createHistoryRequest(oldest, latest), handler);
+  }
+
+  function getSlackHistory(request, callback) {
+    httpClient.get(request, function(error, response, body) {
+      var jsonBody = JSON.parse(body);
+      var messages = jsonBody.messages;
+      var enews = parseMessages(messages);
+      var reducedLatest = messages[messages.length - 1].ts;
+      callback(enews, jsonBody.has_more, reducedLatest);
+    });
+  }
+
+  function parseMessages(messages) {
+    var enews = [];
+    messages.forEach(function(message) {
+      if (isEnewsMessage(message)) {
+        enews.push(message.text);
+      }
+    });
+    return enews;
+  }
+
+  function isEnewsMessage(message) {
+    return isValidMessage(message) && isEnews(message.text)
+  }
+
+  function isEnews(messageText) {
+    return contains(messageText, '#enews') || contains(messageText, '#eNews');
+  }
+
+  function isValidMessage(message) {
+    return !message.bot_id && message.type == 'message'
+  }
+
+  function contains(input, check) {
+    return input.indexOf(check) > -1;
+  }
+
+  function createHistoryRequest(oldest, latest) {
+    return {
+      url: HISTORY_ENDPOINT,
+      qs: {
+        token: token,
+        channel: GENERAL_CHANNEL_ID,
+        count: MESSAGE_COUNT,
+        oldest: oldest,
+        latest: latest
+      }
+    }
+  };
+
+}

--- a/enews-node/package.json
+++ b/enews-node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "enews",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "request": "^2.69.0"
+  }
+}


### PR DESCRIPTION
Uses nodejs to parse all the slack general channel history for `#enews`, we can pass the amount of days to backtrace and the latest day.

run with `token=bamtoken node app.js`

```
#eNews go incognito and <http://www.twitter.com|www.twitter.com> <http://www.bbc.co.uk/news/technology-35481975>
forgot this in #enews but it seems pretty cool to me <https://sketchfab.com/>
#enews <http://motherboard.vice.com/read/google-will-soon-shame-all-websites-that-are-unencrypted-chrome-https>
#enews Combinations for a go board of 19x19 =&gt; <http://tromp.github.io/go/legal.html>
#enews: <https://twitter.com/tomgara/status/692111800289095682?s=09>
#enews <https://github.com/brave/browser-android>
#enews <http://www.bbc.co.uk/news/entertainment-arts-35371204>
#enews <http://www.theguardian.com/uk-news/2016/jan/21/tfl-londons-commuter-rail-services-department-for-transport|www.theguardian.com/uk-news/2016/jan/21/tfl-londons-commuter-rail-services-department-for-transport>
#enews <https://youtu.be/y-WQ6qORAZ4>
#enews <http://mobile.nytimes.com/2016/01/24/arts/television/the-x-files-david-duchovny-and-gillian-anderson-return-to-the-paranormal-beat.html>
#enews Colossal star explosion detected
<http://www.bbc.co.uk/news/science-environment-35315509>
#enews Fake Old Woman <http://www.wcvb.com/news/rhode-island-official-tells-man-to-dress-as-woman-for-media-event/37425596>
#enews: <http://www.theverge.com/2016/1/13/10762076/mubi-china-movie-streaming-huanxi-media>
Also, not sure if it was #enews, but Netflix is now in 130 more countries
#enews BBC news reporter breaks world’s safest drone <http://www.bbc.co.uk/news/technology-35240062>
and last, #enews oh god I hope I don’t have to come in on Monday :simple_smile: <http://www.bbc.co.uk/news/uk-35240597>
#enews sugar app that I can’t even use : <http://www.bbc.co.uk/news/health-35199889>
oh the #enews I forgot good article on history of IE <http://www.bbc.co.uk/newsbeat/article/31945739/rip-internet-explorer-how-you-were-mocked>
```