### PR TITLE
Firebase/death to whitespace

### DIFF
--- a/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
+++ b/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
@@ -12,8 +12,10 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         FIRApp.configure()
         GIDSignIn.sharedInstance().clientID = FIRApp.defaultApp()?.options.clientID
 
-//                try! FIRAuth.auth()?.signOut()
-//                GIDSignIn.sharedInstance().signOut()
+        // Uncomment these lines to sign out and start afresh!
+        // try! FIRAuth.auth()?.signOut()
+        // GIDSignIn.sharedInstance().signOut()
+
         UIApplication.sharedApplication().statusBarStyle = .LightContent
 
         if let navigationController = (SharedServices.navigator as? AppNavigator)?.navigationController {
@@ -47,7 +49,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(
         application: UIApplication,
         continueUserActivity userActivity: NSUserActivity,
-        restorationHandler: ([AnyObject]?) -> Void
+                             restorationHandler: ([AnyObject]?) -> Void
         ) -> Bool {
 
         let handled = FIRDynamicLinks.dynamicLinks()?.handleUniversalLink(userActivity.webpageURL!) { (dynamiclink, error) in

--- a/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
+++ b/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
@@ -12,10 +12,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         FIRApp.configure()
         GIDSignIn.sharedInstance().clientID = FIRApp.defaultApp()?.options.clientID
 
-        // Uncomment these lines to sign out and start afresh!
-        // try! FIRAuth.auth()?.signOut()
-        // GIDSignIn.sharedInstance().signOut()
-
         UIApplication.sharedApplication().statusBarStyle = .LightContent
 
         if let navigationController = (SharedServices.navigator as? AppNavigator)?.navigationController {

--- a/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
+++ b/Firebase/ios/Bonfire/Mobile/AppDelegate.swift
@@ -1,13 +1,11 @@
 import UIKit
 import Firebase
 import GoogleSignIn
-import RxSwift
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    let disposeBag = DisposeBag()
     var userService: UsersService!
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {

--- a/Firebase/ios/Bonfire/Mobile/Channel/ChannelCell.swift
+++ b/Firebase/ios/Bonfire/Mobile/Channel/ChannelCell.swift
@@ -28,8 +28,6 @@ final class ChannelCell: UICollectionViewCell {
 
         privateImage.contentMode = .ScaleAspectFill
 
-//        backgroundCircle.layer.borderWidth = 3
-//        backgroundCircle.layer.borderColor = UIColor(red: 248 / 255, green: 95 / 255, blue: 65 / 255, alpha: 1.0).CGColor
         backgroundCircle.layer.cornerRadius = layer.frame.height / 2
         backgroundCircle.backgroundColor = UIColor.whiteColor()
 

--- a/Firebase/ios/Bonfire/Mobile/Channel/ChannelCreation/CreateChannelView.swift
+++ b/Firebase/ios/Bonfire/Mobile/Channel/ChannelCreation/CreateChannelView.swift
@@ -1,6 +1,4 @@
 import UIKit
-import RxSwift
-import RxCocoa
 
 final class CreateChannelView: UIView {
 
@@ -22,8 +20,6 @@ final class CreateChannelView: UIView {
 
     weak var actionListener: CreateChannelActionListener?
     weak var viewController: UIViewController?
-
-    private let disposeBag = DisposeBag()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -82,7 +78,6 @@ final class CreateChannelView: UIView {
 
     }
 
-
     func setupLayout() {
         addSubview(scrollView)
         scrollView.pinToSuperviewEdges()
@@ -140,10 +135,7 @@ final class CreateChannelView: UIView {
     }
 
     func setupActions() {
-        submitButton.rx_tap.subscribe(
-            onNext: { [weak self] in
-                self?.createChannel()
-            }).addDisposableTo(disposeBag)
+        submitButton.addTarget(self, action: #selector(createChannel), forControlEvents: .TouchUpInside)
     }
 
     func createChannel() {

--- a/Firebase/ios/Bonfire/Mobile/Chat/ChatView.swift
+++ b/Firebase/ios/Bonfire/Mobile/Chat/ChatView.swift
@@ -1,6 +1,4 @@
 import UIKit
-import RxSwift
-import RxCocoa
 
 protocol ChatViewNavigationItemDelegate: class {
     func updateNavigationItem(withChat chat: Chat)
@@ -56,6 +54,7 @@ final class ChatView: UIView {
         sendButton.titleLabel?.font = UIFont.boldSystemFontOfSize(17)
 
         sendButton.addTarget(self, action: #selector(submitMessage), forControlEvents: .TouchUpInside)
+        textField.addTarget(self, action: #selector(updateButtonState), forControlEvents: [.ValueChanged, .AllEditingEvents])
     }
 
     private func setupHierarchy() {
@@ -121,9 +120,21 @@ extension ChatView {
         actionListener?.addUsers()
     }
 
+    func updateButtonState() {
+        sendButton.enabled = !messageText.isEmpty
+    }
+
     func submitMessage() {
-        actionListener?.submitMessage(textField.text ?? "")
+        guard !messageText.isEmpty else {
+            return
+        }
+
+        actionListener?.submitMessage(messageText)
         textField.text = ""
+    }
+
+    var messageText: String {
+        return textField.text?.stringByTrimmingCharactersInSet(.whitespaceCharacterSet()) ?? ""
     }
 }
 


### PR DESCRIPTION
New features:

* We now disable the send button for empty messages, including messages made of only whitespace.
* We trim the string before submitting it.

Refactoring / clean up:
* Removed unused property and import of RxSwift in AppDelegate
* Now using traditional target/action rather than `rx_` extensions in all view controllers, for consistency
* Removed some unused lines and added a little description
