### PR TITLE
BuildPropertiesPlugin: Fix signing config support

### DIFF
--- a/BuildPropertiesPlugin/CHANGELOG.md
+++ b/BuildPropertiesPlugin/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.2.1 *(17/09/2016)*
+----------------------------
+
+- Fixed bug with `signingConfigProperties` not filling signing configuration
+ as intended
+
 Version 1.2.0 *(03/09/2016)*
 ----------------------------
 

--- a/BuildPropertiesPlugin/CHANGELOG.md
+++ b/BuildPropertiesPlugin/CHANGELOG.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-Version 1.2.1 *(17/09/2016)*
+Version 1.2.1 *(18/09/2016)*
 ----------------------------
 
 - Fixed bug with `signingConfigProperties` not filling signing configuration

--- a/BuildPropertiesPlugin/README.md
+++ b/BuildPropertiesPlugin/README.md
@@ -23,7 +23,7 @@ buildscript {
     jcenter()
    }
   dependencies {
-    classpath 'com.novoda:build-properties-plugin:1.1.0'
+    classpath 'com.novoda:build-properties-plugin:1.2.1'
   }
 }
 ```

--- a/BuildPropertiesPlugin/build.gradle
+++ b/BuildPropertiesPlugin/build.gradle
@@ -1,5 +1,5 @@
 ext {
   pluginGroup = 'com.novoda'
-  pluginVersion = '1.2.0'
+  pluginVersion = '1.2.1'
   pluginId = 'build-properties-plugin'
 }

--- a/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/BuildPropertiesPlugin/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -95,12 +95,10 @@ class BuildPropertiesPlugin implements Plugin<Project> {
 
     private void addSigningConfigSupportTo(target, Project project) {
         target.ext.signingConfigProperties = { BuildProperties buildProperties ->
-            project.afterEvaluate {
-                target.storeFile new File(buildProperties.parentFile, buildProperties['storeFile'].string)
-                target.storePassword buildProperties['storePassword'].string
-                target.keyAlias buildProperties['keyAlias'].string
-                target.keyPassword buildProperties['keyPassword'].string
-            }
+            target.storeFile new File(buildProperties.parentFile, buildProperties['storeFile'].string)
+            target.storePassword buildProperties['storePassword'].string
+            target.keyAlias buildProperties['keyAlias'].string
+            target.keyPassword buildProperties['keyPassword'].string
         }
     }
 

--- a/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/SampleProjectTest.groovy
+++ b/BuildPropertiesPlugin/plugin/src/test/groovy/com/novoda/buildproperties/SampleProjectTest.groovy
@@ -90,6 +90,11 @@ public class SampleProjectTest {
     }
   }
 
+  @Test
+  public void shouldSignReleaseBuildUsingProperties() throws Exception {
+    assertThat(new File(PROJECT.apkDir, 'app-release.apk').exists()).isTrue()
+  }
+
   static class ProjectRule implements TestRule {
     File projectDir
     BuildResult buildResult
@@ -97,6 +102,7 @@ public class SampleProjectTest {
     File releaseBuildConfig
     File debugResValues
     File releaseResValues
+    File apkDir
     Entries secrets
 
     @Override
@@ -105,19 +111,20 @@ public class SampleProjectTest {
 
       File propertiesFile = new File(Resources.getResource('any.properties').toURI())
       File rootDir = propertiesFile.parentFile.parentFile.parentFile.parentFile.parentFile
-
       projectDir = new File(rootDir, 'sample')
+      File buildDir = new File(projectDir, 'app/build')
+      apkDir = new File(buildDir, 'outputs/apk')
       buildResult = DefaultGradleRunner.create()
-              .withProjectDir(PROJECT.projectDir)
+              .withProjectDir(projectDir)
               .withDebug(true)
               .forwardStdOutput(new OutputStreamWriter(System.out))
-              .withArguments('clean', "-Poverridable=$COMMAND_LINE_PROPERTY", 'compileDebugSources', 'compileReleaseSources')
+              .withArguments('clean', "-Poverridable=$COMMAND_LINE_PROPERTY", 'assemble')
               .build()
-      debugBuildConfig = new File(PROJECT.projectDir, 'app/build/generated/source/buildConfig/debug/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')
-      releaseBuildConfig = new File(PROJECT.projectDir, 'app/build/generated/source/buildConfig/release/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')
-      debugResValues = new File(PROJECT.projectDir, 'app/build/generated/res/resValues/debug/values/generated.xml')
-      releaseResValues = new File(PROJECT.projectDir, 'app/build/generated/res/resValues/release/values/generated.xml')
-      secrets = FilePropertiesEntries.create(new File(PROJECT.projectDir, 'properties/secrets.properties'))
+      debugBuildConfig = new File(buildDir, 'generated/source/buildConfig/debug/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')
+      releaseBuildConfig = new File(buildDir, 'generated/source/buildConfig/release/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')
+      debugResValues = new File(buildDir, 'generated/res/resValues/debug/values/generated.xml')
+      releaseResValues = new File(buildDir, 'generated/res/resValues/release/values/generated.xml')
+      secrets = FilePropertiesEntries.create(new File(projectDir, 'properties/secrets.properties'))
       return base;
     }
   }

--- a/BuildPropertiesPlugin/sample/app/build.gradle
+++ b/BuildPropertiesPlugin/sample/app/build.gradle
@@ -46,7 +46,7 @@ android {
     buildConfigProperty 'GOOGLE_MAPS_KEY', buildProperties.secrets['googleMapsKey']
     buildConfigProperty 'SUPER_SECRET', buildProperties.secrets['superSecret']
     buildConfigProperty 'FOO', buildProperties.secrets['notThere'].or(buildProperties.notThere['foo']).or('bar')
-    buildConfigProperty 'WAT', buildProperties.env['WAT']
+    buildConfigProperty 'WAT', buildProperties.env['WAT'].or('?!?')
   }
 
   signingConfigs {

--- a/BuildPropertiesPlugin/sample/app/build.gradle
+++ b/BuildPropertiesPlugin/sample/app/build.gradle
@@ -28,8 +28,8 @@ buildProperties {
 }
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.2"
+  compileSdkVersion 24
+  buildToolsVersion "24.0.2"
 
   defaultConfig {
     applicationId "com.novoda.buildpropertiesplugin.sample"


### PR DESCRIPTION
APKs are not signed and zip-aligned at all if the signing configuration is read from a properties file via `signingConfigProperties`. It seems the lazy evaluation facilities introduced in the previous releases broke somehow this feature. To avoid this problem in the future a new test has been added checking the zip-aligned release APK is generated as intended.

This PR incidentally bumps the plugin version to 1.2.1 to make a new release possible.