### PR TITLE
Introducing a very lightweight Statistics screen.

### DIFF
--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/navigation/Navigator.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/navigation/Navigator.java
@@ -12,4 +12,6 @@ public interface Navigator {
 
     void toAddTask();
 
+    void toStatistics();
+
 }

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/data/model/Statistics.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/data/model/Statistics.java
@@ -1,0 +1,29 @@
+package com.novoda.todoapp.statistics.data.model;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class Statistics {
+
+    public static Builder builder() {
+        return new AutoValue_Statistics.Builder()
+                .activeTasks(0)
+                .completedTasks(0);
+    }
+
+    public abstract int activeTasks();
+
+    public abstract int completedTasks();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        public abstract Builder activeTasks(int activeTasks);
+
+        public abstract Builder completedTasks(int completedTasks);
+
+        public abstract Statistics build();
+
+    }
+
+}

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/data/model/Statistics.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/data/model/Statistics.java
@@ -15,6 +15,10 @@ public abstract class Statistics {
 
     public abstract int completedTasks();
 
+    public boolean noTasks() {
+        return activeTasks() == 0 && completedTasks() == 0;
+    }
+
     @AutoValue.Builder
     public abstract static class Builder {
 

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/displayer/StatisticsDisplayer.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/displayer/StatisticsDisplayer.java
@@ -1,0 +1,9 @@
+package com.novoda.todoapp.statistics.displayer;
+
+import com.novoda.todoapp.statistics.data.model.Statistics;
+
+public interface StatisticsDisplayer {
+
+    void display(Statistics statistics);
+
+}

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/presenter/StatisticsPresenter.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/presenter/StatisticsPresenter.java
@@ -1,0 +1,44 @@
+package com.novoda.todoapp.statistics.presenter;
+
+import com.novoda.event.DataObserver;
+import com.novoda.todoapp.statistics.data.model.Statistics;
+import com.novoda.todoapp.statistics.displayer.StatisticsDisplayer;
+import com.novoda.todoapp.statistics.service.StatisticsService;
+
+import rx.subscriptions.CompositeSubscription;
+
+import static com.novoda.event.EventFunctions.asData;
+
+public class StatisticsPresenter {
+
+    private final StatisticsService statisticsService;
+    private final StatisticsDisplayer statisticsDisplayer;
+
+    private CompositeSubscription subscriptions = new CompositeSubscription();
+
+    public StatisticsPresenter(StatisticsService statisticsService, StatisticsDisplayer statisticsDisplayer) {
+        this.statisticsService = statisticsService;
+        this.statisticsDisplayer = statisticsDisplayer;
+    }
+
+    public void startPresenting() {
+        subscriptions.add(
+                statisticsService.getStatisticsEvent()
+                        .compose(asData(Statistics.class))
+                        .subscribe(new StatisticsObserver())
+        );
+    }
+
+    public void stopPresenting() {
+        subscriptions.clear();
+        subscriptions = new CompositeSubscription();
+    }
+
+    private class StatisticsObserver extends DataObserver<Statistics> {
+        @Override
+        public void onNext(Statistics statistics) {
+            statisticsDisplayer.display(statistics);
+        }
+    }
+
+}

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/service/StatisticsService.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/service/StatisticsService.java
@@ -1,0 +1,12 @@
+package com.novoda.todoapp.statistics.service;
+
+import com.novoda.event.Event;
+import com.novoda.todoapp.statistics.data.model.Statistics;
+
+import rx.Observable;
+
+public interface StatisticsService {
+
+    public Observable<Event<Statistics>> getStatisticsEvent();
+
+}

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/service/TasksStatisticsService.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/statistics/service/TasksStatisticsService.java
@@ -1,0 +1,44 @@
+package com.novoda.todoapp.statistics.service;
+
+import com.google.common.base.Optional;
+import com.novoda.event.Event;
+import com.novoda.todoapp.statistics.data.model.Statistics;
+import com.novoda.todoapp.tasks.data.model.Tasks;
+import com.novoda.todoapp.tasks.service.TasksService;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+public class TasksStatisticsService implements StatisticsService {
+
+    private final TasksService tasksService;
+
+    public TasksStatisticsService(TasksService tasksService) {
+        this.tasksService = tasksService;
+    }
+
+    @Override
+    public Observable<Event<Statistics>> getStatisticsEvent() {
+        return tasksService.getTasksEvent().map(new Func1<Event<Tasks>, Event<Statistics>>() {
+            @Override
+            public Event<Statistics> call(Event<Tasks> tasksEvent) {
+                return Event.<Statistics>builder()
+                        .state(tasksEvent.state())
+                        .error(tasksEvent.error())
+                        .data(from(tasksEvent.data()))
+                        .build();
+            }
+        });
+    }
+
+    private Optional<Statistics> from(Optional<Tasks> data) {
+        Tasks tasks = data.or(Tasks.empty());
+        return Optional.of(
+                Statistics.builder()
+                        .activeTasks(tasks.onlyActives().size())
+                        .completedTasks(tasks.onlyCompleted().size())
+                        .build()
+        );
+    }
+
+}

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/displayer/TasksActionListener.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/displayer/TasksActionListener.java
@@ -16,6 +16,8 @@ public interface TasksActionListener {
 
     void onAddTaskSelected();
 
+    void onStatisticsSelected();
+
     enum Filter {
         ALL,
         ACTIVE,

--- a/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/presenter/TasksPresenter.java
+++ b/Architecture/TodoApp/android/core/src/main/java/com/novoda/todoapp/tasks/presenter/TasksPresenter.java
@@ -159,6 +159,11 @@ public class TasksPresenter {
         public void onAddTaskSelected() {
             navigator.toAddTask();
         }
+
+        @Override
+        public void onStatisticsSelected() {
+            navigator.toStatistics();
+        }
     };
 
     private final DataObserver<Tasks> tasksObserver = new DataObserver<Tasks>() {

--- a/Architecture/TodoApp/android/core/src/test/kotlin/com/novoda/todoapp/statistics/presenter/StatisticsPresenterTest.kt
+++ b/Architecture/TodoApp/android/core/src/test/kotlin/com/novoda/todoapp/statistics/presenter/StatisticsPresenterTest.kt
@@ -1,0 +1,153 @@
+package com.novoda.todoapp.statistics.presenter
+
+import com.novoda.event.Event
+import com.novoda.todoapp.statistics.data.model.Statistics
+import com.novoda.todoapp.statistics.displayer.StatisticsDisplayer
+import com.novoda.todoapp.statistics.service.StatisticsService
+import com.novoda.todoapp.tasks.service.SyncError
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.any
+import org.mockito.Mockito.never
+import rx.subjects.BehaviorSubject
+
+class StatisticsPresenterTest {
+
+    var statisticsEventSubject: BehaviorSubject<Event<Statistics>> = BehaviorSubject.create()
+
+    var service: StatisticsService = Mockito.mock(StatisticsService::class.java)
+
+    var displayer: StatisticsDisplayer = Mockito.mock(StatisticsDisplayer::class.java)
+
+    var presenter = StatisticsPresenter(service, displayer)
+
+    @Before
+    fun setUp() {
+        setUpService()
+        presenter = StatisticsPresenter(service, displayer)
+    }
+
+    @Test
+    fun given_ThePresenterIsPresenting_on_EmissionOfNewIdleEventWithStatistics_it_ShouldPresentTheStatisticsToTheView() {
+        givenThePresenterIsPresenting()
+
+        statisticsEventSubject.onNext(Event.idle<Statistics>().updateData(statistics()))
+
+        Mockito.verify(displayer).display(statistics())
+    }
+
+    @Test
+    fun given_ThePresenterIsPresenting_on_EmissionOfNewLoadingEventWithStatistics_it_ShouldPresentTheStatisticsToTheView() {
+        givenThePresenterIsPresenting()
+
+        statisticsEventSubject.onNext(Event.loading<Statistics>().updateData(statistics()))
+
+        Mockito.verify(displayer).display(statistics())
+    }
+
+    @Test
+    fun given_ThePresenterIsPresenting_on_EmissionOfNewErrorEventWithStatistics_it_ShouldPresentTheStatisticsToTheView() {
+        givenThePresenterIsPresenting()
+
+        statisticsEventSubject.onNext(Event.error<Statistics>(SyncError()).updateData(statistics()))
+
+        Mockito.verify(displayer).display(statistics())
+    }
+
+    @Test
+    fun given_ThePresenterIsPresenting_on_EmissionOfNewIdleEventWithNoStatistics_it_ShouldNotPresentAnyStatisticsToTheView() {
+        givenThePresenterIsPresenting()
+
+        statisticsEventSubject.onNext(Event.idle<Statistics>())
+
+        Mockito.verify(displayer, never()).display(any(Statistics::class.java))
+    }
+
+    @Test
+    fun given_ThePresenterIsPresenting_on_EmissionOfNewLoadingEventWithNoStatistics_it_ShouldNotPresentAnyStatisticsToTheView() {
+        givenThePresenterIsPresenting()
+
+        statisticsEventSubject.onNext(Event.loading<Statistics>())
+
+        Mockito.verify(displayer, never()).display(any(Statistics::class.java))
+    }
+
+    @Test
+    fun given_ThePresenterIsPresenting_on_EmissionOfNewErrorEventWithNoStatistics_it_ShouldNotPresentAnyStatisticsToTheView() {
+        givenThePresenterIsPresenting()
+
+        statisticsEventSubject.onNext(Event.error<Statistics>(SyncError()))
+
+        Mockito.verify(displayer, never()).display(any(Statistics::class.java))
+    }
+
+    @Test
+    fun given_ThePresenterIsNotPresenting_on_EmissionOfNewIdleEventWithStatistics_it_ShouldNotPresentAnythingToTheView() {
+        givenThePresenterIsNotPresenting()
+
+        statisticsEventSubject.onNext(Event.idle<Statistics>().updateData(statistics()))
+
+        Mockito.verifyNoMoreInteractions(displayer)
+    }
+
+    @Test
+    fun given_ThePresenterIsNotPresenting_on_EmissionOfNewLoadingEventWithStatistics_it_ShouldNotPresentAnythingToTheView() {
+        givenThePresenterIsNotPresenting()
+
+        statisticsEventSubject.onNext(Event.loading<Statistics>().updateData(statistics()))
+
+        Mockito.verifyNoMoreInteractions(displayer)
+    }
+
+    @Test
+    fun given_ThePresenterIsNotPresenting_on_EmissionOfNewErrorEventWithStatistics_it_ShouldNotPresentAnythingToTheView() {
+        givenThePresenterIsNotPresenting()
+
+        statisticsEventSubject.onNext(Event.error<Statistics>(SyncError()).updateData(statistics()))
+
+        Mockito.verifyNoMoreInteractions(displayer)
+    }
+
+    @Test
+    fun given_ThePresenterIsNotPresenting_on_EmissionOfNewIdleEventWithNoStatistics_it_ShouldNotPresentAnythingToTheView() {
+        givenThePresenterIsNotPresenting()
+
+        statisticsEventSubject.onNext(Event.idle<Statistics>())
+
+        Mockito.verifyNoMoreInteractions(displayer)
+    }
+
+    @Test
+    fun given_ThePresenterIsNotPresenting_on_EmissionOfNewLoadingEventWithNoStatistics_it_ShouldNotPresentAnythingToTheView() {
+        givenThePresenterIsNotPresenting()
+
+        statisticsEventSubject.onNext(Event.loading<Statistics>())
+
+        Mockito.verifyNoMoreInteractions(displayer)
+    }
+
+    @Test
+    fun given_ThePresenterIsNotPresenting_on_EmissionOfNewErrorEventWithNoStatistics_it_ShouldNotPresentAnythingToTheView() {
+        givenThePresenterIsNotPresenting()
+
+        statisticsEventSubject.onNext(Event.error<Statistics>(SyncError()))
+
+        Mockito.verifyNoMoreInteractions(displayer)
+    }
+
+    private fun givenThePresenterIsPresenting() {
+        presenter.startPresenting()
+    }
+
+    private fun givenThePresenterIsNotPresenting() {
+    }
+
+    private fun statistics() = Statistics.builder().activeTasks(1).completedTasks(3).build()
+
+    private fun setUpService() {
+        statisticsEventSubject = BehaviorSubject.create()
+        Mockito.`when`(service.getStatisticsEvent()).thenReturn(statisticsEventSubject)
+    }
+
+}

--- a/Architecture/TodoApp/android/core/src/test/kotlin/com/novoda/todoapp/statistics/service/TasksStatisticsServiceTest.kt
+++ b/Architecture/TodoApp/android/core/src/test/kotlin/com/novoda/todoapp/statistics/service/TasksStatisticsServiceTest.kt
@@ -1,0 +1,123 @@
+package com.novoda.todoapp.statistics.service
+
+import com.novoda.event.Event
+import com.novoda.todoapp.statistics.data.model.Statistics
+import com.novoda.todoapp.task.data.model.Id
+import com.novoda.todoapp.task.data.model.Task
+import com.novoda.todoapp.tasks.data.model.Tasks
+import com.novoda.todoapp.tasks.service.SyncError
+import com.novoda.todoapp.tasks.service.TasksService
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import rx.observers.TestObserver
+import rx.subjects.BehaviorSubject
+
+class TasksStatisticsServiceTest {
+
+    var tasksEventSubject: BehaviorSubject<Event<Tasks>> = BehaviorSubject.create()
+
+    var tasksService = Mockito.mock(TasksService::class.java)
+
+    var service: StatisticsService = TasksStatisticsService(tasksService)
+
+    @Before
+    fun setUp() {
+        setUpService()
+        service = TasksStatisticsService(tasksService)
+    }
+
+    @Test
+    fun given_TasksEventIsIdleAndEmpty_on_getStatisticsEvent_it_ShouldSendAnIdleEventWithEmptyStatistics() {
+        tasksEventSubject.onNext(Event.idle())
+        val testObserver = TestObserver<Event<Statistics>>()
+
+        service.getStatisticsEvent().subscribe(testObserver)
+
+        testObserver.assertReceivedOnNext(listOf(
+                Event.idle<Statistics>().updateData(emptyStatistics())
+        ))
+    }
+
+    @Test
+    fun given_TasksEventIsLoadingAndEmpty_on_getStatisticsEvent_it_ShouldSendALoadingEventWithEmptyStatistics() {
+        tasksEventSubject.onNext(Event.loading())
+        val testObserver = TestObserver<Event<Statistics>>()
+
+        service.getStatisticsEvent().subscribe(testObserver)
+
+        testObserver.assertReceivedOnNext(listOf(
+                Event.loading<Statistics>().updateData(emptyStatistics())
+        ))
+    }
+
+    @Test
+    fun given_TasksEventIsErrorAndEmpty_on_getStatisticsEvent_it_ShouldSendAnErrorEventWithEmptyStatistics() {
+        tasksEventSubject.onNext(Event.error(SyncError()))
+        val testObserver = TestObserver<Event<Statistics>>()
+
+        service.getStatisticsEvent().subscribe(testObserver)
+
+        testObserver.assertReceivedOnNext(listOf(
+                Event.error<Statistics>(SyncError()).updateData(emptyStatistics())
+        ))
+    }
+
+    @Test
+    fun given_TasksEventIsIdleAndHasTasks_on_getStatisticsEvent_it_ShouldSendAnIdleEventWithStatisticsMatchingTasks() {
+        tasksEventSubject.onNext(Event.idle<Tasks>().updateData(sampleSomeCompletedSomeActiveTasks()))
+        val testObserver = TestObserver<Event<Statistics>>()
+
+        service.getStatisticsEvent().subscribe(testObserver)
+
+        testObserver.assertReceivedOnNext(listOf(
+                Event.idle<Statistics>().updateData(sampleStatisticsSomeCompletedSomeActiveTasks())
+        ))
+    }
+
+    @Test
+    fun given_TasksEventIsLoadingAndHasTasks_on_getStatisticsEvent_it_ShouldSendALoadingEventWithStatisticsMatchingTasks() {
+        tasksEventSubject.onNext(Event.loading<Tasks>().updateData(sampleSomeCompletedSomeActiveTasks()))
+        val testObserver = TestObserver<Event<Statistics>>()
+
+        service.getStatisticsEvent().subscribe(testObserver)
+
+        testObserver.assertReceivedOnNext(listOf(
+                Event.loading<Statistics>().updateData(sampleStatisticsSomeCompletedSomeActiveTasks())
+        ))
+    }
+
+    @Test
+    fun given_TasksEventIsErrorAndHasTasks_on_getStatisticsEvent_it_ShouldSendAnErrorEventWithStatisticsMatchingTasks() {
+        tasksEventSubject.onNext(Event.error<Tasks>(SyncError()).updateData(sampleSomeCompletedSomeActiveTasks()))
+        val testObserver = TestObserver<Event<Statistics>>()
+
+        service.getStatisticsEvent().subscribe(testObserver)
+
+        testObserver.assertReceivedOnNext(listOf(
+                Event.error<Statistics>(SyncError()).updateData(sampleStatisticsSomeCompletedSomeActiveTasks())
+        ))
+    }
+
+    private fun setUpService() {
+        tasksEventSubject = BehaviorSubject.create()
+        val tasksEventReplay = tasksEventSubject.replay()
+        tasksEventReplay.connect()
+        Mockito.`when`(tasksService.getTasksEvent()).thenReturn(tasksEventReplay)
+    }
+
+    private fun emptyStatistics() = Statistics.builder().build()
+
+    private fun sampleStatisticsSomeCompletedSomeActiveTasks() = Statistics.builder()
+            .activeTasks(1)
+            .completedTasks(3)
+            .build()
+
+    private fun sampleSomeCompletedSomeActiveTasks() = Tasks.asSynced(listOf(
+            Task.builder().id(Id.from("24")).title("Bar").isCompleted(true).build(),
+            Task.builder().id(Id.from("42")).title("Foo").isCompleted(true).build(),
+            Task.builder().id(Id.from("12")).title("Whizz").build(),
+            Task.builder().id(Id.from("424")).title("New").isCompleted(true).build()
+    ), 123L)
+
+}

--- a/Architecture/TodoApp/android/core/src/test/kotlin/com/novoda/todoapp/statistics/service/TasksStatisticsServiceTest.kt
+++ b/Architecture/TodoApp/android/core/src/test/kotlin/com/novoda/todoapp/statistics/service/TasksStatisticsServiceTest.kt
@@ -65,37 +65,37 @@ class TasksStatisticsServiceTest {
 
     @Test
     fun given_TasksEventIsIdleAndHasTasks_on_getStatisticsEvent_it_ShouldSendAnIdleEventWithStatisticsMatchingTasks() {
-        tasksEventSubject.onNext(Event.idle<Tasks>().updateData(sampleSomeCompletedSomeActiveTasks()))
+        tasksEventSubject.onNext(Event.idle<Tasks>().updateData(tasksWithSomeActiveAndSomeCompleted()))
         val testObserver = TestObserver<Event<Statistics>>()
 
         service.getStatisticsEvent().subscribe(testObserver)
 
         testObserver.assertReceivedOnNext(listOf(
-                Event.idle<Statistics>().updateData(sampleStatisticsSomeCompletedSomeActiveTasks())
+                Event.idle<Statistics>().updateData(statisticsWithSomeActiveAndSomeCompletedTasks())
         ))
     }
 
     @Test
     fun given_TasksEventIsLoadingAndHasTasks_on_getStatisticsEvent_it_ShouldSendALoadingEventWithStatisticsMatchingTasks() {
-        tasksEventSubject.onNext(Event.loading<Tasks>().updateData(sampleSomeCompletedSomeActiveTasks()))
+        tasksEventSubject.onNext(Event.loading<Tasks>().updateData(tasksWithSomeActiveAndSomeCompleted()))
         val testObserver = TestObserver<Event<Statistics>>()
 
         service.getStatisticsEvent().subscribe(testObserver)
 
         testObserver.assertReceivedOnNext(listOf(
-                Event.loading<Statistics>().updateData(sampleStatisticsSomeCompletedSomeActiveTasks())
+                Event.loading<Statistics>().updateData(statisticsWithSomeActiveAndSomeCompletedTasks())
         ))
     }
 
     @Test
     fun given_TasksEventIsErrorAndHasTasks_on_getStatisticsEvent_it_ShouldSendAnErrorEventWithStatisticsMatchingTasks() {
-        tasksEventSubject.onNext(Event.error<Tasks>(SyncError()).updateData(sampleSomeCompletedSomeActiveTasks()))
+        tasksEventSubject.onNext(Event.error<Tasks>(SyncError()).updateData(tasksWithSomeActiveAndSomeCompleted()))
         val testObserver = TestObserver<Event<Statistics>>()
 
         service.getStatisticsEvent().subscribe(testObserver)
 
         testObserver.assertReceivedOnNext(listOf(
-                Event.error<Statistics>(SyncError()).updateData(sampleStatisticsSomeCompletedSomeActiveTasks())
+                Event.error<Statistics>(SyncError()).updateData(statisticsWithSomeActiveAndSomeCompletedTasks())
         ))
     }
 
@@ -108,12 +108,12 @@ class TasksStatisticsServiceTest {
 
     private fun emptyStatistics() = Statistics.builder().build()
 
-    private fun sampleStatisticsSomeCompletedSomeActiveTasks() = Statistics.builder()
+    private fun statisticsWithSomeActiveAndSomeCompletedTasks() = Statistics.builder()
             .activeTasks(1)
             .completedTasks(3)
             .build()
 
-    private fun sampleSomeCompletedSomeActiveTasks() = Tasks.asSynced(listOf(
+    private fun tasksWithSomeActiveAndSomeCompleted() = Tasks.asSynced(listOf(
             Task.builder().id(Id.from("24")).title("Bar").isCompleted(true).build(),
             Task.builder().id(Id.from("42")).title("Foo").isCompleted(true).build(),
             Task.builder().id(Id.from("12")).title("Whizz").build(),

--- a/Architecture/TodoApp/android/mobile/src/main/AndroidManifest.xml
+++ b/Architecture/TodoApp/android/mobile/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
     <activity
       android:name=".task.newtask.NewTaskActivity"
       android:windowSoftInputMode="adjustResize" />
+    <activity
+      android:name=".statistics.StatisticsActivity" />
 
 
   </application>

--- a/Architecture/TodoApp/android/mobile/src/main/AndroidManifest.xml
+++ b/Architecture/TodoApp/android/mobile/src/main/AndroidManifest.xml
@@ -29,7 +29,6 @@
     <activity
       android:name=".statistics.StatisticsActivity" />
 
-
   </application>
 
 </manifest>

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/TodoApplication.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/TodoApplication.java
@@ -2,6 +2,8 @@ package com.novoda.todoapp;
 
 import android.app.Application;
 
+import com.novoda.todoapp.statistics.service.StatisticsService;
+import com.novoda.todoapp.statistics.service.TasksStatisticsService;
 import com.novoda.todoapp.tasks.data.AlwaysOutOfDateTasksFreshnessChecker;
 import com.novoda.todoapp.tasks.data.source.InMemoryLocalTaskDataSource;
 import com.novoda.todoapp.tasks.data.source.InMemoryRemoteTaskDataSource;
@@ -21,5 +23,8 @@ public class TodoApplication extends Application {
                     new Clock()
             )
     );
+
+    //TODO use proper dependency injection
+    public static final StatisticsService STATISTICS_SERVICE = new TasksStatisticsService(TASKS_SERVICE);
 
 }

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/navigation/AndroidNavigator.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/navigation/AndroidNavigator.java
@@ -3,6 +3,7 @@ package com.novoda.todoapp.navigation;
 import android.app.Activity;
 import android.content.Intent;
 
+import com.novoda.todoapp.statistics.StatisticsActivity;
 import com.novoda.todoapp.task.TaskDetailActivity;
 import com.novoda.todoapp.task.data.model.Task;
 import com.novoda.todoapp.task.edit.EditTaskActivity;
@@ -40,6 +41,12 @@ public class AndroidNavigator implements Navigator {
     @Override
     public void toAddTask() {
         Intent intent = new Intent(activity, NewTaskActivity.class);
+        activity.startActivity(intent);
+    }
+
+    @Override
+    public void toStatistics() {
+        Intent intent = new Intent(activity, StatisticsActivity.class);
         activity.startActivity(intent);
     }
 

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/StatisticsActivity.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/StatisticsActivity.java
@@ -1,0 +1,37 @@
+package com.novoda.todoapp.statistics;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.novoda.todoapp.R;
+import com.novoda.todoapp.TodoApplication;
+import com.novoda.todoapp.statistics.displayer.StatisticsDisplayer;
+import com.novoda.todoapp.statistics.presenter.StatisticsPresenter;
+
+public class StatisticsActivity extends AppCompatActivity {
+
+    private StatisticsPresenter taskPresenter;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.statistics_activity);
+        taskPresenter = new StatisticsPresenter(
+                TodoApplication.STATISTICS_SERVICE,
+                ((StatisticsDisplayer) findViewById(R.id.content))
+        );
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        taskPresenter.startPresenting();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        taskPresenter.stopPresenting();
+    }
+
+}

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/view/StatisticsView.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/view/StatisticsView.java
@@ -29,15 +29,21 @@ public class StatisticsView extends LinearLayout implements StatisticsDisplayer 
         statisticsLabel = Views.findById(this, R.id.statistics_label);
         TodoAppBar todoAppBar = Views.findById(this, R.id.app_bar);
         Toolbar toolbar = todoAppBar.getToolbar();
-        toolbar.setTitle("Statistics");
+        toolbar.setTitle(R.string.statistics);
     }
 
     @Override
     public void display(Statistics statistics) {
         if (statistics.noTasks()) {
-            statisticsLabel.setText("No Tasks");
+            statisticsLabel.setText(R.string.you_have_no_tasks);
         } else {
-            statisticsLabel.setText("Active tasks: " + statistics.activeTasks() + "\nCompleted tasks: " + statistics.completedTasks());
+            statisticsLabel.setText(
+                    getContext().getString(
+                            R.string.active_completed_tasks_statistics,
+                            statistics.activeTasks(),
+                            statistics.completedTasks()
+                    )
+            );
         }
     }
 

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/view/StatisticsView.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/view/StatisticsView.java
@@ -1,0 +1,25 @@
+package com.novoda.todoapp.statistics.view;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+import com.novoda.todoapp.statistics.data.model.Statistics;
+import com.novoda.todoapp.statistics.displayer.StatisticsDisplayer;
+
+public class StatisticsView extends TextView implements StatisticsDisplayer {
+
+    public StatisticsView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public void display(Statistics statistics) {
+        if (statistics.noTasks()) {
+            setText("No Tasks");
+        } else {
+            setText("Active tasks: " + statistics.activeTasks() + "\nCompleted tasks: " + statistics.completedTasks());
+        }
+    }
+
+}

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/view/StatisticsView.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/statistics/view/StatisticsView.java
@@ -1,24 +1,43 @@
 package com.novoda.todoapp.statistics.view;
 
 import android.content.Context;
+import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
+import android.view.View;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.novoda.notils.caster.Views;
+import com.novoda.todoapp.R;
 import com.novoda.todoapp.statistics.data.model.Statistics;
 import com.novoda.todoapp.statistics.displayer.StatisticsDisplayer;
+import com.novoda.todoapp.views.TodoAppBar;
 
-public class StatisticsView extends TextView implements StatisticsDisplayer {
+public class StatisticsView extends LinearLayout implements StatisticsDisplayer {
+
+    private TextView statisticsLabel;
 
     public StatisticsView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setOrientation(VERTICAL);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        View.inflate(getContext(), R.layout.merge_statistics_view, this);
+        statisticsLabel = Views.findById(this, R.id.statistics_label);
+        TodoAppBar todoAppBar = Views.findById(this, R.id.app_bar);
+        Toolbar toolbar = todoAppBar.getToolbar();
+        toolbar.setTitle("Statistics");
     }
 
     @Override
     public void display(Statistics statistics) {
         if (statistics.noTasks()) {
-            setText("No Tasks");
+            statisticsLabel.setText("No Tasks");
         } else {
-            setText("Active tasks: " + statistics.activeTasks() + "\nCompleted tasks: " + statistics.completedTasks());
+            statisticsLabel.setText("Active tasks: " + statistics.activeTasks() + "\nCompleted tasks: " + statistics.completedTasks());
         }
     }
 

--- a/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/tasks/view/TasksView.java
+++ b/Architecture/TodoApp/android/mobile/src/main/java/com/novoda/todoapp/tasks/view/TasksView.java
@@ -90,8 +90,12 @@ public class TasksView extends CoordinatorLayout implements TasksDisplayer {
                 case R.id.menu_clear:
                     tasksActionListener.onClearCompletedSelected();
                     return true;
+                case R.id.menu_stats:
+                    tasksActionListener.onStatisticsSelected();
+                    return true;
+                default:
+                    return false;
             }
-            return false;
         }
     }
 

--- a/Architecture/TodoApp/android/mobile/src/main/res/layout/merge_statistics_view.xml
+++ b/Architecture/TodoApp/android/mobile/src/main/res/layout/merge_statistics_view.xml
@@ -10,6 +10,7 @@
     android:id="@+id/statistics_label"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="16dp"/>
+    android:padding="@dimen/activity_horizontal_margin"
+    android:textAppearance="?android:attr/textAppearanceMedium" />
 
 </merge>

--- a/Architecture/TodoApp/android/mobile/src/main/res/layout/merge_statistics_view.xml
+++ b/Architecture/TodoApp/android/mobile/src/main/res/layout/merge_statistics_view.xml
@@ -1,0 +1,15 @@
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <com.novoda.todoapp.views.TodoAppBar
+    android:id="@+id/app_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+
+  <TextView
+    android:id="@+id/statistics_label"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"/>
+
+</merge>

--- a/Architecture/TodoApp/android/mobile/src/main/res/layout/statistics_activity.xml
+++ b/Architecture/TodoApp/android/mobile/src/main/res/layout/statistics_activity.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.novoda.todoapp.statistics.view.StatisticsView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/content"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent" />

--- a/Architecture/TodoApp/android/mobile/src/main/res/menu/tasks_menu.xml
+++ b/Architecture/TodoApp/android/mobile/src/main/res/menu/tasks_menu.xml
@@ -18,4 +18,9 @@
     android:title="@string/refresh"
     app:showAsAction="never" />
 
+  <item
+    android:id="@+id/menu_stats"
+    android:title="Statistics"
+    app:showAsAction="never" />
+
 </menu>

--- a/Architecture/TodoApp/android/mobile/src/main/res/values/strings.xml
+++ b/Architecture/TodoApp/android/mobile/src/main/res/values/strings.xml
@@ -19,4 +19,7 @@
   <string name="to_do_novoda">TO-DO-NOVODA</string>
   <string name="edit_to_do">Edit TO-DO</string>
   <string name="new_to_do">New TO-DO</string>
+  <string name="statistics">Statistics</string>
+  <string name="you_have_no_tasks">You have no tasks</string>
+  <string name="active_completed_tasks_statistics">Active tasks: %1$d\nCompleted tasks: %2$d</string>
 </resources>


### PR DESCRIPTION
In our quest to get all features from the Google sample into this app, here is the statistics screen.

We access it through the overflow menu at the moment. The nav drawer can be implemented as a separate PR.

##### Screenshots
| Desired | After |
| ----- | ----- |
|![device-2016-07-07-114130](https://cloud.githubusercontent.com/assets/610924/16655649/3a3aabb0-4453-11e6-8c82-45f279fd8771.png)|![device-2016-07-07-150146](https://cloud.githubusercontent.com/assets/610924/16655746/c45cb950-4453-11e6-85c9-2086a108b78b.png)|
|![device-2016-07-07-114632](https://cloud.githubusercontent.com/assets/610924/16655657/4ca9cd1c-4453-11e6-8300-8671e6f39156.png)|![device-2016-07-07-150120](https://cloud.githubusercontent.com/assets/610924/16655763/d4a0b0c8-4453-11e6-8954-bc63e21c7ef3.png)|



