### PR TITLE
React/PT-69/Tweets list

### DIFF
--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -13,7 +13,7 @@ class TweetsList extends Component {
 
   constructor (props) {
     super(props)
-    var dataSource = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+    var dataSource = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2})
     this.state = {
       dataSource: dataSource.cloneWithRows([
         {
@@ -21,7 +21,7 @@ class TweetsList extends Component {
           user: {
             name: 'User 1',
             screen_name: 'user_1',
-            profile_image_url: 'http:\/\/pbs.twimg.com\/profile_images\/2215576731\/ars-logo_normal.png'
+            profile_image_url: 'http://pbs.twimg.com/profile_images/2215576731/ars-logo_normal.png'
           },
           text: 'this is the first tweet'
         },
@@ -30,7 +30,7 @@ class TweetsList extends Component {
           user: {
             name: 'User 2',
             screen_name: 'another_user',
-            profile_image_url: 'http:\/\/pbs.twimg.com\/profile_images\/655059892022022144\/Pq3Q_1oU_normal.png'
+            profile_image_url: 'http://pbs.twimg.com/profile_images/655059892022022144/Pq3Q_1oU_normal.png'
           },
           text: 'this is the a cool tweet!!1!'
         },
@@ -39,12 +39,12 @@ class TweetsList extends Component {
           user: {
             name: 'User 1',
             screen_name: 'user_1',
-            profile_image_url: 'http:\/\/pbs.twimg.com\/profile_images\/2215576731\/ars-logo_normal.png'
+            profile_image_url: 'http://pbs.twimg.com/profile_images/2215576731/ars-logo_normal.png'
           },
           text: 'this is the second tweet'
-        },
-      ]),
-    };
+        }
+      ])
+    }
   }
 
   tweetSelected (tweetId) {
@@ -61,7 +61,7 @@ class TweetsList extends Component {
          underlayColor='#dddddd'>
        <View>
         <View style={styles.rowContainer}>
-          <Image style={styles.thumb} source={{ uri: rowData.user.profile_image_url }} />
+          <Image style={styles.tweet_avatar} source={{ uri: rowData.user.profile_image_url }} />
           <View style={styles.textContainer}>
             <Text style={styles.tweet_author}>{rowData.user.name}</Text>
             <Text style={styles.tweet_author_handle}>{rowData.user.screen_name}</Text>
@@ -71,7 +71,7 @@ class TweetsList extends Component {
          <View style={styles.separator}/>
        </View>
      </TouchableHighlight>
-    );
+    )
   }
 
   render () {
@@ -80,16 +80,11 @@ class TweetsList extends Component {
         dataSource={this.state.dataSource}
         renderRow={this.renderRow.bind(this)}
       />
-    );
+    )
   }
 }
 
 const styles = StyleSheet.create({
-  thumb: {
-    width: 80,
-    height: 80,
-    marginRight: 10
-  },
   textContainer: {
     flex: 1
   },
@@ -110,6 +105,11 @@ const styles = StyleSheet.create({
   tweet_text: {
     fontSize: 20,
     color: '#656565'
+  },
+  tweet_avatar: {
+    width: 80,
+    height: 80,
+    marginRight: 10
   },
   rowContainer: {
     flexDirection: 'row',

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -33,10 +33,17 @@ class TweetsList extends Component {
     };
   }
 
+  tweetSelected (tweetId) {
+    // TODO: navigate to tweet detail screen
+    Alert.alert(
+      'Tweet selected',
+      'User selected tweet with id=' + tweetId
+    )
+  }
 
   renderRow (rowData, sectionID, rowID) {
     return (
-      <TouchableHighlight 
+      <TouchableHighlight onPress={() => this.tweetSelected(rowData.id)}
          underlayColor='#dddddd'>
        <View>
         <View style={styles.rowContainer}>

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -3,12 +3,14 @@ import {
   Alert,
   StyleSheet,
   View,
+  Image,
   ListView,
   Text,
   TouchableHighlight
 } from 'react-native'
 
 class TweetsList extends Component {
+
   constructor (props) {
     super(props)
     var dataSource = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
@@ -16,17 +18,29 @@ class TweetsList extends Component {
       dataSource: dataSource.cloneWithRows([
         {
           id: '1',
-          user: 'user 1',
+          user: {
+            name: 'User 1',
+            screen_name: 'user_1',
+            profile_image_url: 'http:\/\/pbs.twimg.com\/profile_images\/2215576731\/ars-logo_normal.png'
+          },
           text: 'this is the first tweet'
         },
         {
           id: '2',
-          user: 'user 2',
+          user: {
+            name: 'User 2',
+            screen_name: 'another_user',
+            profile_image_url: 'http:\/\/pbs.twimg.com\/profile_images\/655059892022022144\/Pq3Q_1oU_normal.png'
+          },
           text: 'this is the a cool tweet!!1!'
         },
         {
           id: '3',
-          user: 'user 1',
+          user: {
+            name: 'User 1',
+            screen_name: 'user_1',
+            profile_image_url: 'http:\/\/pbs.twimg.com\/profile_images\/2215576731\/ars-logo_normal.png'
+          },
           text: 'this is the second tweet'
         },
       ]),
@@ -47,9 +61,11 @@ class TweetsList extends Component {
          underlayColor='#dddddd'>
        <View>
         <View style={styles.rowContainer}>
+          <Image style={styles.thumb} source={{ uri: rowData.user.profile_image_url }} />
           <View style={styles.textContainer}>
-            <Text>{rowData.user}</Text>
-            <Text>{rowData.text}</Text>
+            <Text style={styles.tweet_author}>{rowData.user.name}</Text>
+            <Text style={styles.tweet_author_handle}>{rowData.user.screen_name}</Text>
+            <Text style={styles.tweet_text}>{rowData.text}</Text>
           </View>
          </View>
          <View style={styles.separator}/>
@@ -85,6 +101,11 @@ const styles = StyleSheet.create({
     fontSize: 25,
     fontWeight: 'bold',
     color: '#48BBEC'
+  },
+  tweet_author_handle: {
+    fontSize: 20,
+    fontStyle: 'italic',
+    color: '#656565'
   },
   tweet_text: {
     fontSize: 20,

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -1,0 +1,92 @@
+import React, { Component } from 'react'
+import {
+  Alert,
+  StyleSheet,
+  View,
+  ListView,
+  Text,
+  TouchableHighlight
+} from 'react-native'
+
+class TweetsList extends Component {
+  constructor (props) {
+    super(props)
+    var dataSource = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+    this.state = {
+      dataSource: dataSource.cloneWithRows([
+        {
+          id: '1',
+          user: 'user 1',
+          text: 'this is the first tweet'
+        },
+        {
+          id: '2',
+          user: 'user 2',
+          text: 'this is the a cool tweet!!1!'
+        },
+        {
+          id: '3',
+          user: 'user 1',
+          text: 'this is the second tweet'
+        },
+      ]),
+    };
+  }
+
+
+  renderRow (rowData, sectionID, rowID) {
+    return (
+      <TouchableHighlight 
+         underlayColor='#dddddd'>
+       <View>
+        <View style={styles.rowContainer}>
+          <View style={styles.textContainer}>
+            <Text>{rowData.user}</Text>
+            <Text>{rowData.text}</Text>
+          </View>
+         </View>
+         <View style={styles.separator}/>
+       </View>
+     </TouchableHighlight>
+    );
+  }
+
+  render () {
+    return (
+      <ListView
+        dataSource={this.state.dataSource}
+        renderRow={this.renderRow.bind(this)}
+      />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  thumb: {
+    width: 80,
+    height: 80,
+    marginRight: 10
+  },
+  textContainer: {
+    flex: 1
+  },
+  separator: {
+    height: 1,
+    backgroundColor: '#dddddd'
+  },
+  tweet_author: {
+    fontSize: 25,
+    fontWeight: 'bold',
+    color: '#48BBEC'
+  },
+  tweet_text: {
+    fontSize: 20,
+    color: '#656565'
+  },
+  rowContainer: {
+    flexDirection: 'row',
+    padding: 10
+  }
+})
+
+module.exports = TweetsList

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -1,13 +1,6 @@
 import React, { Component } from 'react'
-import {
-  Alert,
-  StyleSheet,
-  View,
-  Image,
-  ListView,
-  Text,
-  TouchableHighlight
-} from 'react-native'
+import { ListView } from 'react-native'
+import TweetsListItem from './tweetsListItem'
 
 class TweetsList extends Component {
 
@@ -47,30 +40,15 @@ class TweetsList extends Component {
     }
   }
 
-  tweetSelected (tweetId) {
-    // TODO: navigate to tweet detail screen
-    Alert.alert(
-      'Tweet selected',
-      'User selected tweet with id=' + tweetId
-    )
-  }
-
-  renderRow (rowData, sectionID, rowID) {
+  renderRow (rowData) {
     return (
-      <TouchableHighlight onPress={() => this.tweetSelected(rowData.id)}
-         underlayColor='#dddddd'>
-       <View>
-        <View style={styles.rowContainer}>
-          <Image style={styles.tweet_avatar} source={{ uri: rowData.user.profile_image_url }} />
-          <View style={styles.textContainer}>
-            <Text style={styles.tweet_author}>{rowData.user.name}</Text>
-            <Text style={styles.tweet_author_handle}>{rowData.user.screen_name}</Text>
-            <Text style={styles.tweet_text}>{rowData.text}</Text>
-          </View>
-         </View>
-         <View style={styles.separator}/>
-       </View>
-     </TouchableHighlight>
+       <TweetsListItem
+          id={rowData.id}
+          author_avatar={rowData.user.profile_image_url}
+          author_name={rowData.user.name}
+          author_handle={rowData.user.screen_name}
+          text={rowData.text}
+        />
     )
   }
 
@@ -83,38 +61,5 @@ class TweetsList extends Component {
     )
   }
 }
-
-const styles = StyleSheet.create({
-  textContainer: {
-    flex: 1
-  },
-  separator: {
-    height: 1,
-    backgroundColor: '#dddddd'
-  },
-  tweet_author: {
-    fontSize: 25,
-    fontWeight: 'bold',
-    color: '#48BBEC'
-  },
-  tweet_author_handle: {
-    fontSize: 20,
-    fontStyle: 'italic',
-    color: '#656565'
-  },
-  tweet_text: {
-    fontSize: 20,
-    color: '#656565'
-  },
-  tweet_avatar: {
-    width: 80,
-    height: 80,
-    marginRight: 10
-  },
-  rowContainer: {
-    flexDirection: 'row',
-    padding: 10
-  }
-})
 
 module.exports = TweetsList

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import {
+  Alert,
+  StyleSheet,
+  View,
+  Image,
+  Text,
+  TouchableHighlight
+} from 'react-native'
+
+var TweetsListItem = React.createClass({
+  propTypes: {
+    id: React.PropTypes.string.isRequired,
+    author_avatar: React.PropTypes.string.isRequired,
+    author_name: React.PropTypes.string.isRequired,
+    author_handle: React.PropTypes.string.isRequired,
+    text: React.PropTypes.string.isRequired
+  },
+
+  render () {
+    return (
+      <TouchableHighlight onPress={() => this.tweetSelected(this.props.id)}
+        underlayColor='#dddddd'>
+         <View>
+          <View style={styles.rowContainer}>
+            <Image style={styles.tweet_avatar} source={{ uri: this.props.author_avatar }} />
+            <View style={styles.textContainer}>
+              <Text style={styles.tweet_author}>{this.props.author_name}</Text>
+              <Text style={styles.tweet_author_handle}>{this.props.author_handle}</Text>
+              <Text style={styles.tweet_text}>{this.props.text}</Text>
+            </View>
+           </View>
+           <View style={styles.separator}/>
+         </View>
+       </TouchableHighlight>
+    )
+  },
+
+  tweetSelected (tweetId) {
+    // TODO: navigate to tweet detail screen
+    Alert.alert(
+      'Tweet selected',
+      'User selected tweet with id=' + tweetId
+    )
+  }
+
+})
+
+const styles = StyleSheet.create({
+  textContainer: {
+    flex: 1
+  },
+  separator: {
+    height: 1,
+    backgroundColor: '#dddddd'
+  },
+  tweet_author: {
+    fontSize: 25,
+    fontWeight: 'bold',
+    color: '#48BBEC'
+  },
+  tweet_author_handle: {
+    fontSize: 20,
+    fontStyle: 'italic',
+    color: '#656565'
+  },
+  tweet_text: {
+    fontSize: 20,
+    color: '#656565'
+  },
+  tweet_avatar: {
+    width: 80,
+    height: 80,
+    marginRight: 10
+  },
+  rowContainer: {
+    flexDirection: 'row',
+    padding: 10
+  }
+})
+
+module.exports = TweetsListItem


### PR DESCRIPTION
This PR adds two components shared for both iOS and Android:

- a tweets list component, which in the constructor initialises a mock set of data with a structure similar to the real Twitter data for the home tweet feed
- a single tweet item component, which displays some of the tweet data given a single row passed from the list

Screenshots: 

| iOS | Android |
| --- | --- |
| ![screen shot 2016-05-11 at 12 35 26](https://cloud.githubusercontent.com/assets/3942812/15208473/09868ff0-182c-11e6-957d-74fdb0e5c33c.png) | ![screen shot 2016-05-11 at 12 35 06](https://cloud.githubusercontent.com/assets/3942812/15208479/0fe0acc8-182c-11e6-864c-9129743014dd.png) |

Paired with: 
@me 