### PR TITLE
Monkey runner plugin/Optional properties

### DIFF
--- a/monkey-runner/README.md
+++ b/monkey-runner/README.md
@@ -53,13 +53,15 @@ monkeyRunner {
 }
 ```
 
-In your app manifest, add the following category for your main Activity:
-```xml
-<intent-filter>
-  ...
-  <category android:name="android.intent.category.MONKEY" />
-</intent-filter>
-```
+## Configuration
+
+You can configure the following properties on the `monkeyRunner` extension:
+- `taskDependency`: task to be run before the monkey runner starts (usually this is an install task for your app)
+ - `eventsCount` (optional): number of events executed by the monkey runner (**default: 50000**)
+ - `packageNameFilter`: your app package name
+ - `logFileName` (optional): name of the monkey runner log (**default: monkey.log**)
+ - `useMonkeyTrap` (optional): whether to use the monkey trap or not (**default: true**) 
+
 
 ## Simple usage
 

--- a/monkey-runner/README.md
+++ b/monkey-runner/README.md
@@ -57,10 +57,10 @@ monkeyRunner {
 
 You can configure the following properties on the `monkeyRunner` extension:
 - `taskDependency`: task to be run before the monkey runner starts (usually this is an install task for your app)
- - `eventsCount` (optional): number of events executed by the monkey runner (**default: 50000**)
- - `packageNameFilter`: your app package name
- - `logFileName` (optional): name of the monkey runner log (**default: monkey.log**)
- - `useMonkeyTrap` (optional): whether to use the monkey trap or not (**default: true**) 
+- `eventsCount` (optional): number of events executed by the monkey runner (**default: 50000**)
+- `packageNameFilter`: your app package name
+- `logFileName` (optional): name of the monkey runner log (**default: monkey.log**)
+- `useMonkeyTrap` (optional): whether to use the monkey trap or not (**default: true**)
 
 
 ## Simple usage

--- a/monkey-runner/dependencies.gradle
+++ b/monkey-runner/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     gradlePlugins = [
-            gradle                    : 'com.android.tools.build:gradle:2.1.2',
+            gradle                    : 'com.android.tools.build:gradle:2.1.3',
             gradleAndroidCommandPlugin: 'com.novoda:gradle-android-command-plugin:1.6.2',
             bintrayRelease            : 'com.novoda:bintray-release:0.3.4'
     ]

--- a/monkey-runner/dependencies.gradle
+++ b/monkey-runner/dependencies.gradle
@@ -6,12 +6,16 @@ ext {
     ]
 
     versions = [
-            androidBuildTools   : '24.0.1',
-            androidSupportLibs  : '24.1.1'
+            androidBuildTools : '24.0.1',
+            androidSupportLibs: '24.1.1'
     ]
 
     libraries = [
             appCompat        : "com.android.support:appcompat-v7:${versions.androidSupportLibs}",
             androidV13Support: "com.android.support:support-v13:${versions.androidSupportLibs}",
+    ]
+
+    testLibraries = [
+            truth: 'com.google.truth:truth:0.28'
     ]
 }

--- a/monkey-runner/plugin/build.gradle
+++ b/monkey-runner/plugin/build.gradle
@@ -8,6 +8,10 @@ repositories {
 dependencies {
     compile gradleApi()
     compile gradlePlugins.gradleAndroidCommandPlugin
+
+    testCompile gradleTestKit()
+    testCompile gradlePlugins.gradle
+    testCompile testLibraries.truth
 }
 
 publish {

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -47,7 +47,7 @@ public class MonkeyConfigurationPlugin implements Plugin<Project> {
                 events = extension.eventsCount
                 deviceId = device.id
                 logFileName = extension.logFileName
-                categories = ["android.intent.category.MONKEY"]
+                categories = extension.categories
             }
 
             def hideOverlay = project.task("hideOverlayDevice${index}", type: NotificationBarOverlay) {
@@ -74,6 +74,7 @@ public class MonkeyConfigurationPlugin implements Plugin<Project> {
         Integer eventsCount
         String packageNameFilter
         String logFileName
+        List<String> categories
 
         void setDefaultsForOptionalProperties() {
             eventsCount = 50000

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -36,11 +36,6 @@ public class MonkeyConfigurationPlugin implements Plugin<Project> {
         def android = project.extensions.findByName("android")
         android.command.devices().eachWithIndex { device, index ->
 
-            def showOverlayTask = project.task("showOverlayDevice${index}", type: NotificationBarOverlay) {
-                show = true
-                deviceId = device.id
-            }
-
             def monkeyTask = project.task("runMonkeyDevice${index}", type: TargetedMonkey) {
                 packageName = extension.packageNameFilter
                 events = extension.eventsCount
@@ -49,20 +44,30 @@ public class MonkeyConfigurationPlugin implements Plugin<Project> {
                 categories = extension.categories
             }
 
-            def hideOverlay = project.task("hideOverlayDevice${index}", type: NotificationBarOverlay) {
-                show = false
-                deviceId = device.id
-            }
-
             def uninstallApp = project.task("uninstallMonkeyDevice${index}", type: TargetedUninstall) {
                 packageName = extension.packageNameFilter
                 deviceId = device.id
             }
 
-            hideOverlay.dependsOn uninstallApp
-            monkeyTask.dependsOn showOverlayTask
+            if (extension.useMonkeyTrap) {
+                def showOverlayTask = project.task("showOverlayDevice${index}", type: NotificationBarOverlay) {
+                    show = true
+                    deviceId = device.id
+                }
+
+                def hideOverlay = project.task("hideOverlayDevice${index}", type: NotificationBarOverlay) {
+                    show = false
+                    deviceId = device.id
+                }
+
+                hideOverlay.dependsOn uninstallApp
+                monkeyTask.dependsOn showOverlayTask
+                monkeyTask.finalizedBy hideOverlay
+            } else {
+                monkeyTask.finalizedBy uninstallApp
+            }
+
             monkeyTask.dependsOn extension.taskDependency
-            monkeyTask.finalizedBy hideOverlay
             runMonkeyAllTask.dependsOn monkeyTask
         }
     }

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -6,13 +6,12 @@ import org.gradle.api.Project
 
 public class MonkeyConfigurationPlugin implements Plugin<Project> {
 
-    private static final String MONKEY_RUNNER_EXTENSION_NAME = 'monkeyRunner'
     private static final String TASK_NAME = 'runMonkeyAll'
 
     @Override
     public void apply(Project project) {
         ensureAndroidPluginAppliedTo(project)
-        MonkeyRunnerExtension extension = project.extensions.create(MONKEY_RUNNER_EXTENSION_NAME, MonkeyRunnerExtension)
+        MonkeyRunnerExtension extension = project.extensions.create(MonkeyRunnerExtension.NAME, MonkeyRunnerExtension)
         extension.setDefaultsForOptionalProperties()
 
         project.afterEvaluate {
@@ -65,33 +64,6 @@ public class MonkeyConfigurationPlugin implements Plugin<Project> {
             monkeyTask.dependsOn extension.taskDependency
             monkeyTask.finalizedBy hideOverlay
             runMonkeyAllTask.dependsOn monkeyTask
-        }
-    }
-
-    static class MonkeyRunnerExtension {
-
-        String taskDependency
-        Integer eventsCount
-        String packageNameFilter
-        String logFileName
-        List<String> categories
-
-        void setDefaultsForOptionalProperties() {
-            eventsCount = 50000
-            logFileName = 'monkey.log'
-        }
-
-        void ensureMandatoryPropertiesPresent() {
-            if (taskDependency == null) {
-                notifyMissingProperty('taskDependency')
-            }
-            if (packageNameFilter == null) {
-                notifyMissingProperty('packageNameFilter')
-            }
-        }
-
-        private static void notifyMissingProperty(String propertyName) {
-            throw new IllegalArgumentException("${MONKEY_RUNNER_EXTENSION_NAME}.${propertyName} is not specified")
         }
     }
 }

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyRunnerExtension.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyRunnerExtension.groovy
@@ -1,0 +1,30 @@
+package com.novoda.monkey
+
+public class MonkeyRunnerExtension {
+
+    public static final String NAME = 'monkeyRunner'
+
+    String taskDependency
+    Integer eventsCount
+    String packageNameFilter
+    String logFileName
+    List<String> categories
+
+    void setDefaultsForOptionalProperties() {
+        eventsCount = 50000
+        logFileName = 'monkey.log'
+    }
+
+    void ensureMandatoryPropertiesPresent() {
+        if (taskDependency == null) {
+            notifyMissingProperty('taskDependency')
+        }
+        if (packageNameFilter == null) {
+            notifyMissingProperty('packageNameFilter')
+        }
+    }
+
+    private static void notifyMissingProperty(String propertyName) {
+        throw new IllegalArgumentException("${NAME}.${propertyName} is not specified")
+    }
+}

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyRunnerExtension.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyRunnerExtension.groovy
@@ -9,10 +9,12 @@ public class MonkeyRunnerExtension {
     String packageNameFilter
     String logFileName
     List<String> categories
+    boolean useMonkeyTrap
 
     void setDefaultsForOptionalProperties() {
         eventsCount = 50000
         logFileName = 'monkey.log'
+        useMonkeyTrap = true
     }
 
     void ensureMandatoryPropertiesPresent() {

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
@@ -1,0 +1,30 @@
+package com.novoda.monkey
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Test
+
+public class MonkeyConfigurationPluginTest {
+
+    private Project project
+
+    @Before
+    public void setUp() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'com.android.application'
+    }
+
+    @Test(expected = GradleException.class)
+    public void givenAndroidPluginNotApplied_whenApplyingMonkey_thenItThrowsException() {
+        project = ProjectBuilder.builder().build()
+
+        project.apply plugin: MonkeyConfigurationPlugin
+    }
+
+    @Test
+    public void givenAndroidPluginApplied_whenApplyingMonkey_thenItApplies() {
+        project.apply plugin: MonkeyConfigurationPlugin
+    }
+}

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
@@ -24,7 +24,7 @@ public class MonkeyConfigurationPluginTest {
     }
 
     @Test
-    public void givenAndroidPluginApplied_whenApplyingMonkey_thenItApplies() {
+    public void givenAndroidPluginApplied_whenApplyingMonkey_thenItDoesNotThrowException() {
         project.apply plugin: MonkeyConfigurationPlugin
     }
 }

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
@@ -6,11 +6,12 @@ import org.junit.Test
 import static com.google.common.truth.Truth.assertThat
 
 class MonkeyRunnerExtensionTest {
-    private MonkeyConfigurationPlugin.MonkeyRunnerExtension extension
+
+    private MonkeyRunnerExtension extension
 
     @Before
     public void setUp() {
-        extension = new MonkeyConfigurationPlugin.MonkeyRunnerExtension()
+        extension = new MonkeyRunnerExtension()
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
@@ -41,4 +41,11 @@ class MonkeyRunnerExtensionTest {
 
         assertThat(extension.logFileName).isEqualTo('monkey.log')
     }
+
+    @Test
+    public void defaultMonkeyTrapIsTrue() {
+        extension.setDefaultsForOptionalProperties()
+
+        assertThat(extension.useMonkeyTrap).isTrue()
+    }
 }

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
@@ -1,0 +1,43 @@
+package com.novoda.monkey
+
+import org.junit.Before
+import org.junit.Test
+
+import static com.google.common.truth.Truth.assertThat
+
+class MonkeyRunnerExtensionTest {
+    private MonkeyConfigurationPlugin.MonkeyRunnerExtension extension
+
+    @Before
+    public void setUp() {
+        extension = new MonkeyConfigurationPlugin.MonkeyRunnerExtension()
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNoTaskDependencySpecified_thenItThrows() {
+        extension.packageNameFilter = 'com.package'
+
+        extension.ensureMandatoryPropertiesPresent()
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNoPackageNameFilterSpecified_thenItThrows() {
+        extension.taskDependency = 'someTask'
+
+        extension.ensureMandatoryPropertiesPresent()
+    }
+
+    @Test
+    public void defaultEventsCountIs50000() {
+        extension.setDefaultsForOptionalProperties()
+
+        assertThat(extension.eventsCount).isEqualTo(50000)
+    }
+
+    @Test
+    public void defaultLogFileNameIsMonkeyLog() {
+        extension.setDefaultsForOptionalProperties()
+
+        assertThat(extension.logFileName).isEqualTo('monkey.log')
+    }
+}

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
@@ -3,8 +3,6 @@ package com.novoda.monkey
 import org.junit.Before
 import org.junit.Test
 
-import static com.google.common.truth.Truth.assertThat
-
 class MonkeyRunnerExtensionTest {
 
     private MonkeyRunnerExtension extension
@@ -26,26 +24,5 @@ class MonkeyRunnerExtensionTest {
         extension.taskDependency = 'someTask'
 
         extension.ensureMandatoryPropertiesPresent()
-    }
-
-    @Test
-    public void defaultEventsCountIs50000() {
-        extension.setDefaultsForOptionalProperties()
-
-        assertThat(extension.eventsCount).isEqualTo(50000)
-    }
-
-    @Test
-    public void defaultLogFileNameIsMonkeyLog() {
-        extension.setDefaultsForOptionalProperties()
-
-        assertThat(extension.logFileName).isEqualTo('monkey.log')
-    }
-
-    @Test
-    public void defaultMonkeyTrapIsTrue() {
-        extension.setDefaultsForOptionalProperties()
-
-        assertThat(extension.useMonkeyTrap).isTrue()
     }
 }

--- a/monkey-runner/sample/app/src/main/AndroidManifest.xml
+++ b/monkey-runner/sample/app/src/main/AndroidManifest.xml
@@ -3,12 +3,13 @@
 
   <application
     android:allowBackup="true"
-    android:label="@string/app_name"
     android:icon="@drawable/ic_launcher"
+    android:label="@string/app_name"
     android:theme="@style/AppTheme">
 
-    <activity android:name="com.novoda.monkey.MonkeyRunnerActivity"
-      android:label="@string/activity_name"/>
+    <activity
+      android:name="com.novoda.monkey.MonkeyRunnerActivity"
+      android:label="@string/activity_name" />
 
     <activity-alias
       android:name="activity.primary_launcher"
@@ -17,7 +18,6 @@
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
-        <category android:name="android.intent.category.MONKEY" />
       </intent-filter>
 
     </activity-alias>


### PR DESCRIPTION
### tl;dr
Make `categories` optional. 
Introduce `useMonkeyTrap` property in order to control whether the session should use the trap or not. 

### Problem

The plugin requires an explicit `android.intent.category.MONKEY` intent filter category which adds noise to the application under test, this could be optional. 

Moreover, the plugin automatically starts the monkey trap for every session. In certain cases the monkey trap is not required, thus making the monkey trap optional would be beneficial. 

### Solution

- removed the explicit `android.intent.category.MONKEY` intent filter category and added an optional `categories` property to the extension for configuration
- added an optional `useMonkeyTrap`property on the extension in order to control whether the trap should be launched or not. However, the default value of this property is **true** in order to match previous behaviour

Refactorings:
- pulled out `MonkeyRunnerExtension` class 
- updated gradle plugin to `2.1.3`
- updated `README` in order to reflect the new changes

### Tests
- around the `MonkeyRunnerExtension` in order to ensure default values
- around `MonkeyConfigurationPlugin` in order to ensure the plugin is applied only after the Android plugin is applied