### PR TITLE
Avoid cancelling fetch when unsubscribing from the data

### DIFF
--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/presenter/TasksPresenter.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/presenter/TasksPresenter.java
@@ -32,7 +32,7 @@ public class TasksPresenter {
         this.navigator = navigator;
     }
 
-    public void setInitialFilterTo(TasksActionListener.Filter filter){
+    public void setInitialFilterTo(TasksActionListener.Filter filter) {
         currentFilter = filter;
     }
 

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/service/PersistedTasksService.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/service/PersistedTasksService.java
@@ -122,7 +122,8 @@ public class PersistedTasksService implements TasksService {
                         .flatMap(fetchFromRemoteIfOutOfDate())
                         .switchIfEmpty(fetchFromRemote())
                         .compose(asEvent(taskRelay.getValue()))
-                        .doOnNext(taskRelay); //TODO fix issue with unsubscribe before completion. Either revert or persist request.
+                        .doOnNext(taskRelay)
+                        .publish().autoConnect();
             }
         });
     }

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/tasks/view/loading/AndroidTasksLoadingDisplayer.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/tasks/view/loading/AndroidTasksLoadingDisplayer.java
@@ -3,8 +3,8 @@ package com.novoda.todoapp.tasks.view.loading;
 import android.support.design.widget.Snackbar;
 import android.view.View;
 
-import com.novoda.todoapp.tasks.loading.displayer.TasksLoadingDisplayer;
 import com.novoda.todoapp.tasks.loading.displayer.RetryActionListener;
+import com.novoda.todoapp.tasks.loading.displayer.TasksLoadingDisplayer;
 
 public class AndroidTasksLoadingDisplayer implements TasksLoadingDisplayer {
 


### PR DESCRIPTION
When unsubscribing from the tasks the behaviour was bound to the scheduler and any init still running would be cancelled.

We now allow the init fetch to continue running and cache it's result so that when the next client subscribes the data is there.