### PR TITLE
Remote config

### DIFF
--- a/Firebase/ios/Bonfire.xcodeproj/project.pbxproj
+++ b/Firebase/ios/Bonfire.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		B6210AC61CE21FA500570509 /* FirebaseLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6210AC51CE21FA500570509 /* FirebaseLoginService.swift */; };
 		B6210AC81CE2318B00570509 /* UIViewController+AlertExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6210AC71CE2318B00570509 /* UIViewController+AlertExtensions.swift */; };
 		B6210ACC1CE24AC600570509 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6210ACB1CE24AC600570509 /* Authentication.swift */; };
+		B636BA241CF34D9F009009F2 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636BA231CF34D9F009009F2 /* Config.swift */; };
+		B636BA261CF34DDA009009F2 /* FirebaseRemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636BA251CF34DDA009009F2 /* FirebaseRemoteConfig.swift */; };
 		B654B2671CE0C38000EEDE0A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B654B2661CE0C38000EEDE0A /* AppDelegate.swift */; };
 		B654B2691CE0C38000EEDE0A /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B654B2681CE0C38000EEDE0A /* ChatViewController.swift */; };
 		B654B26E1CE0C38000EEDE0A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B654B26D1CE0C38000EEDE0A /* Assets.xcassets */; };
@@ -65,22 +67,16 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		18552469EE733CDD665FAABA /* Pods-FireChat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireChat.release.xcconfig"; path = "Pods/Target Support Files/Pods-FireChat/Pods-FireChat.release.xcconfig"; sourceTree = "<group>"; };
-		19F398DA972350BEE0B6C106 /* Pods-BonfireTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BonfireTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BonfireTests/Pods-BonfireTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1AF7D19F1CEF651600B74483 /* UsersTableViewManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersTableViewManager.swift; sourceTree = "<group>"; };
 		1AF7D1A11CEF659A00B74483 /* UserCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserCell.swift; sourceTree = "<group>"; };
-		2A4F22BDF6F3209EA6A47490 /* Pods-FireChat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireChat.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FireChat/Pods-FireChat.debug.xcconfig"; sourceTree = "<group>"; };
-		2D075B151032785BA369976F /* Pods-FireChatTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireChatTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FireChatTests/Pods-FireChatTests.debug.xcconfig"; sourceTree = "<group>"; };
-		49CB42CBF07CB67A7098B119 /* Pods_BonfireTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BonfireTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6ED89D707761E000739192BB /* Pods_FireChatTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FireChatTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		762CAACC9748C4C2020DEB68 /* Pods-Bonfire.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bonfire.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Bonfire/Pods-Bonfire.debug.xcconfig"; sourceTree = "<group>"; };
-		8E526CD7E098654A400AFF1B /* Pods-BonfireTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BonfireTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BonfireTests/Pods-BonfireTests.release.xcconfig"; sourceTree = "<group>"; };
-		A163ACC9BD8B9A58E4CCD0BA /* Pods-FireChatTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireChatTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-FireChatTests/Pods-FireChatTests.release.xcconfig"; sourceTree = "<group>"; };
 		A3502F7C2E0D8E18407574C0 /* Pods-Bonfire.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bonfire.release.xcconfig"; path = "Pods/Target Support Files/Pods-Bonfire/Pods-Bonfire.release.xcconfig"; sourceTree = "<group>"; };
 		B6210AC31CE20CEC00570509 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B6210AC51CE21FA500570509 /* FirebaseLoginService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseLoginService.swift; sourceTree = "<group>"; };
 		B6210AC71CE2318B00570509 /* UIViewController+AlertExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+AlertExtensions.swift"; sourceTree = "<group>"; };
 		B6210ACB1CE24AC600570509 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
+		B636BA231CF34D9F009009F2 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		B636BA251CF34DDA009009F2 /* FirebaseRemoteConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseRemoteConfig.swift; sourceTree = "<group>"; };
 		B654B2631CE0C38000EEDE0A /* Bonfire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bonfire.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B654B2661CE0C38000EEDE0A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Mobile/AppDelegate.swift; sourceTree = "<group>"; };
 		B654B2681CE0C38000EEDE0A /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
@@ -131,7 +127,6 @@
 		D0C31879D1AD9CF1461F5956 /* ChannelsDisplayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelsDisplayer.swift; sourceTree = "<group>"; };
 		D0C318BAA30984F559ACD8D2 /* ChannelsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelsService.swift; sourceTree = "<group>"; };
 		D0C318C841B6FF1360F3261D /* FirebaseChannelsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseChannelsService.swift; sourceTree = "<group>"; };
-		E7D71E5C5A01740D1A577CD6 /* Pods_FireChat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FireChat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB70D05C61A560423DF28B22 /* Pods_Bonfire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bonfire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -150,14 +145,8 @@
 		061C0C1246299AC2040CBD3E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2A4F22BDF6F3209EA6A47490 /* Pods-FireChat.debug.xcconfig */,
-				18552469EE733CDD665FAABA /* Pods-FireChat.release.xcconfig */,
-				2D075B151032785BA369976F /* Pods-FireChatTests.debug.xcconfig */,
-				A163ACC9BD8B9A58E4CCD0BA /* Pods-FireChatTests.release.xcconfig */,
 				762CAACC9748C4C2020DEB68 /* Pods-Bonfire.debug.xcconfig */,
 				A3502F7C2E0D8E18407574C0 /* Pods-Bonfire.release.xcconfig */,
-				19F398DA972350BEE0B6C106 /* Pods-BonfireTests.debug.xcconfig */,
-				8E526CD7E098654A400AFF1B /* Pods-BonfireTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -165,10 +154,7 @@
 		84E6A1703F33B68AF3E76306 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E7D71E5C5A01740D1A577CD6 /* Pods_FireChat.framework */,
-				6ED89D707761E000739192BB /* Pods_FireChatTests.framework */,
 				FB70D05C61A560423DF28B22 /* Pods_Bonfire.framework */,
-				49CB42CBF07CB67A7098B119 /* Pods_BonfireTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -238,6 +224,7 @@
 				B654B28A1CE0CE8300EEDE0A /* Chat */,
 				B65C45CB1CE1E3D900B2179D /* Login */,
 				B65C45D81CE1F00000B2179D /* Navigation */,
+				B636BA231CF34D9F009009F2 /* Config.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -251,6 +238,7 @@
 				B65C45D91CE1F05400B2179D /* Navigation */,
 				B6962C891CEF5676006A3A9E /* Users */,
 				B654B2871CE0C86200EEDE0A /* Utilities */,
+				B636BA251CF34DDA009009F2 /* FirebaseRemoteConfig.swift */,
 			);
 			path = Mobile;
 			sourceTree = "<group>";
@@ -526,6 +514,7 @@
 				B65C45D71CE1EFE100B2179D /* Navigator.swift in Sources */,
 				B65C45D11CE1E41200B2179D /* LoginService.swift in Sources */,
 				B6962C911CEF5742006A3A9E /* Firebase+RxExtensions.swift in Sources */,
+				B636BA261CF34DDA009009F2 /* FirebaseRemoteConfig.swift in Sources */,
 				B654B2671CE0C38000EEDE0A /* AppDelegate.swift in Sources */,
 				B65C45BB1CE0E46B00B2179D /* ChatPresenter.swift in Sources */,
 				B65C45CF1CE1E40B00B2179D /* LoginDisplayer.swift in Sources */,
@@ -541,6 +530,7 @@
 				D0C319895F726FA2DAECFC21 /* ChannelsViewController.swift in Sources */,
 				B6CC1CEE1CECA83600BA8500 /* CreateChannelPresenter.swift in Sources */,
 				D0C31F91CCF73EC549BE1264 /* ChannelCell.swift in Sources */,
+				B636BA241CF34D9F009009F2 /* Config.swift in Sources */,
 				B6CC1CEB1CEC992F00BA8500 /* Observable+Extensions.swift in Sources */,
 				D0C31B830B0684A6D238C842 /* ChannelsView.swift in Sources */,
 				D0C317C9CD54BDC5F4607BCD /* ChannelsTableViewManager.swift in Sources */,

--- a/Firebase/ios/Bonfire/Core/Channel/ChannelsPresenter.swift
+++ b/Firebase/ios/Bonfire/Core/Channel/ChannelsPresenter.swift
@@ -6,14 +6,16 @@ class ChannelsPresenter {
     let channelsService: ChannelsService
     let channelsDisplayer: ChannelsDisplayer
     let navigator: Navigator
+    let config: Config
 
     var disposeBag: DisposeBag!
 
-    init(loginService: LoginService, channelsService: ChannelsService, channelsDisplayer: ChannelsDisplayer, navigator: Navigator) {
+    init(loginService: LoginService, channelsService: ChannelsService, channelsDisplayer: ChannelsDisplayer, navigator: Navigator, config: Config) {
         self.loginService = loginService
         self.channelsService = channelsService
         self.channelsDisplayer = channelsDisplayer
         self.navigator = navigator
+        self.config = config
     }
 
     func startPresenting() {
@@ -25,6 +27,12 @@ class ChannelsPresenter {
             auth.isSuccess()
         }).flatMap({ auth in
             return self.channelsService.channels(forUser: auth.user!)
+        }).map({ channels in
+            if self.config.orderChannelsByName() {
+                return channels.sort({$0.name < $1.name})
+            } else {
+                return channels
+            }
         }).subscribe(
             onNext: { [weak self] channels in
                 self?.channelsDisplayer.display(channels)

--- a/Firebase/ios/Bonfire/Core/Config.swift
+++ b/Firebase/ios/Bonfire/Core/Config.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol Config {
+    func orderChannelsByName() -> Bool
+}

--- a/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
+++ b/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
@@ -44,4 +44,5 @@ struct SharedServices {
     static let channelsService: ChannelsService = FirebaseChannelsService()
     static let chatService: ChatService = FirebaseChatService()
     static let navigator: Navigator = AppNavigator()
+    static let config: Config = FirebaseRemoteConfig()
 }

--- a/Firebase/ios/Bonfire/Mobile/Channel/ChannelsViewController.swift
+++ b/Firebase/ios/Bonfire/Mobile/Channel/ChannelsViewController.swift
@@ -5,11 +5,11 @@ final class ChannelsViewController: UIViewController {
     let channelsPresenter: ChannelsPresenter
 
     static func withDependencies() -> ChannelsViewController {
-        return ChannelsViewController(loginService: SharedServices.loginService, channelsService: SharedServices.channelsService, navigator: SharedServices.navigator)
+        return ChannelsViewController(loginService: SharedServices.loginService, channelsService: SharedServices.channelsService, navigator: SharedServices.navigator, config: SharedServices.config)
     }
 
-    init(loginService: LoginService, channelsService: ChannelsService, navigator: Navigator) {
-        self.channelsPresenter = ChannelsPresenter(loginService: loginService, channelsService: channelsService, channelsDisplayer: channelsView, navigator: navigator)
+    init(loginService: LoginService, channelsService: ChannelsService, navigator: Navigator, config: Config) {
+        self.channelsPresenter = ChannelsPresenter(loginService: loginService, channelsService: channelsService, channelsDisplayer: channelsView, navigator: navigator, config: config)
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Firebase/ios/Bonfire/Mobile/FirebaseRemoteConfig.swift
+++ b/Firebase/ios/Bonfire/Mobile/FirebaseRemoteConfig.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Firebase
+
+class FirebaseRemoteConfig: Config {
+
+    let remoteConfig = FIRRemoteConfig.remoteConfig()
+
+    init() {
+        fetchConfig()
+    }
+
+    private func fetchConfig() {
+        let remoteConfigSettings = FIRRemoteConfigSettings(developerModeEnabled: true)
+        remoteConfig.configSettings = remoteConfigSettings!
+
+        var expirationDuration: Double = 3600
+        if (remoteConfig.configSettings.isDeveloperModeEnabled) {
+            expirationDuration = 0
+        }
+        
+        remoteConfig.fetchWithExpirationDuration(expirationDuration) { (status, error) in
+            if status == .Success {
+                self.remoteConfig.activateFetched()
+            }
+        }
+    }
+
+    // MARK: - Config Protocol
+
+    func orderChannelsByName() -> Bool {
+        let order = remoteConfig["orderChannelsByName"].boolValue
+        return order
+    }
+}

--- a/Firebase/ios/Podfile
+++ b/Firebase/ios/Podfile
@@ -9,5 +9,6 @@ target 'Bonfire' do
     pod 'Firebase'
     pod 'Firebase/Database'
     pod 'Firebase/Auth'
+    pod 'Firebase/RemoteConfig'
     pod 'GoogleSignIn'
 end

--- a/Firebase/ios/Podfile.lock
+++ b/Firebase/ios/Podfile.lock
@@ -11,6 +11,9 @@ PODS:
   - Firebase/Database (3.2.0):
     - Firebase/Analytics (= 3.2.0)
     - FirebaseDatabase (= 3.0.1)
+  - Firebase/RemoteConfig (3.2.0):
+    - Firebase/Analytics (= 3.2.0)
+    - FirebaseRemoteConfig (= 1.1.1)
   - FirebaseAnalytics (3.2.0):
     - FirebaseInstanceID (~> 1.0)
     - GoogleInterchangeUtilities (~> 1.2)
@@ -23,6 +26,13 @@ PODS:
   - FirebaseDatabase (3.0.1):
     - FirebaseAnalytics (~> 3.2)
   - FirebaseInstanceID (1.0.6)
+  - FirebaseRemoteConfig (1.1.1):
+    - FirebaseAnalytics (~> 3.2)
+    - FirebaseInstanceID (~> 1.0)
+    - GoogleInterchangeUtilities (~> 1.2)
+    - GoogleIPhoneUtilities (~> 1.2)
+    - GoogleSymbolUtilities (~> 1.1)
+    - GoogleUtilities (~> 1.3)
   - GoogleAppUtilities (1.1.1):
     - GoogleSymbolUtilities (~> 1.0)
   - GoogleAuthUtilities (2.0.1):
@@ -30,6 +40,9 @@ PODS:
     - GoogleSymbolUtilities (~> 1.0)
   - GoogleInterchangeUtilities (1.2.1):
     - GoogleSymbolUtilities (~> 1.0)
+  - GoogleIPhoneUtilities (1.2.1):
+    - GoogleSymbolUtilities (~> 1.0)
+    - GoogleUtilities (~> 1.0)
   - GoogleNetworkingUtilities (1.2.1):
     - GoogleSymbolUtilities (~> 1.0)
   - GoogleSignIn (4.0.0):
@@ -48,6 +61,7 @@ DEPENDENCIES:
   - Firebase
   - Firebase/Auth
   - Firebase/Database
+  - Firebase/RemoteConfig
   - GoogleSignIn
   - RxCocoa (~> 2.0)
   - RxSwift (~> 2.0)
@@ -58,9 +72,11 @@ SPEC CHECKSUMS:
   FirebaseAuth: 94b851fc345ce98036dfedfdc2eddeaef8fa3b4c
   FirebaseDatabase: 34301d11621a83546f39f670d256477ba6f7fcea
   FirebaseInstanceID: d014d574053a2fe84478f12f7bae96979e7051bb
+  FirebaseRemoteConfig: 3260ced812d2adcbb9bcefe0dc78fdce7b8090e6
   GoogleAppUtilities: f1730f91f67767b453c289577040dd3f425ffdc7
   GoogleAuthUtilities: d7a19615cd7627688afcf181737f1011ee8b5a23
   GoogleInterchangeUtilities: def8415a862effc67d549d5b5b0b9c7a2f97d4de
+  GoogleIPhoneUtilities: 63f25e93a3ddcb66884d182aab3a660d98f1479b
   GoogleNetworkingUtilities: 3e83269048cfb498dc7ec83ab36813360965c74f
   GoogleSignIn: 09036ed61f8e75f1424100d63f7719480b2428c3
   GoogleSymbolUtilities: 33117db1b5f290c6fbf259585e4885b4c84b98d7


### PR DESCRIPTION
A very simple example of using Firebase Remote Config, to sort all channels by name rather than separate Public and Private channels (the default).