### PR TITLE
BuildPropertiesPlugin: Introduce support for environment variables

### DIFF
--- a/BuildPropertiesPlugin/README.md
+++ b/BuildPropertiesPlugin/README.md
@@ -142,7 +142,15 @@ another properties files (specified via an `include` property).
 Inherited properties can be overridden by the including set, just redefine
 the property in the file and its value will be used instead of the one
 from the included set.
- 
+
+#### Other built-in `Entry` sets
+It's possible to access a system enviroment variable as `Entry` via a predefined set of entries, ie:
+
+```groovy
+buildProperties.env['FOO']
+```
+Such entries are particularly handy when used alongside the `Entry.or()` operator in order to provide
+fallback values.
 
 #### More on loading properties
 If the specified file is not found an exception is thrown at build time.

--- a/BuildPropertiesPlugin/build.gradle
+++ b/BuildPropertiesPlugin/build.gradle
@@ -1,5 +1,5 @@
 ext {
   pluginGroup = 'com.novoda'
-  pluginVersion = '1.0.1'
+  pluginVersion = '1.1.0'
   pluginId = 'build-properties-plugin'
 }

--- a/BuildPropertiesPlugin/plugin/build.gradle
+++ b/BuildPropertiesPlugin/plugin/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   testCompile 'com.google.truth:truth:0.28'
   testCompile 'com.android.tools.build:gradle:2.1.2'
   testCompile 'com.google.code.findbugs:jsr305:3.0.0'
+  testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
 
 }
 

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -22,6 +22,7 @@ class BuildPropertiesPlugin implements Plugin<Project> {
                 return new BuildProperties(name, project)
             }
         })
+        container.create('env').entries(new EnvironmentPropertiesEntries(project))
         project.extensions.add('buildProperties', container)
 
         def android = project.extensions.findByName("android")

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntries.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntries.groovy
@@ -1,0 +1,37 @@
+package com.novoda.buildproperties
+
+import org.gradle.api.Project
+
+class EnvironmentPropertiesEntries extends Entries {
+
+    private final Project project
+
+    EnvironmentPropertiesEntries(Project project) {
+        this.project = project
+    }
+
+    @Override
+    boolean contains(String key) {
+        System.getenv().containsKey(key)
+    }
+
+    @Override
+    protected Object getValueAt(String key) {
+        String envValue = System.getenv(key)
+        if (envValue != null) {
+            return envValue
+        }
+        throw new IllegalArgumentException("No environment variable defined for key '$key'")
+    }
+
+    @Override
+    File getParentFile() {
+        project.rootDir
+    }
+
+    @Override
+    Enumeration<String> getKeys() {
+        Collections.enumeration(System.getenv().keySet())
+    }
+
+}

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntriesTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntriesTest.groovy
@@ -1,0 +1,77 @@
+package com.novoda.buildproperties
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.rules.TemporaryFolder
+
+import static com.google.common.truth.Truth.assertThat
+
+class EnvironmentPropertiesEntriesTest {
+
+    @Rule
+    public final TemporaryFolder temp = new TemporaryFolder()
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    private Project project
+    private EnvironmentPropertiesEntries entries
+
+    @Before
+    public void setUp() {
+        project = ProjectBuilder.builder()
+                .withProjectDir(temp.newFolder())
+                .build()
+        entries = new EnvironmentPropertiesEntries(project)
+    }
+
+    @Test
+    public void shouldNotContainUndefinedEnvironmentVariable() {
+        assertThat(entries.contains('NOT_THERE')).isFalse()
+    }
+
+    @Test
+    public void shouldThrowWhenEvaluatingUndefinedEnvironmentVariable() {
+        Entry entry = entries['NOT_THERE']
+
+        EntrySubject.assertThat(entry).willThrow(IllegalArgumentException)
+    }
+
+    @Test
+    public void shouldContainDefinedEnvironmentVariable() {
+        environmentVariables.set('FOO', 'foo')
+
+        assertThat(entries.contains('FOO')).isTrue()
+    }
+
+    @Test
+    public void shouldContainedProvidedValueForDefinedEnvironmentVariable() {
+        environmentVariables.set('FOO', 'foo')
+
+        Entry entry = entries['FOO']
+
+        EntrySubject.assertThat(entry).hasValue('foo')
+    }
+
+    @Test
+    public void shouldSupportEnvironmentKeysListing() {
+        environmentVariables.set('FOO', 'foo')
+        environmentVariables.set('BAR', 'bar')
+
+        Enumeration<String> keys = entries.keys
+
+        assertThat(Collections.list(keys)).containsAllOf('FOO', 'BAR')
+    }
+
+    @Test
+    public void shouldProvideProjectRootDirAsParentFile() {
+        File parentFile = entries.parentFile
+
+        assertThat(parentFile).isEqualTo(project.rootDir)
+    }
+
+}

--- a/BuildPropertiesPlugin/sample/app/build.gradle
+++ b/BuildPropertiesPlugin/sample/app/build.gradle
@@ -41,6 +41,7 @@ android {
     buildConfigProperty 'GOOGLE_MAPS_KEY', buildProperties.secrets['googleMapsKey']
     buildConfigProperty 'SUPER_SECRET', buildProperties.secrets['superSecret']
     buildConfigProperty 'FOO', buildProperties.secrets['notThere'].or('bar')
+    buildConfigProperty 'WAT', buildProperties.env['WAT']
   }
 
   signingConfigs {


### PR DESCRIPTION
A built-in set of entries `env` can be used to access an environment variable as `Entry`, like this:
```groovy
Entry entry = buildProperties.env['SOME_ENVIRONMENT_VAR']
```
If the key specified is not defined as environment variable an `IllegalArgumentException` is thrown.

> This is the last feature for version `1.1.0` of the plugin