### PR TITLE
bonfire/Disable submit button when message is empty

### DIFF
--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/view/ChatView.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/view/ChatView.java
@@ -3,6 +3,8 @@ package com.novoda.bonfire.chat.view;
 import android.content.Context;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -20,6 +22,7 @@ public class ChatView extends LinearLayout implements ChatDisplayer {
     private View submitButton;
     private RecyclerView recyclerView;
 
+    private ChatActionListener actionListener;
     public ChatView(Context context, AttributeSet attrs) {
         super(context, attrs);
         setOrientation(VERTICAL);
@@ -41,6 +44,8 @@ public class ChatView extends LinearLayout implements ChatDisplayer {
 
     @Override
     public void attach(final ChatActionListener actionListener) {
+        this.actionListener = actionListener;
+        messageView.addTextChangedListener(textWatcher);
         submitButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -53,6 +58,8 @@ public class ChatView extends LinearLayout implements ChatDisplayer {
     @Override
     public void detach(ChatActionListener actionListener) {
         submitButton.setOnClickListener(null);
+        messageView.removeTextChangedListener(textWatcher);
+        this.actionListener = null;
     }
 
     @Override
@@ -71,5 +78,20 @@ public class ChatView extends LinearLayout implements ChatDisplayer {
     public void disableInteraction() {
         submitButton.setEnabled(false);
     }
+
+    private final TextWatcher textWatcher = new TextWatcher() {
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        }
+
+        @Override
+        public void onTextChanged(CharSequence s, int start, int before, int count) {
+        }
+
+        @Override
+        public void afterTextChanged(Editable s) {
+            actionListener.onMessageLengthChanged(s.length());
+        }
+    };
 
 }

--- a/Firebase/android/core/src/main/java/com/novoda/bonfire/chat/displayer/ChatDisplayer.java
+++ b/Firebase/android/core/src/main/java/com/novoda/bonfire/chat/displayer/ChatDisplayer.java
@@ -14,7 +14,9 @@ public interface ChatDisplayer {
 
     void disableInteraction();
 
-    public interface ChatActionListener {
+    interface ChatActionListener {
+
+        void onMessageLengthChanged(int messageLength);
 
         void onSubmitMessage(String message);
 

--- a/Firebase/android/core/src/main/java/com/novoda/bonfire/chat/presenter/ChatPresenter.java
+++ b/Firebase/android/core/src/main/java/com/novoda/bonfire/chat/presenter/ChatPresenter.java
@@ -43,7 +43,6 @@ public class ChatPresenter {
                     @Override
                     public void call(Authentication authentication) {
                         ChatPresenter.this.user = authentication.getUser(); //TODO handle missing auth
-                        chatDisplayer.enableInteraction();
                     }
                 })
         );
@@ -57,9 +56,22 @@ public class ChatPresenter {
 
     private final ChatDisplayer.ChatActionListener actionListener = new ChatDisplayer.ChatActionListener() {
         @Override
+        public void onMessageLengthChanged(int messageLength) {
+            if (userIsAuthenticated() && messageLength > 0) {
+                chatDisplayer.enableInteraction();
+            } else {
+                chatDisplayer.disableInteraction();
+            }
+        }
+
+        @Override
         public void onSubmitMessage(String message) {
             chatService.sendMessage(new Message(user, message));
         }
     };
+
+    private boolean userIsAuthenticated() {
+        return user != null;
+    }
 
 }


### PR DESCRIPTION
The submit button is disabled when there is no text in the message input in order to prevent users from sending empty messages.

Paired with
@tobiasheine 