### PR TITLE
BPP: Add lazy-loading of properties files

### DIFF
--- a/BuildPropertiesPlugin/CHANGELOG.md
+++ b/BuildPropertiesPlugin/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 1.2.0 *(03/09/2016)*
+----------------------------
+
+- Added lazy-loading for properties files
+
 Version 1.1.0 *(25/08/2016)*
 ----------------------------
 

--- a/BuildPropertiesPlugin/README.md
+++ b/BuildPropertiesPlugin/README.md
@@ -153,8 +153,9 @@ Such entries are particularly handy when used alongside the `Entry.or()` operato
 fallback values.
 
 #### More on loading properties
-If the specified file is not found an exception is thrown at build time.
+If the specified file is not found an exception is thrown at build time as soon as one of its properties is evaluated.
 You can specify a custom error message to provide the user with more information.
+
 Given a `BuildProperties` instance one of its entries can be retrieved using the `getAt` operator:
 
 `Entry entry = buildProperties.secrets['aProperty']`

--- a/BuildPropertiesPlugin/build.gradle
+++ b/BuildPropertiesPlugin/build.gradle
@@ -1,5 +1,5 @@
 ext {
   pluginGroup = 'com.novoda'
-  pluginVersion = '1.1.0'
+  pluginVersion = '1.2.0'
   pluginId = 'build-properties-plugin'
 }

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/BuildScriptTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/BuildScriptTest.groovy
@@ -9,7 +9,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 import static com.google.common.truth.Truth.assertThat
-import static junit.framework.Assert.fail
+import static org.junit.Assert.fail
 
 public class BuildScriptTest {
 
@@ -54,16 +54,28 @@ public class BuildScriptTest {
   }
 
   @Test
-  public void shouldFailBuildWhenPropertiesFileDoesNotExist() {
+  public void shouldNotFailBuildWhenDefiningPropertiesFromNonExistentFile() {
     project.apply plugin: 'com.android.library'
     project.apply plugin: BuildPropertiesPlugin
+    project.buildProperties {
+      foo {
+        file project.file('foo.properties')
+      }
+    }
+  }
+
+  @Test
+  public void shouldFailBuildWhenAccessingPropertyFromNonExistentFile() {
+    project.apply plugin: 'com.android.library'
+    project.apply plugin: BuildPropertiesPlugin
+    project.buildProperties {
+      foo {
+        file project.file('foo.properties')
+      }
+    }
 
     try {
-      project.buildProperties {
-        foo {
-          file project.file('foo.properties')
-        }
-      }
+      project.buildProperties.foo['any'].value
       fail('Gradle exception not thrown')
     } catch (GradleException e) {
       assertThat(e.getMessage()).endsWith('foo.properties does not exist.')
@@ -71,7 +83,7 @@ public class BuildScriptTest {
   }
 
   @Test
-  public void shouldProvideErrorMessageWhenPropertiesFileDoesNotExist() {
+  public void shouldProvideSpecifiedErrorMessageWhenAccessingPropertyFromNonExistentFile() {
     project.apply plugin: 'com.android.library'
     project.apply plugin: BuildPropertiesPlugin
 
@@ -82,6 +94,7 @@ public class BuildScriptTest {
           file project.file('foo.properties'), errorMessage
         }
       }
+      project.buildProperties.foo['any'].value
       fail('Gradle exception not thrown')
     } catch (GradleException e) {
       String message = e.getMessage()

--- a/BuildPropertiesPlugin/sample/app/build.gradle
+++ b/BuildPropertiesPlugin/sample/app/build.gradle
@@ -8,6 +8,11 @@ apply plugin: 'com.android.application'
 apply plugin: com.novoda.buildproperties.BuildPropertiesPlugin
 
 buildProperties {
+  notThere {
+    file rootProject.file('whatever'), '''
+      This file actually doesn't exists. This is used to show properties fiels are lazy-loaded.
+    '''
+  }
   secrets {
     file rootProject.file('properties/secrets.properties')
   }
@@ -40,7 +45,7 @@ android {
     buildConfigProperty 'OVERRIDABLE', buildProperties.secrets['overridable']
     buildConfigProperty 'GOOGLE_MAPS_KEY', buildProperties.secrets['googleMapsKey']
     buildConfigProperty 'SUPER_SECRET', buildProperties.secrets['superSecret']
-    buildConfigProperty 'FOO', buildProperties.secrets['notThere'].or('bar')
+    buildConfigProperty 'FOO', buildProperties.secrets['notThere'].or(buildProperties.notThere['foo']).or('bar')
     buildConfigProperty 'WAT', buildProperties.env['WAT']
   }
 


### PR DESCRIPTION
At the moment the project evaluation fails straight away when `buildProperties` contains a set of entries from a file that is not found.
It would be useful in multiple scenarios to lazy load properties file and fail the build only when one of their entries will actually be evaluated.