### PR TITLE
static-analysis-plugin/Checkstyle configuration improvements

### DIFF
--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
@@ -4,14 +4,19 @@ import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Checkstyle
+import org.gradle.api.plugins.quality.CheckstyleExtension
 import org.gradle.internal.logging.ConsoleRenderer
 
 class CheckstyleConfigurator {
 
     void configure(Project project, Violations violations, Task evaluateViolations) {
+        List<String> excludes = []
         project.apply plugin: 'checkstyle'
         project.checkstyle {
             toolVersion = '7.1.2'
+            ext.exclude = { String filter ->
+                excludes.addAll(filter)
+            }
         }
         project.afterEvaluate {
             boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
@@ -25,6 +30,7 @@ class CheckstyleConfigurator {
                 checkstyle.showViolations = false
                 checkstyle.ignoreFailures = true
                 checkstyle.metaClass.getLogger = { QuietLogger.INSTANCE }
+                checkstyle.exclude(excludes)
                 checkstyle.doLast {
                     File xmlReportFile = checkstyle.reports.xml.destination
                     File htmlReportFile = new File(xmlReportFile.absolutePath - '.xml' + '.html')

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PenaltyExtension.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PenaltyExtension.groovy
@@ -5,11 +5,11 @@ class PenaltyExtension {
     private int maxErrors = 0
 
     void maxErrors(int value) {
-        maxErrors = value
+        maxErrors = Math.max(0, value)
     }
 
     void maxWarnings(int value) {
-        maxWarnings = value
+        maxWarnings = Math.max(0, value)
     }
 
     int getMaxErrors() {

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/QuietLogger.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/QuietLogger.groovy
@@ -1,8 +1,8 @@
-package com.novoda.staticanalysis;
+package com.novoda.staticanalysis
 
-import org.gradle.api.logging.LogLevel;
-import org.gradle.api.logging.Logger;
-import org.slf4j.Marker;
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
+import org.slf4j.Marker
 
 class QuietLogger implements Logger {
 

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -1,6 +1,9 @@
 package com.novoda.staticanalysis
 
-import org.gradle.api.*
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
 
 class StaticAnalysisPlugin implements Plugin<Project> {
     private final CheckstyleConfigurator checkstyleConfigurator = new CheckstyleConfigurator()
@@ -14,7 +17,7 @@ class StaticAnalysisPlugin implements Plugin<Project> {
             task.penalty = extension.penalty
             task.allViolations = allViolations
         }
-        checkstyleConfigurator.configure(project, allViolations.create('Checkstyle'), evaluateViolations)
+        checkstyleConfigurator.configure(project, allViolations.create('Checkstyle'), extension, evaluateViolations)
         project.afterEvaluate {
             project.tasks['check'].dependsOn evaluateViolations
         }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleConfigurationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleConfigurationTest.groovy
@@ -26,117 +26,13 @@ public class CheckstyleConfigurationTest {
     }
 
     @Test
-    public void shouldNotFailBuildByDefaultWhenNoCheckstyleWarningsEncountered() {
-        TestProject.Result result = projectRule.newProject()
-                .build('check')
-
-        assertThat(result.logs).doesNotContainCheckstyleViolations()
-    }
-
-    @Test
-    public void shouldNotFailBuildByDefaultWhenCheckstyleWarningsEncountered() {
+    public void shouldFailBuildWhenCheckstyleWarningsOverTheThreshold() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .build('check')
-
-        assertThat(result.logs).containsCheckstyleViolations(0, 1,
-                result.buildFile('reports/checkstyle/main.html'))
-    }
-
-    @Test
-    public void shouldFailBuildByDefaultWhenCheckstyleErrorsEncountered() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .buildAndFail('check')
-
-        assertThat(result.logs).containsLimitExceeded(1, 0)
-        assertThat(result.logs).containsCheckstyleViolations(1, 1,
-                result.buildFile('reports/checkstyle/main.html'),
-                result.buildFile('reports/checkstyle/test.html'))
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenNoCheckstyleWarningsEncounteredAndNoPenalty() {
-        TestProject.Result result = projectRule.newProject()
-                .withPenalty('none')
-                .build('check')
-
-        assertThat(result.logs).doesNotContainCheckstyleViolations()
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenCheckstyleWarningsEncounteredAndNoPenalty() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withPenalty('none')
-                .build('check')
-
-        assertThat(result.logs).containsCheckstyleViolations(0, 1,
-                result.buildFile('reports/checkstyle/main.html'))
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenCheckstyleErrorsEncounteredAndNoPenalty() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withPenalty('none')
-                .build('check')
-
-        assertThat(result.logs).containsCheckstyleViolations(1, 1,
-                result.buildFile('reports/checkstyle/main.html'),
-                result.buildFile('reports/checkstyle/test.html'))
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenNoCheckstyleWarningsEncounteredAndPenaltyOnErrors() {
-        TestProject.Result result = projectRule.newProject()
-                .withPenalty('failOnErrors')
-                .build('check')
-
-        assertThat(result.logs).doesNotContainCheckstyleViolations()
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenCheckstyleWarningsEncounteredAndPenaltyOnErrors() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withPenalty('failOnErrors')
-                .build('check')
-
-        assertThat(result.logs).containsCheckstyleViolations(0, 1,
-                result.buildFile('reports/checkstyle/main.html'))
-    }
-
-    @Test
-    public void shouldFailBuildWhenCheckstyleErrorsEncounteredAndPenaltyOnErrors() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withPenalty('failOnErrors')
-                .buildAndFail('check')
-
-        assertThat(result.logs).containsLimitExceeded(1, 0)
-        assertThat(result.logs).containsCheckstyleViolations(1, 1,
-                result.buildFile('reports/checkstyle/main.html'),
-                result.buildFile('reports/checkstyle/test.html'))
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenNoCheckstyleWarningsEncounteredAndPenaltyOnWarnings() {
-        TestProject.Result result = projectRule.newProject()
-                .withPenalty('failOnWarnings')
-                .build('check')
-
-        assertThat(result.logs).doesNotContainCheckstyleViolations()
-    }
-
-    @Test
-    public void shouldFailBuildWhenCheckstyleWarningsEncounteredAndPenaltyOnWarnings() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withPenalty('failOnWarnings')
+                .withPenalty('''{
+                    maxWarnings 0
+                    maxErrors 0
+                }''')
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(0, 1)
@@ -145,32 +41,50 @@ public class CheckstyleConfigurationTest {
     }
 
     @Test
-    public void shouldFailBuildWhenCheckstyleErrorsEncounteredAndPenaltyOnWarnings() {
+    public void shouldFailBuildWhenCheckstyleErrorsOverTheThreshold() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withPenalty('failOnWarnings')
+                .withPenalty('''{
+                    maxWarnings 100
+                    maxErrors 0
+                }''')
                 .buildAndFail('check')
 
-        assertThat(result.logs).containsLimitExceeded(1, 1)
+        assertThat(result.logs).containsLimitExceeded(1, 0)
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
                 result.buildFile('reports/checkstyle/main.html'),
                 result.buildFile('reports/checkstyle/test.html'))
     }
 
     @Test
-    public void shouldNotFailBuildWhenCheckstyleErrorsEncounteredAndThresholdsNotReached() {
+    public void shouldNotFailBuildWhenNoCheckstyleWarningsOrErrorsEncounteredAndNoThresholdTrespassed() {
+        TestProject.Result result = projectRule.newProject()
+                .withPenalty('''{
+                    maxWarnings 0
+                    maxErrors 0
+                }''')
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).doesNotContainCheckstyleViolations()
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenCheckstyleWarningsAndErrorsEncounteredAndNoThresholdTrespassed() {
         TestProject.Result result = projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
                 .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
                 .withPenalty('''{
-        maxWarnings 1
-        maxErrors 1
+                    maxWarnings 100
+                    maxErrors 100
                 }''')
                 .build('check')
 
+        assertThat(result.logs).doesNotContainLimitExceeded()
         assertThat(result.logs).containsCheckstyleViolations(1, 1,
                 result.buildFile('reports/checkstyle/main.html'),
                 result.buildFile('reports/checkstyle/test.html'))
     }
+
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
@@ -126,4 +126,23 @@ public class CheckstyleIntegrationTest {
                 .build('check')
     }
 
+    @Test
+    public void shouldNotFailBuildWhenCheckstyleConfiguredIgnoreSourceSets() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
+                .withFile(Fixtures.Checkstyle.MODULES, 'config/checkstyle/checkstyle.xml')
+                .withPenalty('''{
+                    maxWarnings 1
+                    maxErrors 0
+                }''')
+                .withCheckstyle('''checkstyle {
+                    exclude 'Greeter.java'
+                }''')
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).containsCheckstyleViolations(0, 1,
+                result.buildFile('reports/checkstyle/main.html'))
+    }
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
@@ -11,7 +11,7 @@ import org.junit.runners.Parameterized
 import static com.novoda.test.LogsSubject.assertThat
 
 @RunWith(Parameterized.class)
-public class CheckstyleConfigurationTest {
+public class CheckstyleIntegrationTest {
 
     @Parameterized.Parameters
     public static List<Object[]> rules() {
@@ -21,7 +21,7 @@ public class CheckstyleConfigurationTest {
     @Rule
     public final TestProjectRule projectRule
 
-    public CheckstyleConfigurationTest(TestProjectRule projectRule) {
+    public CheckstyleIntegrationTest(TestProjectRule projectRule) {
         this.projectRule = projectRule
     }
 

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
@@ -160,6 +160,36 @@ public class CheckstyleIntegrationTest {
         assertThat(result.logs).doesNotContainCheckstyleViolations()
     }
 
+    @Test
+    public void shouldNotFailBuildWhenNoCheckstyleWarningsOrErrorsEncounteredAndNegativeThresholdsProvided() {
+        TestProject.Result result = projectRule.newProject()
+                .withPenalty('''{
+                    maxWarnings(-10)
+                    maxErrors(-10)
+                }''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).doesNotContainCheckstyleViolations()
+    }
+
+    @Test
+    public void shouldFailBuildWhenCheckstyleWarningsOrErrorsEncounteredAndNegativeThresholdsProvided() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
+                .withPenalty('''{
+                    maxWarnings(-10)
+                    maxErrors(-10)
+                }''')
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG))
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(0, 1)
+        assertThat(result.logs).containsCheckstyleViolations(0, 1,
+                result.buildFile('reports/checkstyle/main.html'))
+    }
+
 
     private static String checkstyle(String configFile, String... configs) {
         """checkstyle {

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PenaltyExtensionTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PenaltyExtensionTest.groovy
@@ -1,0 +1,88 @@
+package com.novoda.staticanalysis
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static com.novoda.test.PenaltyExtensionSubject.assertThat
+
+class PenaltyExtensionTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    private Project project
+
+    @Before
+    public void setUp() throws Exception {
+        project = ProjectBuilder.builder()
+                .withProjectDir(temporaryFolder.newFolder())
+                .build()
+        project.apply plugin: StaticAnalysisPlugin
+    }
+
+    @Test
+    public void shouldUseFailOnErrorsPenaltyThresholdsByDefault() {
+        project.staticAnalysis {}
+
+        PenaltyExtension penaltyExtension = project.staticAnalysis.penalty
+
+        assertThat(penaltyExtension).hasMaxErrors(0)
+        assertThat(penaltyExtension).hasMaxWarnings(Integer.MAX_VALUE)
+    }
+
+    @Test
+    public void shouldUseCorrectThresholdsWhenPenaltyNone() {
+        project.staticAnalysis {
+            penalty none
+        }
+
+        PenaltyExtension penaltyExtension = project.staticAnalysis.penalty
+
+        assertThat(penaltyExtension).hasMaxErrors(Integer.MAX_VALUE)
+        assertThat(penaltyExtension).hasMaxWarnings(Integer.MAX_VALUE)
+    }
+
+    @Test
+    public void shouldUseCorrectThresholdsWhenPenaltyFailOnErrors() {
+        project.staticAnalysis {
+            penalty failOnErrors
+        }
+
+        PenaltyExtension penaltyExtension = project.staticAnalysis.penalty
+
+        assertThat(penaltyExtension).hasMaxErrors(0)
+        assertThat(penaltyExtension).hasMaxWarnings(Integer.MAX_VALUE)
+    }
+
+    @Test
+    public void shouldUseCorrectThresholdsWhenPenaltyFailOnWarnings() {
+        project.staticAnalysis {
+            penalty failOnWarnings
+        }
+
+        PenaltyExtension penaltyExtension = project.staticAnalysis.penalty
+
+        assertThat(penaltyExtension).hasMaxWarnings(0)
+        assertThat(penaltyExtension).hasMaxErrors(0)
+    }
+
+    @Test
+    public void shouldUseCorrectThresholdsWhenCustomPenaltySpecified() {
+        project.staticAnalysis {
+            penalty {
+                maxWarnings 100
+                maxErrors 10
+            }
+        }
+
+        PenaltyExtension penaltyExtension = project.staticAnalysis.penalty
+
+        assertThat(penaltyExtension).hasMaxWarnings(100)
+        assertThat(penaltyExtension).hasMaxErrors(10)
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PenaltyExtensionTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PenaltyExtensionTest.groovy
@@ -85,4 +85,19 @@ class PenaltyExtensionTest {
         assertThat(penaltyExtension).hasMaxErrors(10)
     }
 
+    @Test
+    public void shouldFailWhenCustomPenaltySpecifiedWithInvalidThresholds() {
+        project.staticAnalysis {
+            penalty {
+                maxWarnings(-100)
+                maxErrors(-100)
+            }
+        }
+
+        PenaltyExtension penaltyExtension = project.staticAnalysis.penalty
+
+        assertThat(penaltyExtension).hasMaxWarnings(0)
+        assertThat(penaltyExtension).hasMaxErrors(0)
+    }
+
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -41,7 +41,7 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
 
     public void containsCheckstyleViolations(int errors, int warnings, File... reports) {
         def output = Truth.assertThat(actual().output)
-        output.contains( "$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
+        output.contains("$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
         for (File report : reports) {
             output.contains(report.path)
         }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -10,15 +10,8 @@ import javax.annotation.Nullable
 import static com.novoda.test.TestProject.Result.Logs;
 
 class LogsSubject extends Subject<LogsSubject, Logs> {
-    private static final Closure<String> LIMIT_EXCEEDED_LOG = { int errors, int warnings ->
-        "Violations limit exceeded by $errors errors, $warnings warnings."
-    }
-    private static final String CHECKSTYLE_FAILURE_LOG = "Checkstyle rule violations were found"
-    private static final Closure<String> CHECKSTYLE_VIOLATIONS_LOG = { int errors, int warnings, String... reports ->
-        CHECKSTYLE_FAILURE_LOG +
-                " ($errors errors, $warnings warnings). See the reports at:\n" +
-                "${reports.collect { "- $it" }.join('\n')}"
-    }
+    private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
+    private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle rule violations were found"
     private static final SubjectFactory<LogsSubject, Logs> FACTORY = new SubjectFactory<LogsSubject, Logs>() {
         @Override
         LogsSubject getSubject(FailureStrategy failureStrategy, Logs logs) {
@@ -34,19 +27,23 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
         super(failureStrategy, actual)
     }
 
+    public void doesNotContainLimitExceeded() {
+        Truth.assertThat(actual().output).doesNotContain(VIOLATIONS_LIMIT_EXCEEDED)
+    }
+
     public void containsLimitExceeded(int errors, int warnings) {
-        Truth.assertThat(actual().output).contains(LIMIT_EXCEEDED_LOG(errors, warnings))
+        Truth.assertThat(actual().output).contains("$VIOLATIONS_LIMIT_EXCEEDED by $errors errors, $warnings warnings.")
+    }
+
+    public void doesNotContainCheckstyleViolations() {
+        Truth.assertThat(actual().output).doesNotContain(CHECKSTYLE_VIOLATIONS_FOUND)
     }
 
     public void containsCheckstyleViolations(int errors, int warnings, File... reports) {
         def output = Truth.assertThat(actual().output)
-        output.contains(CHECKSTYLE_VIOLATIONS_LOG(errors, warnings))
+        output.contains( "$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
         for (File report : reports) {
             output.contains(report.path)
         }
-    }
-
-    public void doesNotContainCheckstyleViolations() {
-        Truth.assertThat(actual().output).doesNotContain(CHECKSTYLE_FAILURE_LOG)
     }
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/PenaltyExtensionSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/PenaltyExtensionSubject.groovy
@@ -13,6 +13,7 @@ import static com.google.common.truth.Truth.assertThat;
 class PenaltyExtensionSubject extends Subject<PenaltyExtensionSubject, PenaltyExtension> {
 
     private static final SubjectFactory<PenaltyExtensionSubject, PenaltyExtension> FACTORY = newFactory()
+
     private static SubjectFactory<PenaltyExtensionSubject, PenaltyExtension> newFactory() {
         new SubjectFactory<PenaltyExtensionSubject, PenaltyExtension>() {
             @Override

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/PenaltyExtensionSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/PenaltyExtensionSubject.groovy
@@ -1,0 +1,41 @@
+package com.novoda.test
+
+import com.google.common.truth.FailureStrategy
+import com.google.common.truth.Subject
+import com.google.common.truth.SubjectFactory
+import com.novoda.staticanalysis.PenaltyExtension
+
+import javax.annotation.Nullable
+
+import static com.google.common.truth.Truth.assertAbout
+import static com.google.common.truth.Truth.assertThat;
+
+class PenaltyExtensionSubject extends Subject<PenaltyExtensionSubject, PenaltyExtension> {
+
+    private static final SubjectFactory<PenaltyExtensionSubject, PenaltyExtension> FACTORY = newFactory()
+    private static SubjectFactory<PenaltyExtensionSubject, PenaltyExtension> newFactory() {
+        new SubjectFactory<PenaltyExtensionSubject, PenaltyExtension>() {
+            @Override
+            PenaltyExtensionSubject getSubject(FailureStrategy failureStrategy, PenaltyExtension extension) {
+                new PenaltyExtensionSubject(failureStrategy, extension)
+            }
+        }
+    }
+
+    private PenaltyExtensionSubject(FailureStrategy failureStrategy, @Nullable PenaltyExtension actual) {
+        super(failureStrategy, actual)
+    }
+
+    public static PenaltyExtensionSubject assertThat(PenaltyExtension extension) {
+        assertAbout(FACTORY).that(extension)
+    }
+
+    public void hasMaxWarnings(int maxWarnings) {
+        assertThat(actual().maxWarnings).isEqualTo(maxWarnings)
+    }
+
+    public void hasMaxErrors(int maxErrors) {
+        assertThat(actual().maxErrors).isEqualTo(maxErrors)
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -45,7 +45,7 @@ ${formatExtension(project)}
         project.sourceSets
                 .entrySet()
                 .collect { Map.Entry<String, List<String>> entry ->
-        """$entry.key {
+            """$entry.key {
             manifest.srcFile '${Fixtures.ANDROID_MANIFEST}'
             java {
                 ${entry.value.collect { "srcDir '$it'" }.join('\n\t\t\t\t')}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -38,7 +38,7 @@ ${formatExtension(project)}
 
     TestAndroidProject() {
         super(TEMPLATE)
-        copyFile(Fixtures.LOCAL_PROPERTIES, 'local.properties')
+        withFile(Fixtures.LOCAL_PROPERTIES, 'local.properties')
     }
 
     private static String formatSourceSets(TestProject project) {

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -8,7 +8,7 @@ abstract class TestProject {
         """
 staticAnalysis {
     ${(project.penalty ?: '').replace('            ', '')}
-    ${(project.checkstyle ?: '').replace('            ', '')}
+    ${(project.checkstyle ?: '').replace('        ', '    ')}
 }
 """
     }
@@ -79,9 +79,7 @@ staticAnalysis {
     }
 
     private GradleRunner newRunner(String... arguments) {
-        if (checkstyle == null) {
-            withFile(Fixtures.Checkstyle.MODULES, 'config/checkstyle/checkstyle.xml')
-        }
+        withFile(Fixtures.Checkstyle.MODULES, 'config/checkstyle/checkstyle.xml')
         new File(projectDir, 'build.gradle').text = template.call(this)
         List<String> defaultArgs = defaultArguments()
         List<String> args = new ArrayList<>(arguments.size() + defaultArgs.size())


### PR DESCRIPTION
This PR focuses on improving the Checkstyle support in the `static-analysis-plugin`:
- It's now possible to specify a configuration file detailing the Checkstyle modules for the static analysis. To achieve so it's just needed to use the [`config`](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.Checkstyle.html#org.gradle.api.plugins.quality.Checkstyle:config)/[`configFile`](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.Checkstyle.html#org.gradle.api.plugins.quality.Checkstyle:configFile) property in the checkstyle extension, eg:
```gradle
staticAnalysis {
    checkstyle {
        configFile project.file('foo.xml')
    }
}
```
- To allow to easily exclude files from the analysis the original checkstyle extension has been extended with a `exclude` method that accepts a filter string, eg:
```gradle
staticAnalsysis {
    checkstyle {
        exclude '**Test.java'
    }
}
```
- It's possible to disable checkstyle analysis just avoiding to specify any `checkstyle` configuration closure in the buildscript

Incidentally the integration tests validating the checkstyle analysis output have been simplified, avoiding to mention the built-in penalties, tested separately in `PenaltyExtensionTest` instead.