### PR TITLE
React/PT-131/Android accessibility

### DIFF
--- a/ReactNative/ReactTwitter/core/views/common/avatar-view.js
+++ b/ReactNative/ReactTwitter/core/views/common/avatar-view.js
@@ -25,6 +25,7 @@ class AvatarView extends Image {
     return <Image
       source= {source}
       style = {style.image}
+      importantForAccessibility="no"
       resizeMode='contain'/>
   }
 

--- a/ReactNative/ReactTwitter/core/views/common/avatar-view.js
+++ b/ReactNative/ReactTwitter/core/views/common/avatar-view.js
@@ -25,7 +25,7 @@ class AvatarView extends Image {
     return <Image
       source= {source}
       style = {style.image}
-      importantForAccessibility="no"
+      importantForAccessibility='no'
       resizeMode='contain'/>
   }
 

--- a/ReactNative/ReactTwitter/core/views/tweetView.js
+++ b/ReactNative/ReactTwitter/core/views/tweetView.js
@@ -8,9 +8,10 @@ import {
   Navigator
 } from 'react-native'
 import AndroidBackNavigationMixin from './mixins/android-back-navigation'
-var novodaDataFormat = require('./common/data-format.js')
-var TwitterRequestsService = require('../service/twitter-requests-service.js')
-var AvatarView = require('./common/avatar-view.js')
+const novodaDataFormat = require('./common/data-format.js')
+const TwitterRequestsService = require('../service/twitter-requests-service.js')
+const AvatarView = require('./common/avatar-view.js')
+const AutoLink = require('react-native-autolink')
 
 var TweetsView = React.createClass({
   mixins: [AndroidBackNavigationMixin],
@@ -55,7 +56,7 @@ var TweetsView = React.createClass({
         <Text style={styles.tweet_author}>{this.state.tweet.user.name}</Text>
         <Text style={styles.tweet_author_handle}>@{this.state.tweet.user.screen_name}</Text>
         <Text style={styles.tweet_time}>Tweeted {formattedTime}</Text>
-        <Text style={styles.tweet_text}>{this.state.tweet.text}</Text>
+        <AutoLink style={styles.tweet_text} text={this.state.tweet.text}/>
       </View>
     )
   }

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -37,7 +37,7 @@ var TweetsListItem = React.createClass({
             <View style={styles.textContainer}>
               <View style={styles.userInfoContainer}>
                 <Text style={styles.tweet_author}>{this.props.author_name}</Text>
-                <Text importantForAccessibility="no" style={styles.tweet_author_handle}>@{this.props.author_handle}</Text>
+                <Text importantForAccessibility='no' style={styles.tweet_author_handle}>@{this.props.author_handle}</Text>
               </View>
               <Text style={styles.tweet_time}>{formattedTime}</Text>
               <Text style={styles.tweet_text} accessibilityLabel={textWithoutUrls}>{this.props.text}</Text>
@@ -49,7 +49,7 @@ var TweetsListItem = React.createClass({
     )
   },
 
-  _removeUrls(originalText: string) {
+  _removeUrls (originalText: string) {
     // This is not the best user experience, accessibility-wise,
     // but we want to try different accessibilityLabels, for the sake of the spike
     return originalText.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '')

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -27,6 +27,7 @@ var TweetsListItem = React.createClass({
 
   render () {
     var formattedTime = novodaDataFormat.elapsedTime(this.props.time)
+    var textWithoutUrls = this._removeUrls(this.props.text)
     return (
       <TouchableHighlight onPress={() => this._tweetSelected(this.props.id)}
         underlayColor='#dddddd'>
@@ -39,13 +40,19 @@ var TweetsListItem = React.createClass({
                 <Text importantForAccessibility="no" style={styles.tweet_author_handle}>@{this.props.author_handle}</Text>
               </View>
               <Text style={styles.tweet_time}>{formattedTime}</Text>
-              <Text style={styles.tweet_text}>{this.props.text}</Text>
+              <Text style={styles.tweet_text} accessibilityLabel={textWithoutUrls}>{this.props.text}</Text>
             </View>
            </View>
            <View style={styles.separator}/>
          </View>
        </TouchableHighlight>
     )
+  },
+
+  _removeUrls(originalText: string) {
+    // This is not the best user experience, accessibility-wise,
+    // but we want to try different accessibilityLabels, for the sake of the spike
+    return originalText.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '')
   },
 
   _tweetSelected (tweetId: string) {

--- a/ReactNative/ReactTwitter/core/views/tweetsListItem.js
+++ b/ReactNative/ReactTwitter/core/views/tweetsListItem.js
@@ -36,7 +36,7 @@ var TweetsListItem = React.createClass({
             <View style={styles.textContainer}>
               <View style={styles.userInfoContainer}>
                 <Text style={styles.tweet_author}>{this.props.author_name}</Text>
-                <Text style={styles.tweet_author_handle}>@{this.props.author_handle}</Text>
+                <Text importantForAccessibility="no" style={styles.tweet_author_handle}>@{this.props.author_handle}</Text>
               </View>
               <Text style={styles.tweet_time}>{formattedTime}</Text>
               <Text style={styles.tweet_text}>{this.props.text}</Text>

--- a/ReactNative/ReactTwitter/package.json
+++ b/ReactNative/ReactTwitter/package.json
@@ -11,9 +11,10 @@
     "crypto-js": "^3.1.6",
     "react": "15.0.2",
     "react-native": "^0.26.1",
+    "react-native-autolink": "^0.4.0",
     "react-native-button": "^1.5.0",
-    "tiny-human-time": "^1.2.0",
-    "react-native-push-notification": "^1.0.6"
+    "react-native-push-notification": "^1.0.6",
+    "tiny-human-time": "^1.2.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
This PR investigates the following aspects of accessibility:

- Add a custom text read from TalkBack instead of the default one
- Ignore certain elements of a group when navigating (for example in a list)

Also uses the Autolink library to automatically highlight links inside a text and handle click.
This is not working with accessibility though (it's not possible to select the link inside the text when navigating with talkback on). An issue will be opened to the library repo.

![image](https://cloud.githubusercontent.com/assets/3942812/15610316/83da522c-241c-11e6-83b6-46b46c7098e1.png)

Paired with ☕ 