### PR TITLE
#eNews node v2

### DIFF
--- a/enews-node/app.js
+++ b/enews-node/app.js
@@ -6,20 +6,12 @@ var newsFetcher = new NewsFetcher(token);
 var latestDate = new Date();
 var oldestDate = new Date();
 
-oldestDate.setDate(latestDate.getDate() - 31);
+oldestDate.setDate(latestDate.getDate() - 7);
 
 // node timestamps are in milliseconds, need to convert to epoch
 var latest = latestDate / 1000;
 var oldest = oldestDate / 1000;
 
-// newsFetcher.getEnews(oldest, latest, function(eNews) {
-//   eNews.forEach(function(each) {
-//     console.log(each);
-//   });
-// });
-
-newsFetcher.getEnews(oldest, latest, function(messages) {
-  messages.forEach(function(each) {
-    console.log(each);
-  });
+newsFetcher.getEnews(oldest, latest, function(eNews) {
+  console.log(eNews);
 });

--- a/enews-node/app.js
+++ b/enews-node/app.js
@@ -12,8 +12,14 @@ oldestDate.setDate(latestDate.getDate() - 31);
 var latest = latestDate / 1000;
 var oldest = oldestDate / 1000;
 
-newsFetcher.getEnews(oldest, latest, function(eNews) {
-  eNews.forEach(function(each) {
+// newsFetcher.getEnews(oldest, latest, function(eNews) {
+//   eNews.forEach(function(each) {
+//     console.log(each);
+//   });
+// });
+
+newsFetcher.getEnews(oldest, latest, function(messages) {
+  messages.forEach(function(each) {
     console.log(each);
   });
 });

--- a/enews-node/newsFetcher.js
+++ b/enews-node/newsFetcher.js
@@ -1,6 +1,7 @@
 module.exports = NewsFetcher;
 
 var Slack = require('./slack.js');
+var Q = require('q');
 
 function NewsFetcher(token) {
   const GENERAL_CHANNEL_ID = 'C029J9QTH'
@@ -9,21 +10,59 @@ function NewsFetcher(token) {
 
   this.getEnews = function(oldest, latest, callback) {
     var wrap = function(messages) {
-        callback(messages.filter(isEnewsMessage));
+      convertToEnews(messages, callback);
     };
     slack.getMessages(GENERAL_CHANNEL_ID, oldest, latest, wrap);
   }
 
-  function isEnewsMessage(message) {
-    return isEnews(message.text)
+  function convertToEnews(messages, callback) {
+    var eNewsMessages = messages.filter(isEnewsMessage);
+    var usersPromise = getUsersFrom(eNewsMessages);
+    Q.all(usersPromise).then(users => {
+      var eNews = toEnews(eNewsMessages, users);
+      callback(eNews);
+    });
   }
 
-  function isEnews(messageText) {
+  function isEnewsMessage(message) {
+    var messageText = message.text;
     return contains(messageText, '#enews') || contains(messageText, '#eNews') || contains(messageText, '#C0YNBKANM');
   }
 
   function contains(input, check) {
     return input.indexOf(check) > -1;
+  }
+
+  function getUsersFrom(messages) {
+    var userIds = messages.map(each => {
+      return each.user;
+    });
+    var promises = [];
+    userIds.forEach(function(userId) {
+      promises.push(getUser(userId));
+    });
+    return promises;
+  }
+
+  function getUser(userId) {
+    return Q.promise(function(resolve, reject, notify) {
+      var wrap = function(user) {
+          resolve(user);
+      };
+      slack.getUser(userId, wrap);
+    });
+  }
+
+  function toEnews(messages, users) {
+    return messages.map(message => {
+        var posterName = users.filter(user => user.id === message.user).map(user => user.real_name)[0];
+        return {
+            originalMessage: message.text,
+            title: message.attachments[0].title,
+            link: message.attachments[0].title_link,
+            poster: posterName
+        }
+    });
   }
 
 }

--- a/enews-node/newsFetcher.js
+++ b/enews-node/newsFetcher.js
@@ -45,7 +45,7 @@ function NewsFetcher(token) {
   }
 
   function isEnews(messageText) {
-    return contains(messageText, '#enews') || contains(messageText, '#eNews');
+    return contains(messageText, '#enews') || contains(messageText, '#eNews') || contains(messageText, '#C0YNBKANM');
   }
 
   function isValidMessage(message) {

--- a/enews-node/newsFetcher.js
+++ b/enews-node/newsFetcher.js
@@ -56,11 +56,13 @@ function NewsFetcher(token) {
   function toEnews(messages, users) {
     return messages.map(message => {
         var posterName = users.filter(user => user.id === message.user).map(user => user.real_name)[0];
+        var attachment = message.attachments[0];
         return {
             originalMessage: message.text,
-            title: message.attachments[0].title,
-            link: message.attachments[0].title_link,
-            poster: posterName
+            title: attachment.title,
+            link: attachment.title_link,
+            poster: posterName,
+            imageUrl: attachment.imageUrl ? attachment.image_url : attachment.thumb_url
         }
     });
   }

--- a/enews-node/newsFetcher.js
+++ b/enews-node/newsFetcher.js
@@ -1,72 +1,29 @@
 module.exports = NewsFetcher;
 
+var Slack = require('./slack.js');
+
 function NewsFetcher(token) {
   const GENERAL_CHANNEL_ID = 'C029J9QTH'
-  const HISTORY_ENDPOINT = 'https://slack.com/api/channels.history'
-  const MESSAGE_COUNT = 1000;
 
-  var httpClient = require('request');
+  var slack = new Slack(token);
 
-  this.getEnews = function getEnews(oldest, latest, callback) {
-    var allEnews = [];
-    var handler = function(enews, hasMore, reducedLatest) {
-      allEnews = allEnews.concat(enews);
-      if (hasMore) {
-        getSlackHistory(createHistoryRequest(oldest, reducedLatest), handler);
-      } else {
-        callback(allEnews);
-      }
-    }
-    getSlackHistory(createHistoryRequest(oldest, latest), handler);
-  }
-
-  function getSlackHistory(request, callback) {
-    httpClient.get(request, function(error, response, body) {
-      var jsonBody = JSON.parse(body);
-      var messages = jsonBody.messages;
-      var enews = parseMessages(messages);
-      var reducedLatest = messages[messages.length - 1].ts;
-      callback(enews, jsonBody.has_more, reducedLatest);
-    });
-  }
-
-  function parseMessages(messages) {
-    var enews = [];
-    messages.forEach(function(message) {
-      if (isEnewsMessage(message)) {
-        enews.push(message.text);
-      }
-    });
-    return enews;
+  this.getEnews = function(oldest, latest, callback) {
+    var wrap = function(messages) {
+        callback(messages.filter(isEnewsMessage));
+    };
+    slack.getMessages(GENERAL_CHANNEL_ID, oldest, latest, wrap);
   }
 
   function isEnewsMessage(message) {
-    return isValidMessage(message) && isEnews(message.text)
+    return isEnews(message.text)
   }
 
   function isEnews(messageText) {
     return contains(messageText, '#enews') || contains(messageText, '#eNews') || contains(messageText, '#C0YNBKANM');
   }
 
-  function isValidMessage(message) {
-    return !message.bot_id && message.type == 'message'
-  }
-
   function contains(input, check) {
     return input.indexOf(check) > -1;
   }
-
-  function createHistoryRequest(oldest, latest) {
-    return {
-      url: HISTORY_ENDPOINT,
-      qs: {
-        token: token,
-        channel: GENERAL_CHANNEL_ID,
-        count: MESSAGE_COUNT,
-        oldest: oldest,
-        latest: latest
-      }
-    }
-  };
 
 }

--- a/enews-node/slack.js
+++ b/enews-node/slack.js
@@ -2,6 +2,7 @@ module.exports = Slack;
 
 function Slack(token) {
   const HISTORY_ENDPOINT = 'https://slack.com/api/channels.history'
+  const USER_ENDPOINT = 'https://slack.com/api/users.info'
   const MESSAGE_COUNT = 1000;
 
   var httpClient = require('request');
@@ -46,5 +47,24 @@ function Slack(token) {
       }
     }
   };
-  
+
+  this.getUser = function(userId, callback) {
+    var request = createUserRequest(userId);
+    httpClient.get(request, function(error, response, body) {
+      var jsonBody = JSON.parse(body);
+      var user = jsonBody.user;
+      callback(user);
+    });
+  }
+
+  function createUserRequest(userId) {
+    return {
+      url: USER_ENDPOINT,
+      qs: {
+        token: token,
+        user: userId
+      }
+    }
+  };
+
 }

--- a/enews-node/slack.js
+++ b/enews-node/slack.js
@@ -1,0 +1,50 @@
+module.exports = Slack;
+
+function Slack(token) {
+  const HISTORY_ENDPOINT = 'https://slack.com/api/channels.history'
+  const MESSAGE_COUNT = 1000;
+
+  var httpClient = require('request');
+
+  this.getMessages = function getMessages(channel, oldest, latest, callback) {
+    var allMessages = [];
+    var handler = function(messages, hasMore, reducedLatest) {
+      allMessages = allMessages.concat(messages);
+      if (hasMore) {
+        var historyRequest = createHistoryRequest(channel, oldest, reducedLatest);
+        getSlackHistory(historyRequest, handler);
+      } else {
+        callback(allMessages);
+      }
+    }
+    var historyRequest = createHistoryRequest(channel, oldest, latest);
+    getSlackHistory(historyRequest, handler);
+  }
+
+  function getSlackHistory(request, callback) {
+    httpClient.get(request, function(error, response, body) {
+      var jsonBody = JSON.parse(body);
+      var messages = jsonBody.messages.filter(isValidMessage);
+      var reducedLatest = messages[messages.length - 1].ts;
+      callback(messages, jsonBody.has_more, reducedLatest);
+    });
+  }
+
+  function isValidMessage(message) {
+    return !message.bot_id && message.type == 'message'
+  }
+
+  function createHistoryRequest(channel, oldest, latest) {
+    return {
+      url: HISTORY_ENDPOINT,
+      qs: {
+        token: token,
+        channel: channel,
+        count: MESSAGE_COUNT,
+        oldest: oldest,
+        latest: latest
+      }
+    }
+  };
+  
+}


### PR DESCRIPTION
Problem -

Parsing enews was failing due to a slack room being created the same name, enews was being replaced with #C0YNBKANM

There was also some extra information that is useful to attach the the messages, such as the posters name and the news link, title and image.

Solution 

- Filter messages by including the slack room id
- linking message userIds to to Users to give us the message posters real name

```
{ 
  originalMessage: '<#C0YNBKANM|enews> A giant floating barrier might be the answer to cleaner     
  oceans \n<http://yahoonewsdigest-us.tumblr.com/146517763724>',
  title: 'A giant floating barrier might be the answer to cleaner oceans',
  link: 'http://yahoonewsdigest-us.tumblr.com/146517763724',
  poster: 'Wagner Truppel',
  imageUrl: 'https://msearch.zenfs.com/atomed/b26f4d10-3bb7-11e6-af21-6c3be5be5218.jpg'
}
```
