### PR TITLE
BuildPropertiesPlugin: Introduce recursive include support for properties

### DIFF
--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/FilePropertiesEntries.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/FilePropertiesEntries.groovy
@@ -5,31 +5,47 @@ class FilePropertiesEntries extends BuildProperties.Entries {
   private final String name
   private final File file
   private final Properties props
+  private final FilePropertiesEntries defaults
+  private final Set<String> keys
 
   static FilePropertiesEntries create(String name = null, File file) {
     Properties props = new Properties()
     props.load(new FileInputStream(file))
-    new FilePropertiesEntries(name ?: file.name, file, props)
+
+    FilePropertiesEntries defaults = null
+    String include = props['include']
+    if (include != null) {
+      defaults = create(new File(file.parentFile, include))
+    }
+    new FilePropertiesEntries(name ?: file.name, file, props, defaults)
   }
 
-  private FilePropertiesEntries(String name, File file, Properties props) {
+  private FilePropertiesEntries(String name, File file, Properties props, FilePropertiesEntries defaults = null) {
     this.name = name
     this.file = file
     this.props = props
+    this.defaults = defaults
+    this.keys = new HashSet<>(props.stringPropertyNames())
+    if (defaults != null) {
+      this.keys.addAll(defaults.keys)
+    }
   }
 
   @Override
   boolean contains(String key) {
-    props[key] != null
+    props[key] != null || defaults?.contains(key)
   }
 
   @Override
   protected Object getValueAt(String key) {
     Object value = props[key]
-    if (value == null) {
-      throw new IllegalArgumentException("No value defined for property '$key' in '$name' properties ($file.absolutePath)")
+    if (value != null) {
+      return value
     }
-    return value
+    if (defaults?.contains(key)) {
+      return defaults.getValueAt(key)
+    }
+    throw new IllegalArgumentException("No value defined for property '$key' in '$name' properties ($file.absolutePath)")
   }
 
   @Override
@@ -39,7 +55,7 @@ class FilePropertiesEntries extends BuildProperties.Entries {
 
   @Override
   Enumeration<String> getKeys() {
-    Collections.enumeration(props.stringPropertyNames())
+    Collections.enumeration(keys)
   }
 
 }

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/FilePropertiesEntriesTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/FilePropertiesEntriesTest.groovy
@@ -97,4 +97,17 @@ public class FilePropertiesEntriesTest {
     assertThat(Collections.list(entries.keys)).containsExactly('aProperty', 'another_PROPERTY', 'api.key', 'negative', 'positive', 'int', 'double', 'string')
   }
 
+  @Test
+  public void shouldRecursivelyIncludePropertiesFromSpecifiedFilesWhenIncludeProvided() {
+    def moreEntries = FilePropertiesEntries.create(new File(Resources.getResource('more.properties').toURI()))
+    def includingEntries = FilePropertiesEntries.create(new File(Resources.getResource('including.properties').toURI()))
+
+    entries.keys.each { String key ->
+      assertThat(moreEntries[key].value).isEqualTo(entries[key].value)
+    }
+    assertThat(moreEntries['foo'].value).isEqualTo(includingEntries['foo'].value)
+    assertThat(moreEntries['a'].value).isEqualTo('android')
+    assertThat(includingEntries['a'].value).isEqualTo('apple')
+  }
+
 }

--- a/BuildPropertiesPlugin/plugin/src/test/resources/including.properties
+++ b/BuildPropertiesPlugin/plugin/src/test/resources/including.properties
@@ -1,0 +1,3 @@
+include=any.properties
+foo=bar
+a=apple

--- a/BuildPropertiesPlugin/plugin/src/test/resources/more.properties
+++ b/BuildPropertiesPlugin/plugin/src/test/resources/more.properties
@@ -1,0 +1,2 @@
+include=including.properties
+a=android


### PR DESCRIPTION
We found useful to have properties files that can recursively include other properties files specified in a `include` property. This can help composing set of properties in a hierarchical way allowing to define cohesive sets of properties and helping reusing them. Inherited properties can be overridden by the including set, just redefine the property in the file and its value will be used instead of the one from the included set.