### PR TITLE
StaticAnalysisPlugin: Improve collection/evaluation of violations

### DIFF
--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
@@ -38,7 +38,7 @@ class CheckstyleConfigurator {
         }
     }
 
-    private EvaluateViolationsTask createEvaluateViolationsTask(Project project, PenaltyExtension penalty) {
+    private static EvaluateViolationsTask createEvaluateViolationsTask(Project project, PenaltyExtension penalty) {
         project.tasks.create('evaluateCheckstyleViolations', EvaluateViolationsTask) { task ->
             task.tool = Checkstyle
             task.penalty = penalty

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
@@ -9,6 +9,9 @@ class CheckstyleConfigurator {
 
     void configure(Project project, StaticAnalysisExtension extension) {
         project.apply plugin: 'checkstyle'
+        project.checkstyle {
+            toolVersion = '7.1.2'
+        }
         project.afterEvaluate {
             PenaltyExtension penalty = extension.penalty
             EvaluateViolationsTask evaluateViolationsTask = createEvaluateViolationsTask(project, penalty)

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
@@ -28,8 +28,7 @@ class EvaluateViolationsTask extends DefaultTask {
                 "${reports.collect { "- $it" }.join('\n')}"
         if (errors > penalty.maxErrors || warnings > penalty.maxWarnings) {
             throw new GradleException(message)
-        } else {
-            project.logger.warn(message)
         }
+        project.logger.warn(message)
     }
 }

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/Violations.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/Violations.groovy
@@ -1,0 +1,37 @@
+package com.novoda.staticanalysis;
+
+class Violations {
+    private final String toolName
+    private int errors = 0
+    private int warnings = 0
+    private List<String> reports = []
+
+    Violations(String toolName) {
+        this.toolName = toolName
+    }
+
+    public String getName() {
+        return toolName
+    }
+
+    public int getErrors() {
+        errors
+    }
+
+    public int getWarnings() {
+        warnings
+    }
+
+    public void addViolations(int errors, int warnings, String reportUrl) {
+        this.errors += errors
+        this.warnings += warnings
+        if (errors > 0 || warnings > 0) {
+            reports += reportUrl
+        }
+    }
+
+    public String getMessage() {
+        "$toolName rule violations were found ($errors errors, $warnings warnings). See the reports at:\n" +
+                "${reports.collect { "- $it" }.join('\n')}"
+    }
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleConfigurationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleConfigurationTest.groovy
@@ -36,7 +36,7 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldNotFailBuildByDefaultWhenCheckstyleWarningsEncountered() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .build('check')
 
         assertThat(result.logs).containsCheckstyleViolations(0, 1,
@@ -46,8 +46,8 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldFailBuildByDefaultWhenCheckstyleErrorsEncountered() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
-                .withSourceSet('test', Fixtures.SOURCES_WITH_CHECKSTYLE_ERRORS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
                 .buildAndFail('check')
 
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
@@ -67,7 +67,7 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldNotFailBuildWhenCheckstyleWarningsEncounteredAndNoPenalty() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withPenalty('none')
                 .build('check')
 
@@ -78,8 +78,8 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldNotFailBuildWhenCheckstyleErrorsEncounteredAndNoPenalty() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
-                .withSourceSet('test', Fixtures.SOURCES_WITH_CHECKSTYLE_ERRORS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
                 .withPenalty('none')
                 .build('check')
 
@@ -100,7 +100,7 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldNotFailBuildWhenCheckstyleWarningsEncounteredAndPenaltyOnErrors() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withPenalty('failOnErrors')
                 .build('check')
 
@@ -111,8 +111,8 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldFailBuildWhenCheckstyleErrorsEncounteredAndPenaltyOnErrors() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
-                .withSourceSet('test', Fixtures.SOURCES_WITH_CHECKSTYLE_ERRORS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
                 .withPenalty('failOnErrors')
                 .buildAndFail('check')
 
@@ -133,7 +133,7 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldFailBuildWhenCheckstyleWarningsEncounteredAndPenaltyOnWarnings() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withPenalty('failOnWarnings')
                 .buildAndFail('check')
 
@@ -144,8 +144,8 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldFailBuildWhenCheckstyleErrorsEncounteredAndPenaltyOnWarnings() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
-                .withSourceSet('test', Fixtures.SOURCES_WITH_CHECKSTYLE_ERRORS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
                 .withPenalty('failOnWarnings')
                 .buildAndFail('check')
 
@@ -157,8 +157,8 @@ public class CheckstyleConfigurationTest {
     @Test
     public void shouldNotFailBuildWhenCheckstyleErrorsEncounteredAndThresholdsNotReached() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.SOURCES_WITH_CHECKSTYLE_WARNINGS)
-                .withSourceSet('test', Fixtures.SOURCES_WITH_CHECKSTYLE_ERRORS)
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
                 .withPenalty('''{
         maxWarnings 1
         maxErrors 1

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleConfigurationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleConfigurationTest.groovy
@@ -50,6 +50,7 @@ public class CheckstyleConfigurationTest {
                 .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
                 .buildAndFail('check')
 
+        assertThat(result.logs).containsLimitExceeded(1, 0)
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
                 result.buildFile('reports/checkstyle/main.html'),
                 result.buildFile('reports/checkstyle/test.html'))
@@ -116,6 +117,7 @@ public class CheckstyleConfigurationTest {
                 .withPenalty('failOnErrors')
                 .buildAndFail('check')
 
+        assertThat(result.logs).containsLimitExceeded(1, 0)
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
                 result.buildFile('reports/checkstyle/main.html'),
                 result.buildFile('reports/checkstyle/test.html'))
@@ -137,6 +139,7 @@ public class CheckstyleConfigurationTest {
                 .withPenalty('failOnWarnings')
                 .buildAndFail('check')
 
+        assertThat(result.logs).containsLimitExceeded(0, 1)
         assertThat(result.logs).containsCheckstyleViolations(0, 1,
                 result.buildFile('reports/checkstyle/main.html'))
     }
@@ -149,6 +152,7 @@ public class CheckstyleConfigurationTest {
                 .withPenalty('failOnWarnings')
                 .buildAndFail('check')
 
+        assertThat(result.logs).containsLimitExceeded(1, 1)
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
                 result.buildFile('reports/checkstyle/main.html'),
                 result.buildFile('reports/checkstyle/test.html'))

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -2,21 +2,27 @@ package com.novoda.test
 
 import com.google.common.io.Resources
 
-final class Fixtures {
+public final class Fixtures {
+    private static final Exception NO_INSTANCE_ALLOWED = new UnsupportedOperationException("No instance allowed");
     private static final File ROOT_DIR = new File(Resources.getResource('.').file).parentFile.parentFile.parentFile
     private static final File FIXTURES_DIR = new File(ROOT_DIR, 'fixtures')
     public static final File BUILD_DIR = new File(ROOT_DIR, 'build')
-    public static final File CHECKSTYLE_CONFIG = fixture('checkstyle/config/modules.xml')
-    public static final File SOURCES_WITH_CHECKSTYLE_ERRORS = fixture('checkstyle/errors')
-    public static final File SOURCES_WITH_CHECKSTYLE_WARNINGS = fixture('checkstyle/warnings')
     public static final File LOCAL_PROPERTIES = new File(ROOT_DIR.parentFile, 'local.properties')
-    public static final File ANDROID_MANIFEST = fixture('AndroidManifest.xml')
+    public static final File ANDROID_MANIFEST = new File(FIXTURES_DIR, 'AndroidManifest.xml')
 
     private Fixtures() {
-        throw new UnsupportedOperationException("No instance allowed")
+        throw NO_INSTANCE_ALLOWED
     }
 
-    public static File fixture(String path) {
-        return new File(FIXTURES_DIR, path)
+    public final static class Checkstyle {
+        public static final File MODULES = new File(FIXTURES_DIR, 'checkstyle/config/modules.xml')
+        public static final File SOURCES_WITH_ERRORS = new File(FIXTURES_DIR, 'checkstyle/errors')
+        public static final File SOURCES_WITH_WARNINGS = new File(FIXTURES_DIR, 'checkstyle/warnings')
+
+        private Checkstyle() {
+            throw NO_INSTANCE_ALLOWED
+        }
     }
+
+
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -10,6 +10,9 @@ import javax.annotation.Nullable
 import static com.novoda.test.TestProject.Result.Logs;
 
 class LogsSubject extends Subject<LogsSubject, Logs> {
+    private static final Closure<String> LIMIT_EXCEEDED_LOG = { int errors, int warnings ->
+        "Violations limit exceeded by $errors errors, $warnings warnings."
+    }
     private static final String CHECKSTYLE_FAILURE_LOG = "Checkstyle rule violations were found"
     private static final Closure<String> CHECKSTYLE_VIOLATIONS_LOG = { int errors, int warnings, String... reports ->
         CHECKSTYLE_FAILURE_LOG +
@@ -29,6 +32,10 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
 
     LogsSubject(FailureStrategy failureStrategy, @Nullable Logs actual) {
         super(failureStrategy, actual)
+    }
+
+    public void containsLimitExceeded(int errors, int warnings) {
+        Truth.assertThat(actual().output).contains(LIMIT_EXCEEDED_LOG(errors, warnings))
     }
 
     public void containsCheckstyleViolations(int errors, int warnings, File... reports) {

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -57,14 +57,14 @@ staticAnalysis {
     }
 
     public Result build(String... arguments) {
-        copyFile(Fixtures.CHECKSTYLE_CONFIG, 'config/checkstyle/checkstyle.xml')
+        copyFile(Fixtures.Checkstyle.MODULES, 'config/checkstyle/checkstyle.xml')
         new File(projectDir, 'build.gradle').text = template.call(this)
         BuildResult buildResult = withArguments(arguments).build()
         createResult(buildResult)
     }
 
     public Result buildAndFail(String... arguments) {
-        copyFile(Fixtures.CHECKSTYLE_CONFIG, 'config/checkstyle/checkstyle.xml')
+        copyFile(Fixtures.Checkstyle.MODULES, 'config/checkstyle/checkstyle.xml')
         new File(projectDir, 'build.gradle').text = template.call(this)
         BuildResult buildResult = withArguments(arguments).buildAndFail()
         createResult(buildResult)


### PR DESCRIPTION
## Scope
When the build fails after running all the verification tasks we want to provide the user a meaningful log with information about what threshold has been exceeded.

## Considerations / Implementation details

- Introduced `Violations` to collect a summary of the violations encountered when running the checks. A `NamedDomainObjectContainer` will hold an instance of `Violations` for each static analysis tool applied to the project.
- Forced usage of checkstyle v7.1.2
- Made `EvaluateViolationsTask` to check all the `Violations` and provide meaningful logs detailing failures and thresholds exceeded, eg:

```
:compileJava
:processResources UP-TO-DATE
:classes
:checkstyleMain
:compileTestJava
:processTestResources UP-TO-DATE
:testClasses
:checkstyleTest
:evaluateViolations FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':evaluateViolations'.
> Violations limit exceeded by 1 errors, 0 warnings.
  
  > Checkstyle rule violations were found (1 errors, 1 warnings). See the reports at:
  - file:///Users/toto/novoda/spikes/static-analysis-plugin/plugin/build/test-projects/1476732211503/build/reports/checkstyle/main.html
  - file:///Users/toto/novoda/spikes/static-analysis-plugin/plugin/build/test-projects/1476732211503/build/reports/checkstyle/test.html


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 1.352 secs
```
Note that in case the thresholds are not exceeded the output will just contain a log below `:evaluateViolations` similar to the one above.

Tests in `CheckstyleConfigurationTest` have been amended to also check for limit exceeded logs.