### PR TITLE
Load assets according to time of day

### DIFF
--- a/FacesofLondon/app/src/main/java/com/novoda/wallpaper/droidcon/LondonParallaxWallpaper.java
+++ b/FacesofLondon/app/src/main/java/com/novoda/wallpaper/droidcon/LondonParallaxWallpaper.java
@@ -23,11 +23,13 @@ public class LondonParallaxWallpaper extends GLWallpaperService {
 
     private LondonParallaxWallpaperRenderer renderer;
     private TimeOfDayAssetRefresher refresher;
+    private TimeOfDayCalculator calculator = new TimeOfDayCalculator();
 
     @Override
     public void onCreate() {
         super.onCreate();
-        refresher = new TimeOfDayAssetRefresher(renderer, new TimeOfDayCalculator());
+        renderer = new LondonParallaxWallpaperRenderer(getAssets());
+        refresher = new TimeOfDayAssetRefresher(renderer, calculator);
         registerReceiver(refresher, new IntentFilter(Intent.ACTION_SCREEN_ON));
     }
 
@@ -40,9 +42,7 @@ public class LondonParallaxWallpaper extends GLWallpaperService {
 
         ParallaxEngine() {
             super();
-            renderer = new LondonParallaxWallpaperRenderer(LondonParallaxWallpaper.this.getAssets());
             setRenderer(renderer);
-
             setRenderMode(RENDERMODE_WHEN_DIRTY);
 
             initLayers();
@@ -51,7 +51,8 @@ public class LondonParallaxWallpaper extends GLWallpaperService {
 
         void initLayers() {
             try {
-                renderer.reloadLayers();
+                TimeOfDay timeOfDay = calculator.currentTimeOfDay();
+                renderer.reloadLayersFor(timeOfDay);
                 renderer.resizeLayers();
             } catch (IOException e) {
                 Log.e(TAG, "Error loading textures", e);

--- a/FacesofLondon/app/src/main/java/com/novoda/wallpaper/droidcon/TimeOfDayCalculator.java
+++ b/FacesofLondon/app/src/main/java/com/novoda/wallpaper/droidcon/TimeOfDayCalculator.java
@@ -1,18 +1,12 @@
 package com.novoda.wallpaper.droidcon;
 
+import java.util.Calendar;
+
 class TimeOfDayCalculator {
 
-    private static int flag = 0;
-
     TimeOfDay currentTimeOfDay() {
-        TimeOfDay[] values = TimeOfDay.values();
-        flag++;
-        if (flag >= values.length) {
-            flag = 0;
-        }
-        return values[flag];
-//        Calendar calendar = Calendar.getInstance();
-//        int hourOfDay = calendar.get(Calendar.HOUR_OF_DAY);
-//        return TimeOfDay.forHourOfDay(hourOfDay);
+        Calendar calendar = Calendar.getInstance();
+        int hourOfDay = calendar.get(Calendar.HOUR_OF_DAY);
+        return TimeOfDay.forHourOfDay(hourOfDay);
     }
 }

--- a/FacesofLondon/app/src/main/java/com/novoda/wallpaper/droidcon/TimeOfDayCalculator.java
+++ b/FacesofLondon/app/src/main/java/com/novoda/wallpaper/droidcon/TimeOfDayCalculator.java
@@ -1,12 +1,18 @@
 package com.novoda.wallpaper.droidcon;
 
-import java.util.Calendar;
-
 class TimeOfDayCalculator {
 
+    private static int flag = 0;
+
     TimeOfDay currentTimeOfDay() {
-        Calendar calendar = Calendar.getInstance();
-        int hourOfDay = calendar.get(Calendar.HOUR_OF_DAY);
-        return TimeOfDay.forHourOfDay(hourOfDay);
+        TimeOfDay[] values = TimeOfDay.values();
+        flag++;
+        if (flag >= values.length) {
+            flag = 0;
+        }
+        return values[flag];
+//        Calendar calendar = Calendar.getInstance();
+//        int hourOfDay = calendar.get(Calendar.HOUR_OF_DAY);
+//        return TimeOfDay.forHourOfDay(hourOfDay);
     }
 }

--- a/FacesofLondon/app/src/test/java/com/novoda/wallpaper/droidcon/TimeOfDayAssetRefresherTest.java
+++ b/FacesofLondon/app/src/test/java/com/novoda/wallpaper/droidcon/TimeOfDayAssetRefresherTest.java
@@ -87,7 +87,6 @@ public class TimeOfDayAssetRefresherTest {
         verify(mockRender, times(1)).loadAssetsFor(DUSK);
     }
 
-
     @Test
     public void givenItsNight_whenReceivingBroadcast_thenNightAssetsAreLoaded() {
         givenItIs(NIGHT);


### PR DESCRIPTION
In this PR we are actually switching out the displaying assets of the time of day we want to load. Previously we were loading 3 different layers at the same time. Now we are only loading one each time (as the images are static)

For the purpose of the screenshot I am switching out each asset everytime the screen is on:

| Switching in action |
| --- | 
| ![wallapper](https://cloud.githubusercontent.com/assets/1665273/19498188/988f3bc4-9587-11e6-8cfc-2965d110e016.gif) |

_it looks better in person..._ :(