### PR TITLE
BuildProertiesPlugin: Fix maven coordinates

### DIFF
--- a/BuildPropertiesPlugin/build.gradle
+++ b/BuildPropertiesPlugin/build.gradle
@@ -1,7 +1,8 @@
 ext {
   isLocalDeploy = !project.hasProperty('maven')
-  pluginGroup = 'com.novoda.build-properties'
   pluginVersion = isLocalDeploy ? 'LOCAL' : '0.9.5'
+  pluginGroup = 'com.novoda'
+  pluginId = 'build-properties-plugin'
 }
 
 subprojects {

--- a/BuildPropertiesPlugin/build.gradle
+++ b/BuildPropertiesPlugin/build.gradle
@@ -1,7 +1,7 @@
 ext {
   isLocalDeploy = !project.hasProperty('maven')
-  pluginVersion = isLocalDeploy ? 'LOCAL' : '0.9.5'
   pluginGroup = 'com.novoda'
+  pluginVersion = isLocalDeploy ? 'LOCAL' : '0.9.6'
   pluginId = 'build-properties-plugin'
 }
 

--- a/BuildPropertiesPlugin/gradle/publish.gradle
+++ b/BuildPropertiesPlugin/gradle/publish.gradle
@@ -11,6 +11,9 @@ if (isLocalDeploy) {
     repositories {
       mavenDeployer {
         repository(url: localRepo.toURI())
+        pom.groupId = pluginGroup
+        pom.artifactId = pluginId
+        pom.version = pluginVersion
       }
     }
   }
@@ -19,7 +22,7 @@ if (isLocalDeploy) {
   publish {
     userOrg = 'novoda'
     groupId = pluginGroup
-    artifactId = 'build-properties'
+    artifactId = pluginId
     publishVersion = pluginVersion
     website = 'https://github.com/novoda/spikes/tree/master/BuildPropertiesPlugin'
   }

--- a/BuildPropertiesPlugin/plugin/src/integrationTest/groovy/com/novoda/buildproperties/SampleProjectTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/integrationTest/groovy/com/novoda/buildproperties/SampleProjectTest.groovy
@@ -86,7 +86,7 @@ public class SampleProjectTest {
       File localRepoDir = new File(rootDir, '.gradle/repo')
       assertThat(localRepoDir.absolutePath).endsWith('.gradle/repo')
 
-      File artifactDir = new File(localRepoDir, 'com/novoda/build-properties/plugin/LOCAL')
+      File artifactDir = new File(localRepoDir, 'com/novoda/build-properties-plugin/LOCAL')
       assertWithMessage('Run ./gradlew uploadArchives to deploy the plugin to the embedded local repo.\n')
               .that(artifactDir.exists()).isTrue()
 

--- a/BuildPropertiesPlugin/sample/app/build.gradle
+++ b/BuildPropertiesPlugin/sample/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:2.1.2'
-    classpath "com.novoda.build-properties:plugin:${pluginVersion}"
+    classpath "${pluginGroup}:${pluginId}:${pluginVersion}"
   }
 }
 


### PR DESCRIPTION
Version `0.9.5` of the `build-properties-plugin` has been released to Bintray with the wrong coordinates:
```
  <groupId>com.novoda.build-properties</groupId>
  <artifactId>build-properties</artifactId>
  <version>0.9.5</version>
```

We want to align our artifacts to always use `com.novoda` as groupId, removing the redundant artifactId from it. This leads to the deploy of version `0.9.6`. The new pom will look like:
```
  <groupId>com.novoda</groupId>
  <artifactId>build-properties-plugin</artifactId>
  <version>0.9.6</version>
```