### PR TITLE
Add pull-to-refresh mechanism for tweets list

### DIFF
--- a/ReactNative/ReactTwitter/core/views/tweetsList.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsList.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {
   ListView,
   Navigator,
+  RefreshControl,
   StyleSheet
 } from 'react-native'
 import TweetsListItem from './tweetsListItem'
@@ -18,6 +19,7 @@ var TweetsList = React.createClass({
   getInitialState () {
     var ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2})
     return {
+      isRefreshing: false,
       dataSource: ds.cloneWithRows([])
     }
   },
@@ -27,13 +29,30 @@ var TweetsList = React.createClass({
   },
 
   _refreshData () {
+    this.setState({isRefreshing: true})
     this.props.twitterService.getHomeTimeline()
       .then((rjson) => {
         this.setState({
-          dataSource: this.state.dataSource.cloneWithRows(rjson)
+          dataSource: this.state.dataSource.cloneWithRows(rjson),
+          isRefreshing: false
         })
       })
-      .catch((err) => { console.warn(err) })
+      .catch((err) => {
+        console.warn(err)
+        this.setState({isRefreshing: false})
+      })
+  },
+
+  render () {
+    return (
+      <ListView
+        dataSource={this.state.dataSource}
+        enableEmptySections={true}
+        renderRow={this.renderRow}
+        refreshControl={this._refreshControl()}
+        style={styles.container}
+      />
+    )
   },
 
   renderRow (rowData) {
@@ -51,15 +70,16 @@ var TweetsList = React.createClass({
     )
   },
 
-  render () {
-    return (
-      <ListView
-        dataSource={this.state.dataSource}
-        enableEmptySections={true}
-        renderRow={this.renderRow}
-        style={styles.container}
-      />
-    )
+  _refreshControl () {
+    return (<RefreshControl
+      refreshing={this.state.isRefreshing}
+      onRefresh={this._refreshData}
+      tintColor='#aaaaaa'
+      title='Loading...'
+      titleColor='#48BBEC'
+      colors={['#48BBEC']}
+      progressBackgroundColor='#ffffff'
+    />)
   }
 })
 


### PR DESCRIPTION
Basically, added a `RefreshControl` as a `refreshControl` property of the `ListView`

BEFORE: 

| iOS | Android |
| --- | --- |
| ![ios-before](https://cloud.githubusercontent.com/assets/2426348/15425048/5da69c96-1e86-11e6-91a4-956bd8edaf3d.gif) | ![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/2426348/15425254/5c90c998-1e87-11e6-9aad-edae66d2c118.gif) |

AFTER: 

| iOS | Android |
| --- | --- |
| ![ios-after](https://cloud.githubusercontent.com/assets/2426348/15425052/6312cd30-1e86-11e6-911d-cd9ef61df948.gif) | ![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/2426348/15425251/5635afdc-1e87-11e6-8f43-cd3c188b9ae9.gif) |

Paired with no one