### PR TITLE
React/PT-70/tweet detail

### DIFF
--- a/ReactNative/ReactTwitter/core/views/common/data-format.js
+++ b/ReactNative/ReactTwitter/core/views/common/data-format.js
@@ -1,0 +1,9 @@
+var dateFormat = require('dateformat')
+
+class NovodaDataFormat {
+  static longTime(time) {
+    return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
+  }
+}
+
+module.exports = NovodaDataFormat

--- a/ReactNative/ReactTwitter/core/views/common/data-format.js
+++ b/ReactNative/ReactTwitter/core/views/common/data-format.js
@@ -1,7 +1,7 @@
 var dateFormat = require('dateformat')
 
 class NovodaDataFormat {
-  static longTime(time) {
+  static longTime (time) {
     return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
   }
 }

--- a/ReactNative/ReactTwitter/core/views/debug-screen.js
+++ b/ReactNative/ReactTwitter/core/views/debug-screen.js
@@ -25,6 +25,10 @@ var DebugScreenView = React.createClass({
           style={styles.button}
           styleDisabled={styles.button_disabled}
           onPress={this.pushTweetsList}>Tweets List</Button>
+        <Button
+          style={styles.button}
+          styleDisabled={styles.button_disabled}
+          onPress={this.pushTweetView}>Tweet Detail View</Button>
       </View>
     )
   },
@@ -35,6 +39,10 @@ var DebugScreenView = React.createClass({
 
   pushTweetsList () {
     this.props.navigator.push({id: 'tweets-list-identifier'})
+  },
+
+  pushTweetView () {
+    this.props.navigator.push({id: 'tweet-view-identifier'})
   }
 })
 

--- a/ReactNative/ReactTwitter/core/views/debug-screen.js
+++ b/ReactNative/ReactTwitter/core/views/debug-screen.js
@@ -42,7 +42,10 @@ var DebugScreenView = React.createClass({
   },
 
   pushTweetView () {
-    this.props.navigator.push({id: 'tweet-view-identifier'})
+    this.props.navigator.push({
+      id: 'tweet-view-identifier',
+      tweetId: '210462857140252672'
+    })
   }
 })
 

--- a/ReactNative/ReactTwitter/core/views/deep-linking.js
+++ b/ReactNative/ReactTwitter/core/views/deep-linking.js
@@ -11,7 +11,6 @@ var DeepLinkingFacade = require('../service/deep-linking-facade')
 var DeepLinkingView = React.createClass({
 
   getInitialState () {
-    console.log('Get initial state')
     return {
       facade: new DeepLinkingFacade(),
       deepLinkUrl: ''

--- a/ReactNative/ReactTwitter/core/views/deep-linking.js
+++ b/ReactNative/ReactTwitter/core/views/deep-linking.js
@@ -7,9 +7,10 @@ import {
 
 var Button = require('react-native-button')
 var DeepLinkingFacade = require('../service/deep-linking-facade')
+import AndroidBackNavigationMixin from './mixins/android-back-navigation'
 
 var DeepLinkingView = React.createClass({
-
+  mixins: [AndroidBackNavigationMixin],
   getInitialState () {
     return {
       facade: new DeepLinkingFacade(),

--- a/ReactNative/ReactTwitter/core/views/main-navigator.js
+++ b/ReactNative/ReactTwitter/core/views/main-navigator.js
@@ -6,10 +6,12 @@ import {
 var DebugScreenView = require('./debug-screen.js')
 var DeepLinkingView = require('./deep-linking.js')
 var TweetsList = require('./tweetsList.js')
+var TweetView = require('./tweetView.js')
 
 const debugScreenID = 'debug-screen-identifier'
 const deepLinkingID = 'deep-linking-identifier'
 const tweetsListID = 'tweets-list-identifier'
+const tweetViewID = 'tweet-view-identifier'
 
 var MainNavigator = React.createClass({
 
@@ -29,6 +31,8 @@ var MainNavigator = React.createClass({
         return (<DeepLinkingView navigator={navigator} title='Deep Linking' />)
       case tweetsListID:
         return (<TweetsList navigator={navigator} title='Tweets List' />)
+      case tweetViewID:
+        return (<TweetView navigator={navigator} title='Tweet View' />)
     }
   }
 })

--- a/ReactNative/ReactTwitter/core/views/main-navigator.js
+++ b/ReactNative/ReactTwitter/core/views/main-navigator.js
@@ -32,7 +32,7 @@ var MainNavigator = React.createClass({
       case tweetsListID:
         return (<TweetsList navigator={navigator} title='Tweets List' />)
       case tweetViewID:
-        return (<TweetView navigator={navigator} title='Tweet View' />)
+        return (<TweetView navigator={navigator} tweetId={route.tweetId} title='Tweet View' />)
     }
   }
 })

--- a/ReactNative/ReactTwitter/core/views/mixins/android-back-navigation.js
+++ b/ReactNative/ReactTwitter/core/views/mixins/android-back-navigation.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { BackAndroid, Navigator } from 'react-native'
+
+/*eslint-disable no-unused-vars*/
+var AndroidBackNavigationMixin = {
+  propTypes: {
+    navigator: React.PropTypes.instanceOf(Navigator).isRequired
+  },
+
+  componentDidMount () {
+    BackAndroid.addEventListener('hardwareBackPress', () => {
+      if (this.props.navigator.getCurrentRoutes().length === 1) {
+        return false
+      }
+      this.props.navigator.pop()
+      return true
+    })
+  },
+
+  componentWillUnmount: function () {
+    BackAndroid.removeEventListener('hardwareBackPress')
+  }
+}
+
+module.exports = AndroidBackNavigationMixin

--- a/ReactNative/ReactTwitter/core/views/mixins/android-back-navigation.js
+++ b/ReactNative/ReactTwitter/core/views/mixins/android-back-navigation.js
@@ -8,17 +8,20 @@ var AndroidBackNavigationMixin = {
   },
 
   componentDidMount () {
-    BackAndroid.addEventListener('hardwareBackPress', () => {
-      if (this.props.navigator.getCurrentRoutes().length === 1) {
-        return false
-      }
-      this.props.navigator.pop()
-      return true
-    })
+    BackAndroid.addEventListener('hardwareBackPress', this._handleBackAndroid)
   },
 
   componentWillUnmount: function () {
-    BackAndroid.removeEventListener('hardwareBackPress')
+    BackAndroid.removeEventListener('hardwareBackPress', this._handleBackAndroid)
+  },
+
+  _handleBackAndroid () {
+    if (this.props.navigator.getCurrentRoutes().length === 1) {
+      return false
+    }
+    this.props.navigator.pop()
+
+    return true
   }
 }
 

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -7,8 +7,7 @@ import {
   Navigator
 } from 'react-native'
 import AndroidBackNavigationMixin from './mixins/android-back-navigation'
-
-var dateFormat = require('dateformat')
+var novodaDataFormat = require('./common/data-format.js')
 
 var TweetsView = React.createClass({
   mixins: [AndroidBackNavigationMixin],
@@ -51,7 +50,7 @@ var TweetsView = React.createClass({
       return (<View />)
     }
 
-    var formattedTime = this._formatTime(Date.parse(this.state.tweet.created_at))
+    var formattedTime = novodaDataFormat.longTime(Date.parse(this.state.tweet.created_at))
     return (
       <View style={styles.mainContainer}>
         <View style={styles.header}>
@@ -67,10 +66,6 @@ var TweetsView = React.createClass({
         <Text style={styles.tweet_text}>{this.state.tweet.text}</Text>
       </View>
     )
-  },
-
-  _formatTime (time) {
-    return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
   }
 })
 

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -10,7 +10,7 @@ import {
 
 var TweetsView = React.createClass({
   propTypes: {
-    id: React.PropTypes.string.isRequired
+    tweetId: React.PropTypes.string.isRequired
   },
 
   getInitialState: function() {
@@ -24,7 +24,7 @@ var TweetsView = React.createClass({
   },
 
   _refreshData () {
-    var tweetId = '210462857140252672'
+    var tweetId = this.props.tweetId
     var url = 'https://api.twitter.com/1.1/statuses/show.json?id=' + tweetId
     fetch(url, {
       method: 'GET',

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -53,7 +53,6 @@ var TweetsView = React.createClass({
   },
 
   render () {
-    var tweetx = this.state.tweet
     if (!this.state.tweet.user) {
       return (<View />)
     }

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -5,24 +5,35 @@ import {
   View,
   Image,
   Text,
-  TouchableHighlight
+  BackAndroid,
+  Navigator
 } from 'react-native'
 
 var TweetsView = React.createClass({
   propTypes: {
-    tweetId: React.PropTypes.string.isRequired
+    tweetId: React.PropTypes.string.isRequired,
+    navigator: React.PropTypes.instanceOf(Navigator).isRequired
   },
 
-  getInitialState: function() {
+  getInitialState () {
     return {
-        tweet: {}
+      tweet: {}
     }
   },
 
   componentDidMount () {
+    BackAndroid.addEventListener('hardwareBackPress', () => {
+      if (this.props.navigator.getCurrentRoutes().length === 1) {
+        return false
+      }
+      this.props.navigator.pop()
+      return true
+    })
     this._refreshData()
   },
 
+  /*global fetch*/
+  /*eslint no-undef: "error"*/
   _refreshData () {
     var tweetId = this.props.tweetId
     var url = 'https://api.twitter.com/1.1/statuses/show.json?id=' + tweetId
@@ -34,7 +45,6 @@ var TweetsView = React.createClass({
     })
       .then((response) => response.json())
       .then((rjson) => {
-
         this.setState({
           tweet: rjson
         })
@@ -66,7 +76,6 @@ var TweetsView = React.createClass({
         <Text style={styles.tweet_text}>{this.state.tweet.text}</Text>
       </View>
     )
-
   },
 
   _formatTime (time) {
@@ -88,7 +97,7 @@ const styles = StyleSheet.create({
   textContainer: {
     flex: 1,
     flexDirection: 'row',
-    alignItems:'center'
+    alignItems: 'center'
   },
   tweet_author: {
     fontSize: 25,

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import {
-  Alert,
   StyleSheet,
   View,
   Image,
@@ -81,16 +80,7 @@ var TweetsView = React.createClass({
   _formatTime (time) {
     var dateFormat = require('dateformat')
     return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
-  },
-
-  _tweetSelected (tweetId) {
-    // TODO: navigate to tweet details screen
-    Alert.alert(
-      'Tweet selected',
-      'User selected tweet with id=' + tweetId
-    )
   }
-
 })
 
 const styles = StyleSheet.create({

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -4,13 +4,14 @@ import {
   View,
   Image,
   Text,
-  BackAndroid,
   Navigator
 } from 'react-native'
+import AndroidBackNavigationMixin from './mixins/android-back-navigation'
 
 var dateFormat = require('dateformat')
 
 var TweetsView = React.createClass({
+  mixins: [AndroidBackNavigationMixin],
   propTypes: {
     tweetId: React.PropTypes.string.isRequired,
     navigator: React.PropTypes.instanceOf(Navigator).isRequired
@@ -23,13 +24,6 @@ var TweetsView = React.createClass({
   },
 
   componentDidMount () {
-    BackAndroid.addEventListener('hardwareBackPress', () => {
-      if (this.props.navigator.getCurrentRoutes().length === 1) {
-        return false
-      }
-      this.props.navigator.pop()
-      return true
-    })
     this._refreshData()
   },
 

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -8,6 +8,8 @@ import {
   Navigator
 } from 'react-native'
 
+var dateFormat = require('dateformat')
+
 var TweetsView = React.createClass({
   propTypes: {
     tweetId: React.PropTypes.string.isRequired,
@@ -77,7 +79,6 @@ var TweetsView = React.createClass({
   },
 
   _formatTime (time) {
-    var dateFormat = require('dateformat')
     return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
   }
 })

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -48,7 +48,6 @@ var TweetsView = React.createClass({
           tweet: rjson
         })
       })
-      .done()
   },
 
   render () {

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -1,0 +1,125 @@
+import React from 'react'
+import {
+  Alert,
+  StyleSheet,
+  View,
+  Image,
+  Text,
+  TouchableHighlight
+} from 'react-native'
+
+var TweetsView = React.createClass({
+  propTypes: {
+    id: React.PropTypes.string.isRequired
+  },
+
+  getInitialState: function() {
+    return {
+        tweet: {}
+    }
+  },
+
+  componentDidMount () {
+    this._refreshData()
+  },
+
+  _refreshData () {
+    var tweetId = '210462857140252672'
+    var url = 'https://api.twitter.com/1.1/statuses/show.json?id=' + tweetId
+    fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': 'OAuth oauth_consumer_key="aqPSTs1FT2ndP7qXi247BtbXd", oauth_nonce="9e48307c7ed7184557a3d88f6331f00f", oauth_signature="Jr9YqRlJ%2BNH%2BBgLC9cI%2F7LD06qg%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1463143567", oauth_token="730013266697654273-RDssoTCOdHNQtFA9k87OSijeZHcF4SU", oauth_version="1.0"'
+      }
+    })
+      .then((response) => response.json())
+      .then((rjson) => {
+
+        this.setState({
+          tweet: rjson
+        })
+      })
+      .done()
+  },
+
+  render () {
+    var tweetx = this.state.tweet
+    console.log('render')
+    console.log(tweetx)
+    if (!this.state.tweet.user) {
+      return (<View />)
+    }
+
+    var formattedTime = this._formatTime(Date.parse(this.state.tweet.created_at))
+    return (
+      <View style={styles.mainContainer}>
+        <View style={styles.header}>
+          <Image style={styles.tweet_avatar} source={{ uri: this.state.tweet.user.profile_image_url }} />
+          <View style={styles.textContainer}>
+            <View>
+              <Text style={styles.tweet_author}>{this.state.tweet.user.name}</Text>
+              <Text style={styles.tweet_author_handle}>@{this.state.tweet.user.screen_name}</Text>
+            </View>
+          </View>
+        </View>
+        <Text style={styles.tweet_time}>{formattedTime}</Text>
+        <Text style={styles.tweet_text}>{this.state.tweet.text}</Text>
+      </View>
+    )
+
+  },
+
+  _formatTime (time) {
+    var dateFormat = require('dateformat')
+    return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
+  },
+
+  _tweetSelected (tweetId) {
+    // TODO: navigate to tweet details screen
+    Alert.alert(
+      'Tweet selected',
+      'User selected tweet with id=' + tweetId
+    )
+  }
+
+})
+
+const styles = StyleSheet.create({
+  textContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems:'center'
+  },
+  tweet_author: {
+    fontSize: 25,
+    fontWeight: 'bold',
+    color: '#48BBEC'
+  },
+  tweet_author_handle: {
+    fontSize: 20,
+    fontStyle: 'italic',
+    color: '#656565'
+  },
+  tweet_time: {
+    fontSize: 16,
+    color: '#656565'
+  },
+  tweet_text: {
+    fontSize: 20,
+    color: '#656565'
+  },
+  tweet_avatar: {
+    width: 80,
+    height: 80,
+    marginRight: 10
+  },
+  header: {
+    flexDirection: 'row',
+    marginBottom: 10
+  },
+  mainContainer: {
+    padding: 10
+  }
+})
+
+module.exports = TweetsView

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -54,8 +54,6 @@ var TweetsView = React.createClass({
 
   render () {
     var tweetx = this.state.tweet
-    console.log('render')
-    console.log(tweetx)
     if (!this.state.tweet.user) {
       return (<View />)
     }

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -1,11 +1,15 @@
 import React from 'react'
 import {
   ListView,
+  BackAndroid,
   Navigator
 } from 'react-native'
 import TweetsListItem from './tweetsListItem'
 
 var TweetsList = React.createClass({
+  propTypes: {
+    navigator: React.PropTypes.instanceOf(Navigator).isRequired
+  },
 
   getInitialState () {
     var ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2})
@@ -15,6 +19,13 @@ var TweetsList = React.createClass({
   },
 
   componentDidMount () {
+    BackAndroid.addEventListener('hardwareBackPress', () => {
+      if (this.props.navigator.getCurrentRoutes().length === 1) {
+        return false
+      }
+      this.props.navigator.pop()
+      return true
+    })
     this._refreshData()
   },
 

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -1,20 +1,22 @@
-import React, { Component } from 'react'
-import { ListView } from 'react-native'
+import React from 'react'
+import {
+  ListView,
+  Navigator
+} from 'react-native'
 import TweetsListItem from './tweetsListItem'
 
-class TweetsList extends Component {
+var TweetsList = React.createClass({
 
-  constructor (props) {
-    super(props)
+  getInitialState () {
     var ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2})
-    this.state = {
+    return {
       dataSource: ds.cloneWithRows([])
     }
-  }
+  },
 
   componentDidMount () {
     this._refreshData()
-  }
+  },
 
   /*global fetch*/
   /*eslint no-undef: "error"*/
@@ -35,7 +37,7 @@ class TweetsList extends Component {
         })
       })
       .done()
-  }
+  },
 
   renderRow (rowData) {
     return (
@@ -49,7 +51,7 @@ class TweetsList extends Component {
           navigator={this.props.navigator}
         />
     )
-  }
+  },
 
   render () {
     return (
@@ -59,6 +61,6 @@ class TweetsList extends Component {
       />
     )
   }
-}
+})
 
 module.exports = TweetsList

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import {
   ListView,
-  BackAndroid,
   Navigator
 } from 'react-native'
 import TweetsListItem from './tweetsListItem'
+import AndroidBackNavigationMixin from './mixins/android-back-navigation'
 
 var TweetsList = React.createClass({
+  mixins: [AndroidBackNavigationMixin],
   propTypes: {
     navigator: React.PropTypes.instanceOf(Navigator).isRequired
   },
@@ -19,13 +20,6 @@ var TweetsList = React.createClass({
   },
 
   componentDidMount () {
-    BackAndroid.addEventListener('hardwareBackPress', () => {
-      if (this.props.navigator.getCurrentRoutes().length === 1) {
-        return false
-      }
-      this.props.navigator.pop()
-      return true
-    })
     this._refreshData()
   },
 
@@ -40,13 +34,12 @@ var TweetsList = React.createClass({
         'Authorization': 'OAuth oauth_consumer_key="aqPSTs1FT2ndP7qXi247BtbXd", oauth_nonce="987e33536527c50a7a0e1eb7b2d77e36", oauth_signature="K5W7yxsVPmQgd8arTIJ8qZXq%2FTk%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1463065323", oauth_token="730013266697654273-RDssoTCOdHNQtFA9k87OSijeZHcF4SU", oauth_version="1.0"'
       }
     })
-      .then((response) => response.json())
-      .then((rjson) => {
-        console.log(rjson)
-        this.setState({
-          dataSource: this.state.dataSource.cloneWithRows(rjson)
-        })
+    .then((response) => response.json())
+    .then((rjson) => {
+      this.setState({
+        dataSource: this.state.dataSource.cloneWithRows(rjson)
       })
+    })
   },
 
   renderRow (rowData) {

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -46,6 +46,7 @@ class TweetsList extends Component {
           author_name={rowData.user.name}
           author_handle={rowData.user.screen_name}
           text={rowData.text}
+          navigator={this.props.navigator}
         />
     )
   }

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -47,7 +47,6 @@ var TweetsList = React.createClass({
           dataSource: this.state.dataSource.cloneWithRows(rjson)
         })
       })
-      .done()
   },
 
   renderRow (rowData) {

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -8,6 +8,8 @@ import {
   Navigator
 } from 'react-native'
 
+var dateFormat = require('dateformat')
+
 var TweetsListItem = React.createClass({
   propTypes: {
     id: React.PropTypes.string.isRequired,
@@ -41,7 +43,6 @@ var TweetsListItem = React.createClass({
   },
 
   _formatTime (time) {
-    var dateFormat = require('dateformat')
     return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
   },
 

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import {
-  Alert,
   StyleSheet,
   View,
   Image,

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -8,7 +8,7 @@ import {
   Navigator
 } from 'react-native'
 
-var dateFormat = require('dateformat')
+var novodaDataFormat = require('./common/data-format.js')
 
 var TweetsListItem = React.createClass({
   propTypes: {
@@ -22,7 +22,7 @@ var TweetsListItem = React.createClass({
   },
 
   render () {
-    var formattedTime = this._formatTime(this.props.time)
+    var formattedTime = novodaDataFormat.longTime(this.props.time)
     return (
       <TouchableHighlight onPress={() => this._tweetSelected(this.props.id)}
         underlayColor='#dddddd'>
@@ -40,10 +40,6 @@ var TweetsListItem = React.createClass({
          </View>
        </TouchableHighlight>
     )
-  },
-
-  _formatTime (time) {
-    return dateFormat(time, 'mmmm dS, yyyy, h:MM:ss TT')
   },
 
   _tweetSelected (tweetId) {

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -5,7 +5,8 @@ import {
   View,
   Image,
   Text,
-  TouchableHighlight
+  TouchableHighlight,
+  Navigator
 } from 'react-native'
 
 var TweetsListItem = React.createClass({
@@ -15,7 +16,8 @@ var TweetsListItem = React.createClass({
     author_avatar: React.PropTypes.string.isRequired,
     author_name: React.PropTypes.string.isRequired,
     author_handle: React.PropTypes.string.isRequired,
-    text: React.PropTypes.string.isRequired
+    text: React.PropTypes.string.isRequired,
+    navigator: React.PropTypes.instanceOf(Navigator).isRequired
   },
 
   render () {
@@ -45,11 +47,10 @@ var TweetsListItem = React.createClass({
   },
 
   _tweetSelected (tweetId) {
-    // TODO: navigate to tweet details screen
-    Alert.alert(
-      'Tweet selected',
-      'User selected tweet with id=' + tweetId
-    )
+    this.props.navigator.push({
+      id: 'tweet-view-identifier',
+      tweetId: tweetId
+    })
   }
 
 })


### PR DESCRIPTION
Adds a Tweet detail screen.
This screen doesn't show more information (for now) compared to a single tweet item in the list but it's good to see how to implement master-detail navigation.
It's possible to access the detail view by selecting a tweet from the list (but then it's not loading the tweet, due to missing OAuth valid token) or directly from the debug screen (and then passing a hardcoded tweet id).
Also, implementing the Android hardware back navigation (no conflicts with iOS, given in that case all the methods are no-op)

| iOS  | Android |
| --- | --- |
| ![screen shot 2016-05-13 at 17 23 40](https://cloud.githubusercontent.com/assets/3942812/15252739/a0f319a4-192f-11e6-8930-7a5fbf9d0ef1.png) | ![screen shot 2016-05-13 at 17 23 17](https://cloud.githubusercontent.com/assets/3942812/15252740/a3b8eef2-192f-11e6-9ddf-1d2cedb1b0af.png) |