### PR TITLE
Firebase / Show public and private channels in channel list

### DIFF
--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/Dependencies.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/Dependencies.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.database.FirebaseDatabase;
 import com.novoda.bonfire.analytics.FirebaseAnalyticsAnalytics;
 import com.novoda.bonfire.channel.service.ChannelService;
 import com.novoda.bonfire.channel.service.FirebaseChannelService;
@@ -25,15 +27,19 @@ public enum Dependencies {
         if (needsInitialisation()) {
             Context appContext = context.getApplicationContext();
             FirebaseApp firebaseApp = FirebaseApp.initializeApp(appContext, FirebaseOptions.fromResource(appContext), "Bonfire");
+            FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+            FirebaseDatabase firebaseDatabase = FirebaseDatabase.getInstance(firebaseApp);
+            firebaseDatabase.setPersistenceEnabled(true);
+
             firebaseAnalytics = new FirebaseAnalyticsAnalytics(context);
-            loginService = new FirebaseLoginService(firebaseApp);
-            chatService = new FirebaseChatService(firebaseApp);
-            channelService = new FirebaseChannelService(firebaseApp);
+            loginService = new FirebaseLoginService(firebaseDatabase, firebaseAuth);
+            chatService = new FirebaseChatService(firebaseDatabase);
+            channelService = new FirebaseChannelService(firebaseDatabase);
         }
     }
 
     private boolean needsInitialisation() {
-        return loginService == null && chatService == null;
+        return loginService == null && chatService == null && channelService == null && firebaseAnalytics == null;
     }
 
     public FirebaseAnalyticsAnalytics getFirebaseAnalytics() {

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/Dependencies.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/Dependencies.java
@@ -39,7 +39,7 @@ public enum Dependencies {
     }
 
     private boolean needsInitialisation() {
-        return loginService == null && chatService == null && channelService == null && firebaseAnalytics == null;
+        return loginService == null || chatService == null || channelService == null || firebaseAnalytics == null;
     }
 
     public FirebaseAnalyticsAnalytics getFirebaseAnalytics() {

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/ChannelsActivity.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/ChannelsActivity.java
@@ -20,7 +20,10 @@ public class ChannelsActivity extends BaseActivity {
         setContentView(R.layout.activity_channels);
 
         Dependencies dependencies = Dependencies.INSTANCE;
-        channelsPresenter = new ChannelsPresenter((ChannelsDisplayer) findViewById(R.id.channelsView), dependencies.getChannelService(), new AndroidNavigator(this));
+        channelsPresenter = new ChannelsPresenter((ChannelsDisplayer) findViewById(R.id.channelsView),
+                                                  dependencies.getChannelService(),
+                                                  dependencies.getLoginService(),
+                                                  new AndroidNavigator(this));
     }
 
     @Override

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
@@ -8,6 +8,7 @@ import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.ValueEventListener;
 import com.novoda.bonfire.channel.data.model.Channel;
 import com.novoda.bonfire.channel.data.model.Channels;
+import com.novoda.bonfire.login.data.model.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,28 +16,45 @@ import java.util.List;
 import rx.Observable;
 import rx.Subscriber;
 import rx.functions.Action0;
+import rx.functions.Func2;
 import rx.subscriptions.BooleanSubscription;
 
 public class FirebaseChannelService implements ChannelService {
 
-    private final DatabaseReference channelsDB;
+    private final DatabaseReference publicChannelsDB;
+    private final DatabaseReference privateChannelsDB;
 
     public FirebaseChannelService(FirebaseApp firebaseApp) {
         FirebaseDatabase database = FirebaseDatabase.getInstance(firebaseApp);
-        channelsDB = database.getReference("channels-global");
+        publicChannelsDB = database.getReference("channels-global-index");
+        privateChannelsDB = database.getReference("channels-private-index");
     }
 
-
     @Override
-    public Observable<Channels> getChannels() {
-        return Observable.create(new Observable.OnSubscribe<Channels>() {
+    public Observable<Channels> getChannelsFor(User user) {
+        return Observable.zip(
+                privateChannelsFor(user),
+                publicChannels(),
+                new Func2<List<Channel>, List<Channel>, Channels>() {
+                    @Override
+                    public Channels call(List<Channel> channels, List<Channel> channels2) {
+                        List<Channel> combinedChannels = new ArrayList<>(channels);
+                        combinedChannels.addAll(channels2);
+                        return new Channels(combinedChannels);
+                    }
+                }
+        );
+    }
+
+    private Observable<List<Channel>> privateChannelsFor(final User user) {
+        return Observable.create(new Observable.OnSubscribe<List<Channel>>() {
             @Override
-            public void call(final Subscriber<? super Channels> subscriber) {
-                final ValueEventListener eventListener = channelsDB.addValueEventListener(new ValueEventListener() {
+            public void call(final Subscriber<? super List<Channel>> subscriber) {
+                final DatabaseReference privateChannelsOfUserDb = FirebaseChannelService.this.privateChannelsDB.child(user.getId());
+                final ValueEventListener eventListener = privateChannelsOfUserDb.addValueEventListener(new ValueEventListener() {
                     @Override
                     public void onDataChange(DataSnapshot dataSnapshot) {
-                        List<Channel> channels = toChannels(dataSnapshot);
-                        subscriber.onNext(new Channels(channels));
+                        subscriber.onNext(toChannels(dataSnapshot));
                     }
 
                     @Override
@@ -48,7 +66,33 @@ public class FirebaseChannelService implements ChannelService {
                 subscriber.add(BooleanSubscription.create(new Action0() {
                     @Override
                     public void call() {
-                        channelsDB.removeEventListener(eventListener);
+                        privateChannelsOfUserDb.removeEventListener(eventListener);
+                    }
+                }));
+            }
+        });
+    }
+
+    private Observable<List<Channel>> publicChannels() {
+        return Observable.create(new Observable.OnSubscribe<List<Channel>>() {
+            @Override
+            public void call(final Subscriber<? super List<Channel>> subscriber) {
+                final ValueEventListener eventListener = FirebaseChannelService.this.publicChannelsDB.addValueEventListener(new ValueEventListener() {
+                    @Override
+                    public void onDataChange(DataSnapshot dataSnapshot) {
+                        subscriber.onNext(toChannels(dataSnapshot));
+                    }
+
+                    @Override
+                    public void onCancelled(DatabaseError databaseError) {
+                        subscriber.onError(databaseError.toException()); //TODO handle errors in pipeline
+                    }
+
+                });
+                subscriber.add(BooleanSubscription.create(new Action0() {
+                    @Override
+                    public void call() {
+                        FirebaseChannelService.this.publicChannelsDB.removeEventListener(eventListener);
                     }
                 }));
             }
@@ -56,11 +100,13 @@ public class FirebaseChannelService implements ChannelService {
     }
 
     private List<Channel> toChannels(DataSnapshot dataSnapshot) {
-        Iterable<DataSnapshot> children = dataSnapshot.getChildren();
         List<Channel> channels = new ArrayList<>();
-        for (DataSnapshot child : children) {
-            String channelName = child.getKey();
-            channels.add(new Channel(channelName));
+        if (dataSnapshot.hasChildren()) {
+            Iterable<DataSnapshot> children = dataSnapshot.getChildren();
+            for (DataSnapshot child : children) {
+                String channelName = child.getValue(String.class);
+                channels.add(new Channel(channelName));
+            }
         }
         return channels;
     }

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
@@ -1,6 +1,5 @@
 package com.novoda.bonfire.channel.service;
 
-import com.google.firebase.FirebaseApp;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -24,10 +23,9 @@ public class FirebaseChannelService implements ChannelService {
     private final DatabaseReference publicChannelsDB;
     private final DatabaseReference privateChannelsDB;
 
-    public FirebaseChannelService(FirebaseApp firebaseApp) {
-        FirebaseDatabase database = FirebaseDatabase.getInstance(firebaseApp);
-        publicChannelsDB = database.getReference("channels-public-index");
-        privateChannelsDB = database.getReference("channels-private-index");
+    public FirebaseChannelService(FirebaseDatabase firebaseDatabase) {
+        publicChannelsDB = firebaseDatabase.getReference("channels-public-index");
+        privateChannelsDB = firebaseDatabase.getReference("channels-private-index");
     }
 
     @Override

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
@@ -26,7 +26,7 @@ public class FirebaseChannelService implements ChannelService {
 
     public FirebaseChannelService(FirebaseApp firebaseApp) {
         FirebaseDatabase database = FirebaseDatabase.getInstance(firebaseApp);
-        publicChannelsDB = database.getReference("channels-global-index");
+        publicChannelsDB = database.getReference("channels-public-index");
         privateChannelsDB = database.getReference("channels-private-index");
     }
 

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
@@ -23,7 +23,7 @@ public class FirebaseChannelService implements ChannelService {
 
     public FirebaseChannelService(FirebaseApp firebaseApp) {
         FirebaseDatabase database = FirebaseDatabase.getInstance(firebaseApp);
-        channelsDB = database.getReference("channels");
+        channelsDB = database.getReference("channels-global");
     }
 
 

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/channel/service/FirebaseChannelService.java
@@ -35,9 +35,9 @@ public class FirebaseChannelService implements ChannelService {
                 publicChannels(),
                 new Func2<List<Channel>, List<Channel>, Channels>() {
                     @Override
-                    public Channels call(List<Channel> channels, List<Channel> channels2) {
-                        List<Channel> combinedChannels = new ArrayList<>(channels);
-                        combinedChannels.addAll(channels2);
+                    public Channels call(List<Channel> privateChannels, List<Channel> publicChannels) {
+                        List<Channel> combinedChannels = new ArrayList<>(privateChannels);
+                        combinedChannels.addAll(publicChannels);
                         return new Channels(combinedChannels);
                     }
                 }

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/ChatActivity.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/ChatActivity.java
@@ -28,16 +28,16 @@ public class ChatActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_chat);
         ChatDisplayer chatDisplayer = (ChatDisplayer) findViewById(R.id.chatView);
-        String channelName = getIntent().getStringExtra(CHANNEL_EXTRA);
+        Channel channel = new Channel(getIntent().getStringExtra(CHANNEL_EXTRA));
 
-        getSupportActionBar().setTitle(channelName);
+        getSupportActionBar().setTitle(channel.getName());
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         presenter = new ChatPresenter(
                 Dependencies.INSTANCE.getLoginService(),
                 Dependencies.INSTANCE.getChatService(),
                 chatDisplayer,
-                channelName,
+                channel,
                 Dependencies.INSTANCE.getFirebaseAnalytics()
         );
     }

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/service/FirebaseChatService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/service/FirebaseChatService.java
@@ -20,11 +20,11 @@ import rx.subscriptions.BooleanSubscription;
 
 public class FirebaseChatService implements ChatService {
 
-    private final DatabaseReference messagesDB;
+    private final DatabaseReference channelsDB;
 
     public FirebaseChatService(FirebaseApp firebaseApp) {
         FirebaseDatabase database = FirebaseDatabase.getInstance(firebaseApp);
-        messagesDB = database.getReference("channels-global");
+        channelsDB = database.getReference("channels");
     }
 
     @Override
@@ -61,7 +61,7 @@ public class FirebaseChatService implements ChatService {
     }
 
     private DatabaseReference channelDB(Channel channel) {
-        return messagesDB.child(channel.getName());
+        return channelsDB.child(channel.getName());
     }
 
     private List<Message> toMessages(DataSnapshot dataSnapshot) {

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/service/FirebaseChatService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/service/FirebaseChatService.java
@@ -1,6 +1,5 @@
 package com.novoda.bonfire.chat.service;
 
-import com.google.firebase.FirebaseApp;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -22,9 +21,8 @@ public class FirebaseChatService implements ChatService {
 
     private final DatabaseReference channelsDB;
 
-    public FirebaseChatService(FirebaseApp firebaseApp) {
-        FirebaseDatabase database = FirebaseDatabase.getInstance(firebaseApp);
-        channelsDB = database.getReference("channels");
+    public FirebaseChatService(FirebaseDatabase firebaseDatabase) {
+        channelsDB = firebaseDatabase.getReference("channels");
     }
 
     @Override

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/service/FirebaseChatService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/chat/service/FirebaseChatService.java
@@ -24,7 +24,7 @@ public class FirebaseChatService implements ChatService {
 
     public FirebaseChatService(FirebaseApp firebaseApp) {
         FirebaseDatabase database = FirebaseDatabase.getInstance(firebaseApp);
-        messagesDB = database.getReference("channels");
+        messagesDB = database.getReference("channels-global");
     }
 
     @Override
@@ -57,7 +57,7 @@ public class FirebaseChatService implements ChatService {
 
     @Override
     public void sendMessage(Channel channel, Message message) {
-        channelDB(channel).push().setValue(message);
+        channelDB(channel).child("messages").push().setValue(message);
     }
 
     private DatabaseReference channelDB(Channel channel) {
@@ -65,7 +65,7 @@ public class FirebaseChatService implements ChatService {
     }
 
     private List<Message> toMessages(DataSnapshot dataSnapshot) {
-        Iterable<DataSnapshot> children = dataSnapshot.getChildren();
+        Iterable<DataSnapshot> children = dataSnapshot.child("messages").getChildren();
         List<Message> messages = new ArrayList<>();
         for (DataSnapshot child : children) {
             Message message = child.getValue(Message.class);

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/login/service/FirebaseLoginService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/login/service/FirebaseLoginService.java
@@ -78,9 +78,9 @@ public class FirebaseLoginService implements LoginService {
                     public void onComplete(@NonNull Task<AuthResult> task) {
                         if (task.isSuccessful()) {
                             FirebaseUser firebaseUser = task.getResult().getUser();
-                            User user = new User(firebaseUser.getUid(), firebaseUser.getDisplayName(), firebaseUser.getPhotoUrl().toString()); //Refactor this double creation
-                            usersDB.child(firebaseUser.getUid()).setValue(user);
-                            authRelay.call(authenticationFrom(firebaseUser));
+                            Authentication authentication = authenticationFrom(firebaseUser);
+                            usersDB.child(firebaseUser.getUid()).setValue(authentication.getUser());
+                            authRelay.call(authentication);
                         } else {
                             Throwable exception = task.getException();
                             Log.e(exception, "Failed to authenticate Firebase");

--- a/Firebase/android/app/src/main/java/com/novoda/bonfire/login/service/FirebaseLoginService.java
+++ b/Firebase/android/app/src/main/java/com/novoda/bonfire/login/service/FirebaseLoginService.java
@@ -4,7 +4,6 @@ import android.support.annotation.NonNull;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
@@ -28,9 +27,9 @@ public class FirebaseLoginService implements LoginService {
     private final BehaviorRelay<Authentication> authRelay;
     private final DatabaseReference usersDB;
 
-    public FirebaseLoginService(FirebaseApp firebaseApp) {
-        firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
-        usersDB = FirebaseDatabase.getInstance(firebaseApp).getReference("users");
+    public FirebaseLoginService(FirebaseDatabase firebaseDatabase, FirebaseAuth firebaseAuth) {
+        this.firebaseAuth = firebaseAuth;
+        usersDB = firebaseDatabase.getReference("users");
         authRelay = BehaviorRelay.create();
     }
 

--- a/Firebase/android/core/src/main/java/com/novoda/bonfire/channel/presenter/ChannelsPresenter.java
+++ b/Firebase/android/core/src/main/java/com/novoda/bonfire/channel/presenter/ChannelsPresenter.java
@@ -39,7 +39,8 @@ public class ChannelsPresenter {
                                       public void call(Channels channels) {
                                           channelsDisplayer.display(channels);
                                       }
-                                  }));
+                                  })
+        );
     }
 
     private Func1<Authentication, Observable<Channels>> channelsForUser() {

--- a/Firebase/android/core/src/main/java/com/novoda/bonfire/channel/presenter/ChannelsPresenter.java
+++ b/Firebase/android/core/src/main/java/com/novoda/bonfire/channel/presenter/ChannelsPresenter.java
@@ -4,33 +4,60 @@ import com.novoda.bonfire.channel.data.model.Channel;
 import com.novoda.bonfire.channel.data.model.Channels;
 import com.novoda.bonfire.channel.displayer.ChannelsDisplayer;
 import com.novoda.bonfire.channel.service.ChannelService;
+import com.novoda.bonfire.login.data.model.Authentication;
+import com.novoda.bonfire.login.service.LoginService;
 import com.novoda.bonfire.navigation.Navigator;
 
+import rx.Observable;
 import rx.functions.Action1;
+import rx.functions.Func1;
 import rx.subscriptions.CompositeSubscription;
 
 public class ChannelsPresenter {
 
     private final ChannelsDisplayer channelsDisplayer;
     private final ChannelService channelService;
+    private final LoginService loginService;
     private final Navigator navigator;
 
     private CompositeSubscription subscriptions = new CompositeSubscription();
 
-    public ChannelsPresenter(ChannelsDisplayer channelsDisplayer, ChannelService channelService, Navigator navigator) {
+    public ChannelsPresenter(ChannelsDisplayer channelsDisplayer, ChannelService channelService, LoginService loginService, Navigator navigator) {
         this.channelsDisplayer = channelsDisplayer;
         this.channelService = channelService;
+        this.loginService = loginService;
         this.navigator = navigator;
     }
 
     public void startPresenting() {
         channelsDisplayer.attach(channelSelectionListener);
-        subscriptions.add(channelService.getChannels().subscribe(new Action1<Channels>() {
+        subscriptions.add(loginService.getAuthentication()
+                                  .filter(successfullyAuthenticated())
+                                  .flatMap(channelsForUser())
+                                  .subscribe(new Action1<Channels>() {
+                                      @Override
+                                      public void call(Channels channels) {
+                                          channelsDisplayer.display(channels);
+                                      }
+                                  }));
+    }
+
+    private Func1<Authentication, Observable<Channels>> channelsForUser() {
+        return new Func1<Authentication, Observable<Channels>>() {
             @Override
-            public void call(Channels channels) {
-                channelsDisplayer.display(channels);
+            public Observable<Channels> call(Authentication authentication) {
+                return channelService.getChannelsFor(authentication.getUser());
             }
-        }));
+        };
+    }
+
+    private Func1<Authentication, Boolean> successfullyAuthenticated() {
+        return new Func1<Authentication, Boolean>() {
+            @Override
+            public Boolean call(Authentication authentication) {
+                return authentication.isSuccess();
+            }
+        };
     }
 
     public void stopPresenting() {

--- a/Firebase/android/core/src/main/java/com/novoda/bonfire/channel/service/ChannelService.java
+++ b/Firebase/android/core/src/main/java/com/novoda/bonfire/channel/service/ChannelService.java
@@ -1,10 +1,11 @@
 package com.novoda.bonfire.channel.service;
 
 import com.novoda.bonfire.channel.data.model.Channels;
+import com.novoda.bonfire.login.data.model.User;
 
 import rx.Observable;
 
 public interface ChannelService {
 
-    Observable<Channels> getChannels();
+    Observable<Channels> getChannelsFor(User user);
 }

--- a/Firebase/android/core/src/main/java/com/novoda/bonfire/chat/presenter/ChatPresenter.java
+++ b/Firebase/android/core/src/main/java/com/novoda/bonfire/chat/presenter/ChatPresenter.java
@@ -25,12 +25,12 @@ public class ChatPresenter {
 
     private User user;
 
-    public ChatPresenter(LoginService loginService, ChatService chatService, ChatDisplayer chatDisplayer, String channelName, Analytics analytics) {
+    public ChatPresenter(LoginService loginService, ChatService chatService, ChatDisplayer chatDisplayer, Channel channel, Analytics analytics) {
         this.loginService = loginService;
         this.chatService = chatService;
         this.chatDisplayer = chatDisplayer;
         this.analytics = analytics;
-        this.channel = new Channel(channelName);
+        this.channel = channel;
     }
 
     public void startPresenting() {

--- a/Firebase/android/core/src/main/java/com/novoda/bonfire/login/service/LoginService.java
+++ b/Firebase/android/core/src/main/java/com/novoda/bonfire/login/service/LoginService.java
@@ -4,7 +4,7 @@ import com.novoda.bonfire.login.data.model.Authentication;
 
 import rx.Observable;
 
-public interface LoginService<T> {
+public interface LoginService {
 
     Observable<Authentication> getAuthentication();
 

--- a/Firebase/server/database.rules.json
+++ b/Firebase/server/database.rules.json
@@ -1,28 +1,6 @@
 {
   "rules": {
     "channels": {
-      ".read": "auth != null",
-      "global": {
-        "messages": {
-          ".read": "auth != null",
-          "$message": {
-            ".write": "!data.exists() && newData.exists()",
-            ".validate": "newData.hasChildren(['author', 'body', 'timestamp'])",
-            "author": {
-              ".validate": "newData.hasChildren(['id', 'name'])",
-              "id": {
-                ".validate": "newData.val() === auth.uid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "channels-global-index": {
-      ".read": "auth != null",
-      ".write": "auth != null"
-    },
-    "channels": {
       "$channel": {
         ".read": "!data.child('owners').exists() || data.child('owners').child(auth.uid).exists()",
         "messages": {
@@ -44,6 +22,10 @@
           }
         }
       }
+    },
+    "channels-public-index": {
+      ".read": "auth != null",
+      ".write": "auth != null"
     },
     "channels-private-index": {
         ".read": "auth != null",

--- a/Firebase/server/database.rules.json
+++ b/Firebase/server/database.rules.json
@@ -18,12 +18,16 @@
         }
       }
     },
-    "channels-global": {
+    "channels-global-index": {
+      ".read": "auth != null",
+      ".write": "auth != null"
+    },
+    "channels": {
       "$channel": {
         ".read": "!data.child('owners').exists() || data.child('owners').child(auth.uid).exists()",
         "messages": {
           "$message": {
-            ".write": "(!data.child('owners').exists() || data.child('owners').child(auth.uid).exists()) && !data.exists() && newData.exists()",
+            ".write": "(!data.parent().parent().child('owners').exists() || data.parent().parent().child('owners').child(auth.uid).exists()) && !data.exists() && newData.exists()",
             ".validate": "newData.hasChildren(['author', 'body', 'timestamp'])",
             "author": {
               ".validate": "newData.hasChildren(['id', 'name'])",
@@ -35,15 +39,15 @@
         },
         "owners": {
           "$user_id": {
-            ".write": "(!root.child('channels-private/'+$channel).exists() || data.parent().child(auth.uid).exists()) && newData.exists() && auth != null",
+            ".write": "(!root.child('channels/'+$channel).exists() || data.parent().child(auth.uid).exists()) && newData.exists() && auth != null",
             ".validate": "newData.hasChildren(['id', 'name'])"
           }
         }
       }
     },
-    "channels-global-index": {
-      ".read": "auth != null",
-      ".write": "auth != null"
+    "channels-private-index": {
+        ".read": "auth != null",
+        ".write": "auth != null"
     },
     "users": {
       "$user_id": {

--- a/Firebase/server/database.rules.json
+++ b/Firebase/server/database.rules.json
@@ -2,10 +2,10 @@
   "rules": {
     "channels": {
       "$channel": {
-        ".read": "!data.child('owners').exists() || data.child('owners').child(auth.uid).exists()",
+        ".read": "!root.child('owners').child($channel).exists() || root.child('owners').child($channel).child(auth.uid).exists()",
         "messages": {
           "$message": {
-            ".write": "(!data.parent().parent().child('owners').exists() || data.parent().parent().child('owners').child(auth.uid).exists()) && !data.exists() && newData.exists()",
+            ".write": "(!root.child('owners').child($channel).exists() || root.child('owners').child($channel).child(auth.uid).exists()) && !data.exists() && newData.exists()",
             ".validate": "newData.hasChildren(['author', 'body', 'timestamp'])",
             "author": {
               ".validate": "newData.hasChildren(['id', 'name'])",
@@ -13,12 +13,6 @@
                 ".validate": "newData.val() === auth.uid"
               }
             }
-          }
-        },
-        "owners": {
-          "$user_id": {
-            ".write": "(!root.child('channels/'+$channel).exists() || data.parent().child(auth.uid).exists()) && newData.exists() && auth != null",
-            ".validate": "newData.hasChildren(['id', 'name'])"
           }
         }
       }


### PR DESCRIPTION
Public and private channels are now displayed in the channel list. The channels are indexed separately in firebase and database rules were updated to ensure the correct access rights.

Nothing changes in the UI, the user does not know if the channel is private or public yet.

Paired with
@Dorvaryn and @dominicfreeston on the DB rules