### PR TITLE
BuildPropertiesPlugin: Prepare v1.0.1

### DIFF
--- a/BuildPropertiesPlugin/CHANGELOG.md
+++ b/BuildPropertiesPlugin/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.0.1 *(16/07/2016)*
+----------------------------
+
+Added possibility to specify error message when properties file not found.
+
+
 Version 1.0.0 *(16/07/2016)*
 ----------------------------
 

--- a/BuildPropertiesPlugin/README.md
+++ b/BuildPropertiesPlugin/README.md
@@ -1,6 +1,9 @@
 # Android build properties plugin
 
-Sometimes it's necessary to retrieve some information from a properties file that is not checked in as part of your repo for security reasons (keys, credentials, passwords, etc). Such properties need to end up in your application `BuildConfig` or in some resource file.
+Sometimes it's necessary to retrieve some information from a properties 
+file that is not checked in as part of your repo for security reasons 
+(keys, credentials, passwords, etc). Such properties need to end up in 
+your application `BuildConfig` or in some resource file.
 
 This plugin aims to provide a simple way to:
 - define handles to properties file in your build script (à la `signingConfig`)
@@ -11,7 +14,8 @@ This plugin aims to provide a simple way to:
 
 ## How To Use
 
-The plugin is deployed to Bintray's JCenter. Ensure it's correctly defined as dependency for your build script:
+The plugin is deployed to Bintray's JCenter. Ensure it's correctly defined
+as dependency for your build script:
 
 ```
 buildscript {
@@ -19,7 +23,7 @@ buildscript {
     jcenter()
    }
   dependencies {
-    classpath 'com.novoda:gradle-build-properties-plugin:1.0.0'
+    classpath 'com.novoda:gradle-build-properties-plugin:1.0.1'
   }
 }
 ```
@@ -27,8 +31,8 @@ Then apply the plugin in your buildscript **after the android plugin** via:
 ```
 apply plugin: 'com.novoda.build-properties'
 ```
-Add a `buildProperties` configuration to your android buildscript listing all the properties files you intend
-to reference in your `android` configuration:
+Add a `buildProperties` configuration to your android buildscript listing
+all the properties files you intend to reference in your `android` configuration:
 ```
 buildProperties {
     secrets {
@@ -40,12 +44,14 @@ android {
     ...
 }
 ```
-where `secrets.properties` is a properties file that can now be referenced in the buildscript as `buildProperties.secrets`.   
+where `secrets.properties` is a properties file that can now be referenced
+in the buildscript as `buildProperties.secrets`.   
 
 ## Features
 
 #### 1. Store whole properties file in `BuildConfig`
-In any product flavor configuration (or `defaultConfig`) you can use `buildConfigProperties` as follows:
+In any product flavor configuration (or `defaultConfig`) you can use
+`buildConfigProperties` as follows:
 
 ```
     defaultConfig {
@@ -54,17 +60,21 @@ In any product flavor configuration (or `defaultConfig`) you can use `buildConfi
         ...
     }
 ```
-All the entries in that properties files are converted to string fields in your `BuildConfig`. Names of the fields are
-created formatting the key of each entry to follow the standard constant field naming in Java (uppercase with underscores), eg:
+All the entries in that properties files are converted to string fields
+in your `BuildConfig`. Names of the fields are created formatting the key
+of each entry to follow the standard constant field naming in Java
+(uppercase with underscores), eg:
 
 - `apiKey` -> `API_KEY`
 - `api_key` -> `API_KEY`
 - `api.key` -> `API_KEY`
 
-Note that properties files treat values as strings, therefore only string fields are generated in this case.
+Note that properties files treat values as strings, therefore only string
+fields are generated in this case.
 
 #### 2. Store a property value into your `BuildConfig`
-In any product flavor configuration (or `defaultConfig`) you can use `buildConfigProperty` as follows:
+In any product flavor configuration (or `defaultConfig`) you can use
+`buildConfigProperty` as follows:
 ```
     defaultConfig {
         ...
@@ -72,10 +82,12 @@ In any product flavor configuration (or `defaultConfig`) you can use `buildConfi
         ...
     }
 ```
-You can omit the field name and let the plugin generate one for you (following the same rules at 1.)
+You can omit the field name and let the plugin generate one for you
+(following the same rules at 1.)
 
 #### 3. Store whole properties file as generated string resources
-In any product flavor configuration (or `defaultConfig`) you can use `resValueProperties` as follows:
+In any product flavor configuration (or `defaultConfig`) you can use
+`resValueProperties` as follows:
 
 ```
     defaultConfig {
@@ -84,11 +96,13 @@ In any product flavor configuration (or `defaultConfig`) you can use `resValuePr
         ...
     }
 ```
-All the entries in that properties files are converted to string resources, named after their key, enforcing snake casing over camel casing if necessary.
+All the entries in that properties files are converted to string resources,
+named after their key, enforcing snake casing over camel casing if necessary.
 
 
 #### 4. Store a property value as generated string resource
-In any product flavor configuration (or `defaultConfig`) you can use `resValueProperty` as follows:
+In any product flavor configuration (or `defaultConfig`) you can use
+`resValueProperty` as follows:
 
 ```
     defaultConfig {
@@ -97,11 +111,13 @@ In any product flavor configuration (or `defaultConfig`) you can use `resValuePr
         ...
     }
 ```
-You can omit the name of the resource and let the plugin generate one for you from the property key, enforcing snake casing over camel casing if necessary.
+You can omit the name of the resource and let the plugin generate one for
+you from the property key, enforcing snake casing over camel casing if necessary.
 
 
 #### 5. Load signing configuration from properties
-Instead of inline your passwords and other details in your build script you can fill the signing configuration using a properties file.
+Instead of inline your passwords and other details in your build script
+you can fill the signing configuration using a properties file.
 ```
 signingConfigs {
   release {
@@ -109,14 +125,15 @@ signingConfigs {
   }
 }
 ```
-The plugin will automatically retrieve all the needed fields from the properties file.
-Note: the path of the keystore file is considered relative to the path of the specified properties file.
+The plugin will automatically retrieve all the needed fields from the
+properties file. Note: the path of the keystore file is considered relative
+to the path of the specified properties file.
 
 ## Bonus
 
 #### Typed `buildConfigField`/`resValue`
-The plugin enhances the `buildConfigField` and `resValue` facilities to enforce types.
-To generate a string field in your `BuildConfig` you used to write:
+The plugin enhances the `buildConfigField` and `resValue` facilities to
+enforce types. To generate a string field in your `BuildConfig` you used to write:
 ```
 buildConfigField 'String', 'LOL', '\"sometimes the picture take\"'
 ```
@@ -138,14 +155,21 @@ The full list of new typed facilities is as follows:
 |`resValueString` | `resValueString 'debug_test_string', 'dunno bro...'`|
 
 #### Override properties at build time
-A property from any file listed in `buildProperties` can be overridden at build time specifying a new value as project property (ie: `-PapiKey=newValue`).
+A property from any file listed in `buildProperties` can be overridden at
+build time specifying a new value as project property (ie: `-PapiKey=newValue`).
 
 #### Properties inheritance
-It might be useful to have properties files that can recursively include another properties files (specified via an `include` property). Inherited properties can be overridden by the including set, just redefine the property in the file and its value will be used instead of the one from the included set.
+It might be useful to have properties files that can recursively include
+another properties files (specified via an `include` property).
+Inherited properties can be overridden by the including set, just redefine
+the property in the file and its value will be used instead of the one
+from the included set.
  
 
-#### More on load properties
-Properties files are lazy-loaded when accessing some of their properties for the first time in the build script. Given a `BuildProperties` instance one of its entries can be retrieved using the `getAt` operator:
+#### More on loading properties
+If the specified file is not found an exception is thrown at build time.
+You can specify a custom error message to provide the user with more information.
+Given a `BuildProperties` instance one of its entries can be retrieved using the `getAt` operator:
 
 `BuildProperty.Entry entry = buildProperties.secrets['aProperty']`
 
@@ -156,8 +180,10 @@ The value of an entry can be retrieved via one of the following typed accessors:
 - `entry.getDouble()`, or `entry.double`
 - `entry.getString()`, or `entry.string`
 
-If you want to access the raw value (`Object`) you can also use `entry.getValue()`/`entry.value`. Is important to note that values are lazily accessed too (via the internal closure provided in `Entry`).
-Trying to access the value of a specific property could generate an exception if the key is missing in the provided properties file, eg:
+If you want to access the raw value (`Object`) you can also use `entry.getValue()`/`entry.value`.
+Is important to note that values are lazily accessed too (via the internal closure provided in `Entry`).
+Trying to access the value of a specific property could generate an exception
+if the key is missing in the provided properties file, eg:
 ```
 FAILURE: Build failed with an exception.
 

--- a/BuildPropertiesPlugin/build.gradle
+++ b/BuildPropertiesPlugin/build.gradle
@@ -1,5 +1,5 @@
 ext {
   pluginGroup = 'com.novoda'
-  pluginVersion = '1.0.0'
+  pluginVersion = '1.0.1'
   pluginId = 'build-properties-plugin'
 }

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -30,18 +30,18 @@ class BuildProperties {
   }
 
   File getParentFile() {
-    entries.call().parentFile
+    entries.parentFile
   }
 
   Enumeration<String> getKeys() {
-    entries.call().keys
+    entries.keys
   }
 
   Entry getAt(String key) {
     if (project.hasProperty(key)) {
       new Entry(key, { project[key] })
     } else {
-      entries.call().getAt(key)
+      entries.getAt(key)
     }
   }
 

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -1,5 +1,6 @@
 package com.novoda.buildproperties
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 
 class BuildProperties {
@@ -17,7 +18,10 @@ class BuildProperties {
     name
   }
 
-  void file(File file) {
+  void file(File file, String errorMessage = null) {
+    if (!file.exists()) {
+      throw new GradleException("File $file.name does not exist.${errorMessage ? "\n$errorMessage" : ''}")
+    }
     entries(FilePropertiesEntries.create(name, file))
   }
 

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -7,7 +7,7 @@ class BuildProperties {
 
   private final String name
   private final Project project
-  private Closure<Entries> entries
+  private Entries entries
 
   BuildProperties(String name, Project project) {
     this.name = name
@@ -26,9 +26,7 @@ class BuildProperties {
   }
 
   void entries(Entries entries) {
-    this.entries = {
-      entries
-    }.memoize()
+    this.entries = entries
   }
 
   File getParentFile() {

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/BuildScriptTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/BuildScriptTest.groovy
@@ -53,4 +53,41 @@ public class BuildScriptTest {
     assertThat(project.plugins.hasPlugin(BuildPropertiesPlugin)).isTrue()
   }
 
+  @Test
+  public void shouldFailBuildWhenPropertiesFileDoesNotExist() {
+    project.apply plugin: 'com.android.library'
+    project.apply plugin: BuildPropertiesPlugin
+
+    try {
+      project.buildProperties {
+        foo {
+          file project.file('foo.properties')
+        }
+      }
+      fail('Gradle exception not thrown')
+    } catch (GradleException e) {
+      assertThat(e.getMessage()).endsWith('foo.properties does not exist.')
+    }
+  }
+
+  @Test
+  public void shouldProvideErrorMessageWhenPropertiesFileDoesNotExist() {
+    project.apply plugin: 'com.android.library'
+    project.apply plugin: BuildPropertiesPlugin
+
+    def errorMessage = 'This file should contain the following properties:\n- foo\n- bar'
+    try {
+      project.buildProperties {
+        foo {
+          file project.file('foo.properties'), errorMessage
+        }
+      }
+      fail('Gradle exception not thrown')
+    } catch (GradleException e) {
+      String message = e.getMessage()
+      assertThat(message).contains('foo.properties does not exist.')
+      assertThat(message).endsWith(errorMessage)
+    }
+  }
+
 }


### PR DESCRIPTION
- Added possibility to provide custom error message when specified properties file not found.
- Fixed README to remove mention of lazy-loading of files because inaccurate.