### PR TITLE
React/pt 70/tweets list oauth integration

### DIFF
--- a/ReactNative/ReactTwitter/core/service/authentication-service.js
+++ b/ReactNative/ReactTwitter/core/service/authentication-service.js
@@ -6,7 +6,13 @@ var {
 const TOKEN_STORAGE_KEY = '@AuthenticationServiceToken:key'
 
 class AuthenticationService {
-  loadDataFromDisk () {
+  loadData () {
+    if (this.tokenData) {
+      return new Promise((resolve, reject) => {
+        resolve(this.tokenData)
+      })
+    }
+
     return AsyncStorage.getItem(TOKEN_STORAGE_KEY).then((tokenString) => {
       this.tokenData = JSON.parse(tokenString)
       return this.tokenData

--- a/ReactNative/ReactTwitter/core/service/config.json
+++ b/ReactNative/ReactTwitter/core/service/config.json
@@ -4,5 +4,6 @@
   "BASE_URL": "https://api.twitter.com",
   "REQUEST_TOKEN": "/oauth/request_token",
   "ACCESS_TOKEN": "/oauth/access_token",
-  "CALLBACK_URL": "react-twitter-oauth://callback"
+  "CALLBACK_URL": "react-twitter-oauth://callback",
+  "HOME_TIMELINE": "/1.1/statuses/home_timeline.json"
 }

--- a/ReactNative/ReactTwitter/core/service/config.json
+++ b/ReactNative/ReactTwitter/core/service/config.json
@@ -5,5 +5,6 @@
   "REQUEST_TOKEN": "/oauth/request_token",
   "ACCESS_TOKEN": "/oauth/access_token",
   "CALLBACK_URL": "react-twitter-oauth://callback",
-  "HOME_TIMELINE": "/1.1/statuses/home_timeline.json"
+  "HOME_TIMELINE": "/1.1/statuses/home_timeline.json",
+  "TWEET_DETAIL": "/1.1/statuses/show.json"
 }

--- a/ReactNative/ReactTwitter/core/service/oauth-helper.js
+++ b/ReactNative/ReactTwitter/core/service/oauth-helper.js
@@ -6,11 +6,7 @@ class OauthHelper {
   constructor (consumerSecret) {
     this.consumerSecret = consumerSecret
   }
-
-  buildAuthorizationHeader (method, url, params, oauthTokenSecret) {
-    return buildAuthorizationHeader (method, url, params, [], oauthTokenSecret)
-  }
-
+  
   buildAuthorizationHeader (method, url, params, queryParams, oauthTokenSecret) {
     let output = 'OAuth '
     let signature = this.getSigningKey(method, url, params, queryParams, oauthTokenSecret)

--- a/ReactNative/ReactTwitter/core/service/oauth-helper.js
+++ b/ReactNative/ReactTwitter/core/service/oauth-helper.js
@@ -6,7 +6,7 @@ class OauthHelper {
   constructor (consumerSecret) {
     this.consumerSecret = consumerSecret
   }
-  
+
   buildAuthorizationHeader (method, url, params, queryParams, oauthTokenSecret) {
     let output = 'OAuth '
     let signature = this.getSigningKey(method, url, params, queryParams, oauthTokenSecret)
@@ -38,8 +38,8 @@ class OauthHelper {
   }
 
   static _getSignatureBase (method, url, params, queryParams) {
-    return method.toUpperCase() + '&' + PercentEncoder.encode(url) + '&'
-      + PercentEncoder.encode(OauthHelper._collectParameters(params, queryParams))
+    return method.toUpperCase() + '&' + PercentEncoder.encode(url) + '&' +
+      PercentEncoder.encode(OauthHelper._collectParameters(params, queryParams))
   }
 
   static _collectParameters (params, queryParams) {

--- a/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
+++ b/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
@@ -20,7 +20,7 @@ class TwitterRequestsService {
       {
         method: 'POST',
         headers: {
-          'Authorization': ouathHelper.buildAuthorizationHeader('post', url, parameters, '')
+          'Authorization': ouathHelper.buildAuthorizationHeader('post', url, parameters, [], '')
         }
       })
       .then((response) => { return response.text() })

--- a/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
+++ b/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
@@ -79,9 +79,7 @@ class TwitterRequestsService {
     let finalUrl = baseURL
     for (let key in queryParams) {
       finalUrl += (finalUrl === baseURL) ? '?' : '&'
-      finalUrl += key
-      finalUrl += '='
-      finalUrl += queryParams[key]
+      finalUrl += `${key}=${queryParams[key]}`
     }
 
     return this.callsManager.makeCall(finalUrl,

--- a/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
+++ b/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
@@ -5,7 +5,8 @@ const config = require('./config.json')
 
 class TwitterRequestsService {
 
-  constructor () {
+  constructor (authService) {
+    this.authService = authService
     this.callsManager = new NetworkCallsManager()
   }
 
@@ -43,33 +44,55 @@ class TwitterRequestsService {
         }
       })
       .then((response) => { return response.text() })
-      .then((text) => { return this._getTokenDataFromResponse(text) })
+      .then((text) => {
+        let tokenData = this._getTokenDataFromResponse(text)
+        return this.authService.updateWithTokenData(tokenData)
+      })
   }
 
-  getHomeTimeline (userHandle, oauthToken, oauthTokenSecret) {
-    let ouathHelper = new OauthHelper(config.CONSUMER_SECRET)
+  getHomeTimeline () {
     let url = config.BASE_URL + config.HOME_TIMELINE
 
     let parameters = this._getBaseParams()
-    parameters['oauth_token'] = oauthToken
+    parameters['oauth_token'] = this.authService.getOAuthToken()
 
-    let queryParams = {'screen_name': userHandle }
-
-    let authHeader = ouathHelper
-      .buildAuthorizationHeader('get', url, parameters, queryParams, oauthTokenSecret)
-
-    let finalUrl = url + '?screen_name=' + userHandle
-
-    return this.callsManager.makeCall(finalUrl,
-      {
-        method: 'GET',
-        headers: {
-          'Authorization': authHeader
-        }
-      })
-    .then((response) => { return response.json() })
+    let queryParams = {'screen_name': this.authService.getUsername() }
+    return this._getResource(url, parameters, queryParams)
   }
 
+  getTweet (tweetId, oauthToken) {
+    let url = config.BASE_URL + config.TWEET_DETAIL
+
+    let parameters = this._getBaseParams()
+    parameters['oauth_token'] = this.authService.getOAuthToken()
+
+    let queryParams = {'id': tweetId }
+
+    return this._getResource(url, parameters, queryParams)
+  }
+
+ _getResource(baseURL, parameters, queryParams) {
+   let ouathHelper = new OauthHelper(config.CONSUMER_SECRET)
+   let authHeader = ouathHelper
+     .buildAuthorizationHeader('get', baseURL, parameters, queryParams, this.authService.getSecretToken())
+
+   let finalUrl = baseURL
+   for (let key in queryParams) {
+     finalUrl += (finalUrl == baseURL) ? '?': '&'
+     finalUrl += key
+     finalUrl += '='
+     finalUrl += queryParams[key]
+   }
+
+   return this.callsManager.makeCall(finalUrl,
+     {
+       method: 'GET',
+       headers: {
+         'Authorization': authHeader
+       }
+     })
+   .then((response) => { return response.json() })
+ }
   _getBaseParams () {
     let time = new Date().getTime() / 1000 | 0
     let nonce = OauthHelper.generateNonce()

--- a/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
+++ b/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
@@ -46,6 +46,30 @@ class TwitterRequestsService {
       .then((text) => { return this._getTokenDataFromResponse(text) })
   }
 
+  getHomeTimeline (userHandle, oauthToken, oauthTokenSecret) {
+    let ouathHelper = new OauthHelper(config.CONSUMER_SECRET)
+    let url = config.BASE_URL + config.HOME_TIMELINE
+
+    let parameters = this._getBaseParams()
+    parameters['oauth_token'] = oauthToken
+
+    let queryParams = {'screen_name': userHandle }
+
+    let authHeader = ouathHelper
+      .buildAuthorizationHeader('get', url, parameters, queryParams, oauthTokenSecret)
+
+    let finalUrl = url + '?screen_name=' + userHandle
+
+    return this.callsManager.makeCall(finalUrl,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': authHeader
+        }
+      })
+    .then((response) => { return response.json() })
+  }
+
   _getBaseParams () {
     let time = new Date().getTime() / 1000 | 0
     let nonce = OauthHelper.generateNonce()

--- a/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
+++ b/ReactNative/ReactTwitter/core/service/twitter-requests-service.js
@@ -56,7 +56,7 @@ class TwitterRequestsService {
     let parameters = this._getBaseParams()
     parameters['oauth_token'] = this.authService.getOAuthToken()
 
-    let queryParams = {'screen_name': this.authService.getUsername() }
+    let queryParams = { 'screen_name': this.authService.getUsername() }
     return this._getResource(url, parameters, queryParams)
   }
 
@@ -66,33 +66,33 @@ class TwitterRequestsService {
     let parameters = this._getBaseParams()
     parameters['oauth_token'] = this.authService.getOAuthToken()
 
-    let queryParams = {'id': tweetId }
+    let queryParams = { 'id': tweetId }
 
     return this._getResource(url, parameters, queryParams)
   }
 
- _getResource(baseURL, parameters, queryParams) {
-   let ouathHelper = new OauthHelper(config.CONSUMER_SECRET)
-   let authHeader = ouathHelper
+  _getResource (baseURL, parameters, queryParams) {
+    let ouathHelper = new OauthHelper(config.CONSUMER_SECRET)
+    let authHeader = ouathHelper
      .buildAuthorizationHeader('get', baseURL, parameters, queryParams, this.authService.getSecretToken())
 
-   let finalUrl = baseURL
-   for (let key in queryParams) {
-     finalUrl += (finalUrl == baseURL) ? '?': '&'
-     finalUrl += key
-     finalUrl += '='
-     finalUrl += queryParams[key]
-   }
+    let finalUrl = baseURL
+    for (let key in queryParams) {
+      finalUrl += (finalUrl === baseURL) ? '?' : '&'
+      finalUrl += key
+      finalUrl += '='
+      finalUrl += queryParams[key]
+    }
 
-   return this.callsManager.makeCall(finalUrl,
-     {
-       method: 'GET',
-       headers: {
-         'Authorization': authHeader
-       }
-     })
-   .then((response) => { return response.json() })
- }
+    return this.callsManager.makeCall(finalUrl,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': authHeader
+        }
+      })
+    .then((response) => { return response.json() })
+  }
   _getBaseParams () {
     let time = new Date().getTime() / 1000 | 0
     let nonce = OauthHelper.generateNonce()

--- a/ReactNative/ReactTwitter/core/views/debug/oauth-screen.js
+++ b/ReactNative/ReactTwitter/core/views/debug/oauth-screen.js
@@ -29,7 +29,7 @@ var OauthView = React.createClass({
   },
 
   componentDidMount () {
-    this.state.authenticationService.loadDataFromDisk().then(() => {
+    this.state.authenticationService.loadData().then(() => {
       this._updateAuthenaticationServiceState()
     })
   },

--- a/ReactNative/ReactTwitter/core/views/login-screen.js
+++ b/ReactNative/ReactTwitter/core/views/login-screen.js
@@ -57,7 +57,7 @@ var LoginScreenView = React.createClass({
       let parsedURI = OauthHelper.getOauthTokenAndVerifierFromURLCallback(uri)
       this.state.facade.stopListeningForDeepLinking()
 
-      if (parsedURI.oauth_token == null || parsedURI.oauth_token.length === 0) {
+      if (this._userCancelledLogin(parsedURI)) {
         // user canceled login
         return
       }
@@ -75,6 +75,10 @@ var LoginScreenView = React.createClass({
         })
     })
     Linking.openURL('https://api.twitter.com/oauth/authenticate?oauth_token=' + oauthToken)
+  },
+
+  _userCancelledLogin (parsedURI) {
+    return parsedURI.oauth_token == null || parsedURI.oauth_token.length === 0
   },
 
   _pushTweetsList () {

--- a/ReactNative/ReactTwitter/core/views/login-screen.js
+++ b/ReactNative/ReactTwitter/core/views/login-screen.js
@@ -11,18 +11,16 @@ var Button = require('react-native-button')
 var TwitterRequestsService = require('../service/twitter-requests-service.js')
 var DeepLinkingFacade = require('../service/deep-linking-facade')
 var OauthHelper = require('../service/oauth-helper.js')
-var AuthenticationService = require('../service/authentication-service.js')
 
 var LoginScreenView = React.createClass({
   propTypes: {
-    navigator: React.PropTypes.instanceOf(Navigator).isRequired
+    navigator: React.PropTypes.instanceOf(Navigator).isRequired,
+    twitterService: React.PropTypes.instanceOf(TwitterRequestsService).isRequired
   },
 
   getInitialState () {
     return {
-      facade: new DeepLinkingFacade(),
-      twitterService: new TwitterRequestsService(),
-      authenticationService: new AuthenticationService()
+      facade: new DeepLinkingFacade()
     }
   },
 
@@ -44,7 +42,7 @@ var LoginScreenView = React.createClass({
   },
 
   _startLogin () {
-    this.state.twitterService.requestToken()
+    this.props.twitterService.requestToken()
         .then((tokenData) => {
           let oauthToken = tokenData.oauth_token
           this._browserAuthenticationWithToken(oauthToken)
@@ -62,16 +60,9 @@ var LoginScreenView = React.createClass({
         return
       }
 
-      this.state.twitterService.getAccessToken(parsedURI.oauth_token, parsedURI.oauth_verifier)
+      this.props.twitterService.getAccessToken(parsedURI.oauth_token, parsedURI.oauth_verifier)
         .then((tokenData) => {
-          let authService = this.state.authenticationService
-          authService.updateWithTokenData(tokenData).then(() => {
-            if (authService.isUserLoggedIn()) {
-              this._pushTweetsList()
-            } else {
-              console.log('Something went wrong :o')
-            }
-          })
+          this._pushTweetsList()
         })
     })
     Linking.openURL('https://api.twitter.com/oauth/authenticate?oauth_token=' + oauthToken)
@@ -82,7 +73,7 @@ var LoginScreenView = React.createClass({
   },
 
   _pushTweetsList () {
-    this.props.navigator.resetTo({id: 'tweets-list-identifier'})
+    this.props.navigator.resetTo({id: 'tweets-list-identifier', twitterService: this.props.twitterService})
   }
 })
 

--- a/ReactNative/ReactTwitter/core/views/login-screen.js
+++ b/ReactNative/ReactTwitter/core/views/login-screen.js
@@ -55,8 +55,8 @@ var LoginScreenView = React.createClass({
       let parsedURI = OauthHelper.getOauthTokenAndVerifierFromURLCallback(uri)
       this.state.facade.stopListeningForDeepLinking()
 
-      if (this._userCancelledLogin(parsedURI)) {
-        // user canceled login
+      let userCancelledLogin = parsedURI.oauth_token == null || parsedURI.oauth_token.length === 0
+      if (userCancelledLogin) {
         return
       }
 
@@ -66,10 +66,6 @@ var LoginScreenView = React.createClass({
         })
     })
     Linking.openURL('https://api.twitter.com/oauth/authenticate?oauth_token=' + oauthToken)
-  },
-
-  _userCancelledLogin (parsedURI) {
-    return parsedURI.oauth_token == null || parsedURI.oauth_token.length === 0
   },
 
   _pushTweetsList () {

--- a/ReactNative/ReactTwitter/core/views/main-navigator.js
+++ b/ReactNative/ReactTwitter/core/views/main-navigator.js
@@ -34,7 +34,7 @@ var MainNavigator = React.createClass({
       case splashScreenID:
         return (<SplashScreenView navigator={navigator} title='Splash Screen' />)
       case loginScreenID:
-        return (<LoginScreenView navigator={navigator} title='Login Screen' />)
+        return (<LoginScreenView navigator={navigator} title='Login Screen' twitterService={route.twitterService}/>)
       case debugScreenID:
         return (<DebugScreenView navigator={navigator} title='Debug Screen' />)
       case deepLinkingID:
@@ -42,9 +42,9 @@ var MainNavigator = React.createClass({
       case OauthViewID:
         return (<OauthView navigator={navigator} title='Oauth' />)
       case tweetsListID:
-        return (<TweetsList navigator={navigator} title='Tweets List' />)
+        return (<TweetsList navigator={navigator} title='Tweets List' twitterService={route.twitterService} />)
       case tweetViewID:
-        return (<TweetView navigator={navigator} tweetId={route.tweetId} title='Tweet View' />)
+        return (<TweetView navigator={navigator} tweetId={route.tweetId} title='Tweet View' twitterService={route.twitterService} />)
     }
   }
 })

--- a/ReactNative/ReactTwitter/core/views/splash-screen.js
+++ b/ReactNative/ReactTwitter/core/views/splash-screen.js
@@ -6,6 +6,7 @@ import {
   Navigator
 } from 'react-native'
 var AuthenticationService = require('../service/authentication-service.js')
+var TwitterRequestsService = require('../service/twitter-requests-service.js')
 
 const SPLASH_DURATION_MS = 1000
 
@@ -15,8 +16,10 @@ var SplashScreenView = React.createClass({
   },
 
   getInitialState () {
+    let authService = new AuthenticationService()
     return {
-      authenticationService: new AuthenticationService()
+      authenticationService: authService,
+      twitterService: new TwitterRequestsService(authService)
     }
   },
 
@@ -52,11 +55,11 @@ var SplashScreenView = React.createClass({
   },
 
   _pushLogin () {
-    this.props.navigator.resetTo({id: 'login-screen-identifier'})
+    this.props.navigator.resetTo({id: 'login-screen-identifier', twitterService: this.state.twitterService})
   },
 
   _pushTweetsList () {
-    this.props.navigator.resetTo({id: 'tweets-list-identifier'})
+    this.props.navigator.resetTo({id: 'tweets-list-identifier', twitterService: this.state.twitterService})
   }
 })
 

--- a/ReactNative/ReactTwitter/core/views/splash-screen.js
+++ b/ReactNative/ReactTwitter/core/views/splash-screen.js
@@ -23,7 +23,7 @@ var SplashScreenView = React.createClass({
   componentDidMount () {
     let authService = this.state.authenticationService
 
-    authService.loadDataFromDisk()
+    authService.loadData()
       .then(() => {
         return new Promise((resolve, reject) => {
           setTimeout(resolve, SPLASH_DURATION_MS)

--- a/ReactNative/ReactTwitter/core/views/splash-screen.js
+++ b/ReactNative/ReactTwitter/core/views/splash-screen.js
@@ -14,14 +14,8 @@ var SplashScreenView = React.createClass({
     navigator: React.PropTypes.instanceOf(Navigator).isRequired
   },
 
-  getInitialState () {
-    return {
-      authenticationService: new AuthenticationService()
-    }
-  },
-
   componentDidMount () {
-    let authService = this.state.authenticationService
+    let authService = new AuthenticationService()
 
     authService.loadDataFromDisk()
       .then(() => {

--- a/ReactNative/ReactTwitter/core/views/splash-screen.js
+++ b/ReactNative/ReactTwitter/core/views/splash-screen.js
@@ -14,8 +14,14 @@ var SplashScreenView = React.createClass({
     navigator: React.PropTypes.instanceOf(Navigator).isRequired
   },
 
+  getInitialState () {
+    return {
+      authenticationService: new AuthenticationService()
+    }
+  },
+
   componentDidMount () {
-    let authService = new AuthenticationService()
+    let authService = this.state.authenticationService
 
     authService.loadDataFromDisk()
       .then(() => {

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -8,12 +8,14 @@ import {
 } from 'react-native'
 import AndroidBackNavigationMixin from './mixins/android-back-navigation'
 var novodaDataFormat = require('./common/data-format.js')
+var TwitterRequestsService = require('../service/twitter-requests-service.js')
 
 var TweetsView = React.createClass({
   mixins: [AndroidBackNavigationMixin],
   propTypes: {
     tweetId: React.PropTypes.string.isRequired,
-    navigator: React.PropTypes.instanceOf(Navigator).isRequired
+    navigator: React.PropTypes.instanceOf(Navigator).isRequired,
+    twitterService: React.PropTypes.instanceOf(TwitterRequestsService).isRequired
   },
 
   getInitialState () {
@@ -26,22 +28,16 @@ var TweetsView = React.createClass({
     this._refreshData()
   },
 
-  /*global fetch*/
-  /*eslint no-undef: "error"*/
   _refreshData () {
-    var tweetId = this.props.tweetId
-    var url = 'https://api.twitter.com/1.1/statuses/show.json?id=' + tweetId
-    fetch(url, {
-      method: 'GET',
-      headers: {
-        'Authorization': 'OAuth oauth_consumer_key="aqPSTs1FT2ndP7qXi247BtbXd", oauth_nonce="9e48307c7ed7184557a3d88f6331f00f", oauth_signature="Jr9YqRlJ%2BNH%2BBgLC9cI%2F7LD06qg%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1463143567", oauth_token="730013266697654273-RDssoTCOdHNQtFA9k87OSijeZHcF4SU", oauth_version="1.0"'
-      }
-    })
-      .then((response) => response.json())
+    let tweetId = this.props.tweetId
+    this.props.twitterService.getTweet(tweetId)
       .then((rjson) => {
         this.setState({
           tweet: rjson
         })
+      })
+      .catch((error) => {
+        console.warn(error)
       })
   },
 

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -32,7 +32,7 @@ var TweetsList = React.createClass({
           dataSource: this.state.dataSource.cloneWithRows(rjson)
         })
       })
-      .catch((err) => { console.log(err) })
+      .catch((err) => { console.warn(err) })
   },
 
   renderRow (rowData) {

--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -6,11 +6,11 @@ import {
 import TweetsListItem from './tweetsListItem'
 import AndroidBackNavigationMixin from './mixins/android-back-navigation'
 var TwitterRequestsService = require('../service/twitter-requests-service.js')
-var AuthenticationService = require('../service/authentication-service.js')
 
 var TweetsList = React.createClass({
   mixins: [AndroidBackNavigationMixin],
   propTypes: {
+    twitterService: React.PropTypes.instanceOf(TwitterRequestsService).isRequired,
     navigator: React.PropTypes.instanceOf(Navigator).isRequired
   },
 
@@ -22,23 +22,11 @@ var TweetsList = React.createClass({
   },
 
   componentDidMount () {
-    let authService = new AuthenticationService()
-    authService.loadDataFromDisk()
-      .then(() => {
-        this._refreshData(
-          authService.getUsername(),
-          authService.getOAuthToken(),
-          authService.getSecretToken()
-        )
-      })
-      .catch((err) => { console.log(err) })
+    this._refreshData()
   },
 
-  /*global fetch*/
-  /*eslint no-undef: "error"*/
-  _refreshData (username, oauthToken, oauthTokenSecret) {
-    let twitterService = new TwitterRequestsService()
-    twitterService.getHomeTimeline(username, oauthToken, oauthTokenSecret)
+  _refreshData () {
+    this.props.twitterService.getHomeTimeline()
       .then((rjson) => {
         this.setState({
           dataSource: this.state.dataSource.cloneWithRows(rjson)
@@ -57,6 +45,7 @@ var TweetsList = React.createClass({
           author_handle={rowData.user.screen_name}
           text={rowData.text}
           navigator={this.props.navigator}
+          twitterService={this.props.twitterService}
         />
     )
   },

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -9,6 +9,7 @@ import {
 } from 'react-native'
 
 var novodaDataFormat = require('./common/data-format.js')
+var TwitterRequestsService = require('../service/twitter-requests-service.js')
 
 var TweetsListItem = React.createClass({
   propTypes: {
@@ -18,7 +19,8 @@ var TweetsListItem = React.createClass({
     author_name: React.PropTypes.string.isRequired,
     author_handle: React.PropTypes.string.isRequired,
     text: React.PropTypes.string.isRequired,
-    navigator: React.PropTypes.instanceOf(Navigator).isRequired
+    navigator: React.PropTypes.instanceOf(Navigator).isRequired,
+    twitterService: React.PropTypes.instanceOf(TwitterRequestsService).isRequired
   },
 
   render () {
@@ -45,7 +47,8 @@ var TweetsListItem = React.createClass({
   _tweetSelected (tweetId) {
     this.props.navigator.push({
       id: 'tweet-view-identifier',
-      tweetId: tweetId
+      tweetId: tweetId,
+      twitterService: this.props.twitterService
     })
   }
 


### PR DESCRIPTION
TL;DR Use real data for the tweets list and tweet details

Previously, the authorization header for the aforementioned calls was hardcoded. So now we use the `OauthHelper` to compute the real auhorization header. To achieve this, we defined methods in the `TwitterRequestsService` to help us for that, and added support for query parameters in `OauthHelper`. We also inject the `TwitterRequestsService` across the different views so we don't have to instantiate each time a new service, and we encapsulated the `AuthenticationService` logic in the service. Plus misc refactors to improve quality.

No actual screenshots, as we only touched the functionality, not the UI.

Paired with @gbasile 