### PR TITLE
BuildPropertiesPlugin: Introduce fallback support

### DIFF
--- a/BuildPropertiesPlugin/README.md
+++ b/BuildPropertiesPlugin/README.md
@@ -121,6 +121,17 @@ value for a given `Entry` via the `or()` operator, defined as:
 |a `Closure` | `buildProperties.secrets['notThere'].or({ Math.random() })` |
 |a value | `buildProperties.secrets['notThere'].or('fallback')` |
 
+If the whole fallback chain evaluation fails a `CompositeException` is thrown listing all
+the causes in the chain, eg:
+
+```java
+A problem occurred while evaluating entry:
+- exception message 1
+- exception message 2
+- exception message 3
+
+```
+
 #### Override properties at build time
 A property from any file listed in `buildProperties` can be overridden at
 build time specifying a new value as project property (ie: `-PapiKey=newValue`).

--- a/BuildPropertiesPlugin/README.md
+++ b/BuildPropertiesPlugin/README.md
@@ -111,6 +111,16 @@ The full list of new typed facilities is as follows:
 |`resValueBoolean` | `resValueBoolean 'debug_test_bool', true`|
 |`resValueString` | `resValueString 'debug_test_string', 'dunno bro...'`|
 
+#### Fallback support
+If a property cannot be found an exception is thrown. It's possible to provide a fallback
+value for a given `Entry` via the `or()` operator, defined as:
+
+| | Example |
+|----|----|
+|another `Entry` | `buildProperties.secrets['notThere'].or(buildProperties.secrets['fallback'])` |
+|a `Closure` | `buildProperties.secrets['notThere'].or({ Math.random() })` |
+|a value | `buildProperties.secrets['notThere'].or('fallback')` |
+
 #### Override properties at build time
 A property from any file listed in `buildProperties` can be overridden at
 build time specifying a new value as project property (ie: `-PapiKey=newValue`).
@@ -128,7 +138,7 @@ If the specified file is not found an exception is thrown at build time.
 You can specify a custom error message to provide the user with more information.
 Given a `BuildProperties` instance one of its entries can be retrieved using the `getAt` operator:
 
-`BuildProperty.Entry entry = buildProperties.secrets['aProperty']`
+`Entry entry = buildProperties.secrets['aProperty']`
 
 The value of an entry can be retrieved via one of the following typed accessors:
 

--- a/BuildPropertiesPlugin/plugin/build.gradle
+++ b/BuildPropertiesPlugin/plugin/build.gradle
@@ -24,6 +24,8 @@ dependencies {
   testCompile 'com.google.guava:guava:19.0'
   testCompile 'com.google.truth:truth:0.28'
   testCompile 'com.android.tools.build:gradle:2.1.2'
+  testCompile 'com.google.code.findbugs:jsr305:3.0.0'
+
 }
 
 // https://code.google.com/p/android/issues/detail?id=64887

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/CompositeException.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/CompositeException.groovy
@@ -1,0 +1,34 @@
+package com.novoda.buildproperties
+
+class CompositeException extends Exception {
+
+    public static final CompositeException EMPTY = new CompositeException(Collections.emptyList())
+
+    private final List<Throwable> exceptions
+
+    static CompositeException from(Throwable throwable) {
+        return EMPTY.add(throwable)
+    }
+
+    private CompositeException(List<Throwable> exceptions) {
+        this.exceptions = Collections.unmodifiableList(exceptions)
+    }
+
+    CompositeException add(Throwable throwable) {
+        List<Throwable> newExceptions = new ArrayList<>(exceptions)
+        if (throwable instanceof CompositeException) {
+            newExceptions.addAll(((CompositeException) throwable).exceptions)
+        } else {
+            newExceptions.add(throwable)
+        }
+        return new CompositeException(newExceptions)
+    }
+
+    @Override
+    String getMessage() {
+        return exceptions
+                .collect { it.message }
+                .inject('A problem occurred while evaluating entry:', { acc, val -> acc + "\n- $val" })
+    }
+
+}

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/CompositeException.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/CompositeException.groovy
@@ -24,6 +24,10 @@ class CompositeException extends Exception {
         return new CompositeException(newExceptions)
     }
 
+    List<Throwable> getExceptions() {
+        exceptions
+    }
+
     @Override
     String getMessage() {
         return exceptions

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
@@ -34,4 +34,29 @@ class Entry {
         value.call()
     }
 
+    Entry or(def fallback) {
+        def other = from(fallback)
+        new Entry(key, {
+            try {
+                return getValue()
+            } catch (Throwable e) {
+                try {
+                    return other.call()
+                } catch (Throwable e2) {
+                    throw CompositeException.from(e).add(e2)
+                }
+            }
+        })
+    }
+
+    private static def from(def fallback) {
+        if (fallback instanceof Entry) {
+            return { (fallback as Entry).getValue() }
+        }
+        if (fallback instanceof Closure) {
+            return fallback
+        }
+        return { fallback }
+    }
+
 }

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionSubject.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionSubject.groovy
@@ -9,13 +9,13 @@ import javax.annotation.Nullable
 
 final class CompositeExceptionSubject extends Subject<CompositeExceptionSubject, CompositeException> {
 
-    private static
-    final SubjectFactory<CompositeExceptionSubject, CompositeException> FACTORY = new SubjectFactory<CompositeExceptionSubject, CompositeException>() {
-        @Override
-        CompositeExceptionSubject getSubject(FailureStrategy fs, CompositeException that) {
-            new CompositeExceptionSubject(fs, that)
-        }
-    }
+    private static final SubjectFactory<CompositeExceptionSubject, CompositeException> FACTORY =
+            new SubjectFactory<CompositeExceptionSubject, CompositeException>() {
+                @Override
+                CompositeExceptionSubject getSubject(FailureStrategy fs, CompositeException that) {
+                    new CompositeExceptionSubject(fs, that)
+                }
+            }
 
     public static CompositeExceptionSubject assertThat(CompositeException compositeException) {
         Truth.assertAbout(FACTORY).that(compositeException)
@@ -24,10 +24,6 @@ final class CompositeExceptionSubject extends Subject<CompositeExceptionSubject,
     private CompositeExceptionSubject(FailureStrategy failureStrategy,
                                       @Nullable CompositeException subject) {
         super(failureStrategy, subject)
-    }
-
-    public void contains(Throwable... throwables) {
-        Truth.assertThat(subject.exceptions).containsExactly(throwables)
     }
 
     public void hasMessage(String... messages) {

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionSubject.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionSubject.groovy
@@ -1,0 +1,37 @@
+package com.novoda.buildproperties
+
+import com.google.common.truth.FailureStrategy
+import com.google.common.truth.Subject
+import com.google.common.truth.SubjectFactory
+import com.google.common.truth.Truth
+
+import javax.annotation.Nullable
+
+final class CompositeExceptionSubject extends Subject<CompositeExceptionSubject, CompositeException> {
+
+    private static
+    final SubjectFactory<CompositeExceptionSubject, CompositeException> FACTORY = new SubjectFactory<CompositeExceptionSubject, CompositeException>() {
+        @Override
+        CompositeExceptionSubject getSubject(FailureStrategy fs, CompositeException that) {
+            new CompositeExceptionSubject(fs, that)
+        }
+    }
+
+    public static CompositeExceptionSubject assertThat(CompositeException compositeException) {
+        Truth.assertAbout(FACTORY).that(compositeException)
+    }
+
+    private CompositeExceptionSubject(FailureStrategy failureStrategy,
+                                      @Nullable CompositeException subject) {
+        super(failureStrategy, subject)
+    }
+
+    public void contains(Throwable... throwables) {
+        Truth.assertThat(subject.exceptions).containsExactly(throwables)
+    }
+
+    public void hasMessage(String... messages) {
+        Truth.assertThat(subject.exceptions.collect { it.message }).containsExactly(messages)
+    }
+
+}

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionTest.groovy
@@ -3,6 +3,7 @@ package com.novoda.buildproperties
 import org.junit.Test
 
 import static com.google.common.truth.Truth.assertThat
+import static com.novoda.buildproperties.CompositeExceptionSubject.assertThat
 
 class CompositeExceptionTest {
 
@@ -20,21 +21,17 @@ class CompositeExceptionTest {
     }
 
     @Test
-    public void shouldContainWrappedExceptionMessage() {
+    public void shouldContainWrappedException() {
         CompositeException compositeException = CompositeException.from(EXCEPTION_1)
 
-        String message = compositeException.message
-
-        assertThat(message).contains(inOrder(EXCEPTION_1.message))
+        assertThat(compositeException).hasMessage(EXCEPTION_1.message)
     }
 
     @Test
-    public void shouldContainAddedExceptionMessage() {
+    public void shouldContainAddedException() {
         CompositeException compositeException = CompositeException.from(EXCEPTION_1).add(EXCEPTION_2)
 
-        String message = compositeException.message
-
-        assertThat(message).contains(inOrder(EXCEPTION_1.message, EXCEPTION_2.message))
+        assertThat(compositeException).hasMessage(EXCEPTION_1.message, EXCEPTION_2.message)
     }
 
     @Test
@@ -42,13 +39,7 @@ class CompositeExceptionTest {
         CompositeException innerException = CompositeException.from(EXCEPTION_1).add(EXCEPTION_2)
         CompositeException compositeException = innerException.add(EXCEPTION_3)
 
-        String message = compositeException.message
-
-        assertThat(message).contains(inOrder(EXCEPTION_1.message, EXCEPTION_2.message, EXCEPTION_3.message))
-    }
-
-    private static String inOrder(String... messages) {
-        messages.inject ('', { acc, val -> acc + "\n- $val"})
+        assertThat(compositeException).hasMessage(EXCEPTION_1.message, EXCEPTION_2.message, EXCEPTION_3.message)
     }
 
 }

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/CompositeExceptionTest.groovy
@@ -1,0 +1,54 @@
+package com.novoda.buildproperties
+
+import org.junit.Test
+
+import static com.google.common.truth.Truth.assertThat
+
+class CompositeExceptionTest {
+
+    private static final Exception EXCEPTION_1 = new RuntimeException("exception 1")
+    private static final Exception EXCEPTION_2 = new RuntimeException("exception 2")
+    private static final Exception EXCEPTION_3 = new RuntimeException("exception 3")
+
+    @Test
+    public void shouldHaveNoCause() {
+        CompositeException compositeException = CompositeException.from(EXCEPTION_1)
+
+        Throwable cause = compositeException.cause
+
+        assertThat(cause).isNull()
+    }
+
+    @Test
+    public void shouldContainWrappedExceptionMessage() {
+        CompositeException compositeException = CompositeException.from(EXCEPTION_1)
+
+        String message = compositeException.message
+
+        assertThat(message).contains(inOrder(EXCEPTION_1.message))
+    }
+
+    @Test
+    public void shouldContainAddedExceptionMessage() {
+        CompositeException compositeException = CompositeException.from(EXCEPTION_1).add(EXCEPTION_2)
+
+        String message = compositeException.message
+
+        assertThat(message).contains(inOrder(EXCEPTION_1.message, EXCEPTION_2.message))
+    }
+
+    @Test
+    public void shouldContainAddedCompositeExceptionMessage() {
+        CompositeException innerException = CompositeException.from(EXCEPTION_1).add(EXCEPTION_2)
+        CompositeException compositeException = innerException.add(EXCEPTION_3)
+
+        String message = compositeException.message
+
+        assertThat(message).contains(inOrder(EXCEPTION_1.message, EXCEPTION_2.message, EXCEPTION_3.message))
+    }
+
+    private static String inOrder(String... messages) {
+        messages.inject ('', { acc, val -> acc + "\n- $val"})
+    }
+
+}

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EntrySubject.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EntrySubject.groovy
@@ -1,0 +1,49 @@
+package com.novoda.buildproperties
+
+import com.google.common.truth.FailureStrategy
+import com.google.common.truth.Subject
+import com.google.common.truth.SubjectFactory
+import com.google.common.truth.Truth
+
+import javax.annotation.Nullable
+
+final class EntrySubject extends Subject<EntrySubject, Entry> {
+
+    private static final SubjectFactory<EntrySubject, Entry> FACTORY = new SubjectFactory<EntrySubject, Entry>() {
+        @Override
+        EntrySubject getSubject(FailureStrategy fs, Entry that) {
+            new EntrySubject(fs, that)
+        }
+    }
+
+    public static EntrySubject assertThat(Entry entry) {
+        Truth.assertAbout(FACTORY).that(entry)
+    }
+
+    private EntrySubject(FailureStrategy failureStrategy, @Nullable Entry subject) {
+        super(failureStrategy, subject)
+    }
+
+    public void willThrow(Class<? extends Throwable> throwableClass) {
+        try {
+            subject.value
+            fail('throws', throwableClass)
+        } catch (Throwable throwable) {
+            Truth.assertThat(throwable).isInstanceOf(throwableClass)
+        }
+    }
+
+    public void willThrow(CompositeException compositeException) {
+        try {
+            subject.value
+            fail('throws', compositeException)
+        } catch (CompositeException thrown) {
+            Truth.assertThat(thrown.message).isEqualTo(compositeException.message)
+        }
+    }
+
+    public void hasValue(def expected) {
+        Truth.assertThat(subject.value).isEqualTo(expected)
+    }
+
+}

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EntryTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EntryTest.groovy
@@ -14,9 +14,9 @@ class EntryTest {
         Entry entry1 = new Entry('key1', { 'value1' })
         Entry entry2 = new Entry('key2', { 'value2' })
 
-        Entry or = entry1.or(entry2)
+        Entry entryWithFallback = entry1.or(entry2)
 
-        assertThat(or).hasValue('value1')
+        assertThat(entryWithFallback).hasValue('value1')
     }
 
     @Test
@@ -24,9 +24,9 @@ class EntryTest {
         Entry entry1 = new Entry('key1', { throw EXCEPTION_1 })
         Entry entry2 = new Entry('key2', { 'value2' })
 
-        Entry or = entry1.or(entry2)
+        Entry entryWithFallback = entry1.or(entry2)
 
-        assertThat(or).hasValue('value2')
+        assertThat(entryWithFallback).hasValue('value2')
     }
 
     @Test
@@ -34,9 +34,9 @@ class EntryTest {
         Entry entry1 = new Entry('key1', { throw EXCEPTION_1 })
         Entry entry2 = new Entry('key2', { throw EXCEPTION_2 })
 
-        Entry or = entry1.or(entry2)
+        Entry entryWithFallback = entry1.or(entry2)
 
-        assertThat(or).willThrow(CompositeException.from(EXCEPTION_1).add(EXCEPTION_2))
+        assertThat(entryWithFallback).willThrow(CompositeException.from(EXCEPTION_1).add(EXCEPTION_2))
     }
 
     @Test
@@ -44,18 +44,18 @@ class EntryTest {
         Entry entry = new Entry('key', { throw EXCEPTION_1 })
         def fallback = { 'fallback' }
 
-        Entry or = entry.or(fallback)
+        Entry entryWithFallback = entry.or(fallback)
 
-        assertThat(or).hasValue('fallback')
+        assertThat(entryWithFallback).hasValue('fallback')
     }
 
     @Test
     public void shouldReturnValueWhenFirstEntryValueThrows() {
         Entry entry = new Entry('key', { throw EXCEPTION_1 })
 
-        Entry or = entry.or('fallback')
+        Entry entryWithFallback = entry.or('fallback')
 
-        assertThat(or).hasValue('fallback')
+        assertThat(entryWithFallback).hasValue('fallback')
     }
 
 }

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EntryTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EntryTest.groovy
@@ -1,0 +1,61 @@
+package com.novoda.buildproperties
+
+import org.junit.Test
+
+import static com.novoda.buildproperties.EntrySubject.assertThat
+
+class EntryTest {
+
+    private static final RuntimeException EXCEPTION_1 = new RuntimeException("exception 1")
+    private static final RuntimeException EXCEPTION_2 = new RuntimeException("exception 2")
+
+    @Test
+    public void shouldReturnFirstEntryValueInOrWhenFirstEntryValueDoesNotThrow() {
+        Entry entry1 = new Entry('key1', { 'value1' })
+        Entry entry2 = new Entry('key2', { 'value2' })
+
+        Entry or = entry1.or(entry2)
+
+        assertThat(or).hasValue('value1')
+    }
+
+    @Test
+    public void shouldReturnSecondEntryValueInOrWhenFirstEntryValueThrows() {
+        Entry entry1 = new Entry('key1', { throw EXCEPTION_1 })
+        Entry entry2 = new Entry('key2', { 'value2' })
+
+        Entry or = entry1.or(entry2)
+
+        assertThat(or).hasValue('value2')
+    }
+
+    @Test
+    public void shouldThrowWhenFirstAndSecondEntryValueThrow() {
+        Entry entry1 = new Entry('key1', { throw EXCEPTION_1 })
+        Entry entry2 = new Entry('key2', { throw EXCEPTION_2 })
+
+        Entry or = entry1.or(entry2)
+
+        assertThat(or).willThrow(CompositeException.from(EXCEPTION_1).add(EXCEPTION_2))
+    }
+
+    @Test
+    public void shouldReturnEvaluatedClosureWhenFirstEntryValueThrows() {
+        Entry entry = new Entry('key', { throw EXCEPTION_1 })
+        def fallback = { 'fallback' }
+
+        Entry or = entry.or(fallback)
+
+        assertThat(or).hasValue('fallback')
+    }
+
+    @Test
+    public void shouldReturnValueWhenFirstEntryValueThrows() {
+        Entry entry = new Entry('key', { throw EXCEPTION_1 })
+
+        Entry or = entry.or('fallback')
+
+        assertThat(or).hasValue('fallback')
+    }
+
+}

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/SampleProjectTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/SampleProjectTest.groovy
@@ -66,6 +66,14 @@ public class SampleProjectTest {
     }
   }
 
+  @Test
+  public void shouldEvaluateFallbackWhenNeeded() {
+    EntrySubject.assertThat(PROJECT.secrets['FOO']).willThrow(IllegalArgumentException)
+    [PROJECT.debugBuildConfig.text, PROJECT.releaseBuildConfig.text].each { String generatedBuildConfig ->
+      assertThat(generatedBuildConfig).contains('public static final String FOO = "bar";')
+    }
+  }
+
   static class ProjectRule implements TestRule {
     File projectDir
     BuildResult buildResult

--- a/BuildPropertiesPlugin/sample/app/build.gradle
+++ b/BuildPropertiesPlugin/sample/app/build.gradle
@@ -40,6 +40,7 @@ android {
     buildConfigProperty 'OVERRIDABLE', buildProperties.secrets['overridable']
     buildConfigProperty 'GOOGLE_MAPS_KEY', buildProperties.secrets['googleMapsKey']
     buildConfigProperty 'SUPER_SECRET', buildProperties.secrets['superSecret']
+    buildConfigProperty 'FOO', buildProperties.secrets['notThere'].or('bar')
   }
 
   signingConfigs {


### PR DESCRIPTION
Every subclass of `Entries` (eg: `FilePropertiesEntries`) defines if the evaluation of an `Entry` will throw when a property is missing. In such cases we may want to avoid to break the build and to define a fallback via the `or()` operator instead. A fallback can be:

- another `Entry`, eg: `entry.or(buildProperties.secrets['fallback'])`
- a `Closure`, eg: `entry.or({ Math.random() })`
- a simple value, eg: `entry.or('fallback')`

(where `entry` is an instance of `Entry`, eg: `buildProperties.secrets['foo']`)

If the whole fallback chain fails then a `CompositeException` is thrown listing all
the causes of failure encountered evaluating the chain, eg:

```
A problem occurred while evaluating entry:
- No value defined for property 'foo' in 'secrets' properties
- No value defined for property 'fallback' in 'other' properties
```
