### PR TITLE
Drop cap fixes

### DIFF
--- a/drop-cap/README.md
+++ b/drop-cap/README.md
@@ -29,14 +29,16 @@ dependencies {
 Simply add `DropCapView` to one of your layout xml files and use the following xml attributes for customization.
 
 ```
-  <attr name="lineSpacingExtra" format="dimension" />
-  <attr name="dropCapTextSize" format="dimension" />
-  <attr name="dropCapTextColor" format="color" />
-  <attr name="dropCapFontPath" format="string" />
+    <attr name="lineSpacingExtra" format="dimension" />
+    <attr name="dropCapTextSize" format="dimension" />
+    <attr name="dropCapTextColor" format="color" />
+    <attr name="dropCapFontPath" format="string" />
 
-  <attr name="copyTextSize" format="dimension" />
-  <attr name="copyTextColor" format="color" />
-  <attr name="copyFontPath" format="string" />
+    <attr name="copyTextSize" format="dimension" />
+    <attr name="copyTextColor" format="color" />
+    <attr name="copyFontPath" format="string" />
+
+    <attr name="android:text" />
 ```
 
 For ease of use the `DropCapView` uses the `android:text` attribute to specify text via the xml layout.

--- a/drop-cap/README.md
+++ b/drop-cap/README.md
@@ -2,7 +2,10 @@
 
 This library can be used to create a DropCap in your app!
 
-![drop_cap](https://cloud.githubusercontent.com/assets/3380092/12559924/bf2a7ff2-c38f-11e5-927f-c2b7e4993390.png)
+
+| DropCap | Not enough lines to wrap DropCap |
+| ------ | ----- |
+![drop_cap](https://cloud.githubusercontent.com/assets/3380092/20004464/638380e8-a284-11e6-8c35-6c473069cd4d.png) | ![not_enough_text](https://cloud.githubusercontent.com/assets/3380092/20004465/6385c7d6-a284-11e6-875e-b1647968865b.png)
 
 ## Description
 

--- a/drop-cap/README.md
+++ b/drop-cap/README.md
@@ -39,6 +39,9 @@ Simply add `DropCapView` to one of your layout xml files and use the following x
   <attr name="copyFontPath" format="string" />
 ```
 
+For ease of use the `DropCapView` uses the `android:text` attribute to specify text via the xml layout.
+
+
 For further usage or to delve more deeply checkout the associated [`sample`](https://github.com/novoda/spikes/tree/master/drop-cap/sample) app. 
 
 ## Links

--- a/drop-cap/README.md
+++ b/drop-cap/README.md
@@ -10,6 +10,9 @@ This library can be used to create a DropCap in your app! A DropCap is the first
 bigger size than the rest that follow. The formatting is such that the DropCap spans (drops down) to cover the few lines
 following the first.
 
+If there are not enough lines to wrap the `DropCap` then the style on the first character will default to the style
+of the copy text. This styling is to keep the text consist when a `DropCap` is not present.
+
 ## Adding to your project
 
 To start using this library, add these lines to the `build.gradle` of your project:

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -260,7 +260,12 @@ public class DropCapView extends View {
         int widthWithoutPadding = totalWidth - horizontalPadding;
 
         measureDropCapFor(widthWithoutPadding);
-        measureCopyFor(widthWithoutPadding);
+
+        if (enoughLinesForDropCap()) {
+            measureRemainingCopyFor(totalWidth);
+        } else {
+            measureWholeTextFor(totalWidth);
+        }
 
         int desiredHeight = dropCapLineHeight + copyStaticLayout.getHeight() + getPaddingTop() + getPaddingBottom();
         int desiredHeightMeasureSpec = MeasureSpec.makeMeasureSpec(desiredHeight, MeasureSpec.EXACTLY);
@@ -307,38 +312,37 @@ public class DropCapView extends View {
         dropCapLineHeight = currentLineTop;
     }
 
-    private void measureCopyFor(int totalWidth) {
-        if (enoughLinesForDropCap()) {
-            int lineStart = dropCapStaticLayout.getLineEnd(numberOfLinesToSpan - 1);
-            int lineEnd = dropCapStaticLayout.getText().length();
-            String remainingText = String.valueOf(dropCapStaticLayout.getText().subSequence(lineStart, lineEnd));
+    private void measureRemainingCopyFor(int totalWidth) {
+        int lineStart = dropCapStaticLayout.getLineEnd(numberOfLinesToSpan - 1);
+        int lineEnd = dropCapStaticLayout.getText().length();
+        String remainingText = String.valueOf(dropCapStaticLayout.getText().subSequence(lineStart, lineEnd));
 
-            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || !remainingText.equals(copyStaticLayout.getText())) {
-                copyStaticLayout = new StaticLayout(
-                        remainingText,
-                        copyTextPaint,
-                        totalWidth,
-                        Layout.Alignment.ALIGN_NORMAL,
-                        SPACING_MULTIPLIER,
-                        lineSpacingExtra,
-                        true
-                );
+        if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || !remainingText.equals(copyStaticLayout.getText())) {
+            copyStaticLayout = new StaticLayout(
+                    remainingText,
+                    copyTextPaint,
+                    totalWidth,
+                    Layout.Alignment.ALIGN_NORMAL,
+                    SPACING_MULTIPLIER,
+                    lineSpacingExtra,
+                    true
+            );
 
-                distanceFromViewPortTop = calculateCopyDistanceFromViewPortTop();
-            }
+            distanceFromViewPortTop = calculateCopyDistanceFromViewPortTop();
+        }
+    }
 
-        } else {
-            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth) {
-                copyStaticLayout = new StaticLayout(
-                        dropCapText + copyText,
-                        copyTextPaint,
-                        totalWidth,
-                        Layout.Alignment.ALIGN_NORMAL,
-                        SPACING_MULTIPLIER,
-                        lineSpacingExtra,
-                        true
-                );
-            }
+    private void measureWholeTextFor(int totalWidth) {
+        if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth) {
+            copyStaticLayout = new StaticLayout(
+                    dropCapText + copyText,
+                    copyTextPaint,
+                    totalWidth,
+                    Layout.Alignment.ALIGN_NORMAL,
+                    SPACING_MULTIPLIER,
+                    lineSpacingExtra,
+                    true
+            );
         }
     }
 

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -10,6 +10,7 @@ import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.View;
 
 public class DropCapView extends View {
@@ -146,12 +147,21 @@ public class DropCapView extends View {
         invalidate();
     }
 
-    public void setDropCapTextSize(float textSizePx) {
-        if (textSizePx == dropCapPaint.getTextSize()) {
+    public void setDropCapTextSize(float textSizeSp) {
+        setDropCapTextSize(TypedValue.COMPLEX_UNIT_SP, textSizeSp);
+    }
+
+    public void setDropCapTextSize(int unit, float size) {
+        float sizeForDisplay = TypedValue.applyDimension(unit, size, getResources().getDisplayMetrics());
+        setRawDropCapTextSize(sizeForDisplay);
+    }
+
+    private void setRawDropCapTextSize(float size) {
+        if (size == dropCapPaint.getTextSize()) {
             return;
         }
 
-        dropCapPaint.setTextSize(textSizePx);
+        dropCapPaint.setTextSize(size);
         hasPaintChanged = true;
         requestLayout();
         invalidate();

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -115,7 +115,7 @@ public class DropCapView extends View {
         dropCapPaint.setAntiAlias(true);
         dropCapPaint.setSubpixelText(true);
 
-        performRemeasureAndRedraw();
+        remeasureAndRedraw();
     }
 
     public void setCopyFontType(String fontPath) {
@@ -128,7 +128,7 @@ public class DropCapView extends View {
         copyTextPaint.setAntiAlias(true);
         copyTextPaint.setSubpixelText(true);
 
-        performRemeasureAndRedraw();
+        remeasureAndRedraw();
     }
 
     public void setDropCapTextSize(float textSizeSp) {
@@ -147,7 +147,7 @@ public class DropCapView extends View {
 
         dropCapPaint.setTextSize(size);
 
-        performRemeasureAndRedraw();
+        remeasureAndRedraw();
     }
 
     public float getDropCapTextSize() {
@@ -185,7 +185,7 @@ public class DropCapView extends View {
 
         copyTextPaint.setTextSize(size);
 
-        performRemeasureAndRedraw();
+        remeasureAndRedraw();
     }
 
     public float getCopyTextSize() {
@@ -220,10 +220,10 @@ public class DropCapView extends View {
             copyText = (text == null) ? "" : text;
         }
 
-        performRemeasureAndRedraw();
+        remeasureAndRedraw();
     }
 
-    private void performRemeasureAndRedraw() {
+    private void remeasureAndRedraw() {
         if (dropCapStaticLayout != null || copyStaticLayout != null) {
             copyStaticLayout = null;
             dropCapStaticLayout = null;

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -36,6 +36,7 @@ public class DropCapView extends View {
     private int dropCapWidth;
     private int dropCapLineHeight;
     private float dropCapBaseline;
+    private float distanceFromViewPortTop;
 
     private boolean hasPaintChanged;
     private boolean textHasChanged;
@@ -282,8 +283,7 @@ public class DropCapView extends View {
                         true
                 );
 
-                float translateBy = getCopyDistanceFromViewPortTop();
-                dropCapBaseline = dropCapBaseline + translateBy;
+                distanceFromViewPortTop = calculateCopyDistanceFromViewPortTop();
             }
 
         } else {
@@ -305,7 +305,7 @@ public class DropCapView extends View {
         return dropCapStaticLayout.getLineCount() > numberOfLinesToSpan && numberOfLinesToSpan > 0;
     }
 
-    private float getCopyDistanceFromViewPortTop() {
+    private float calculateCopyDistanceFromViewPortTop() {
         copyTextPaint.getTextBounds("d", 0, 1, characterBounds);
         float dHeight = characterBounds.height();
         float lineBaseline = copyStaticLayout.getLineBaseline(0);
@@ -346,7 +346,8 @@ public class DropCapView extends View {
     }
 
     private void drawDropCap(Canvas canvas) {
-        canvas.drawText(dropCapStaticLayout.getText(), 0, 1, getPaddingLeft(), dropCapBaseline, dropCapPaint);
+        float dropCapBaselineFromViewPortTop = dropCapBaseline + distanceFromViewPortTop;
+        canvas.drawText(dropCapStaticLayout.getText(), 0, 1, getPaddingLeft(), dropCapBaselineFromViewPortTop, dropCapPaint);
     }
 
     private void drawCopyForDropCap(Canvas canvas) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -39,6 +39,7 @@ public class DropCapView extends View {
 
     private boolean shouldDisplayDropCap;
     private boolean hasPaintChanged;
+    private boolean textHasChanged;
 
     public DropCapView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
@@ -186,6 +187,10 @@ public class DropCapView extends View {
     }
 
     public void setText(String text) {
+        if (text != null) {
+            textHasChanged = !text.equals(dropCapText + copyText);
+        }
+
         if (enoughTextForDropCap(text)) {
             dropCapText = String.valueOf(text.charAt(0));
             copyText = String.valueOf(text.subSequence(1, text.length()));
@@ -226,7 +231,7 @@ public class DropCapView extends View {
         int copyWidthForDropCap = width - dropCapWidth;
 
         if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != copyWidthForDropCap
-                || hasPaintChanged || copyTextIsDifferent()) {
+                || hasPaintChanged || textHasChanged) {
             dropCapStaticLayout = new StaticLayout(
                     dropCapText + copyText,
                     copyTextPaint,
@@ -285,7 +290,7 @@ public class DropCapView extends View {
             dropCapBaseline = dropCapBaseline + translateBy;
 
         } else {
-            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || copyTextIsDifferent()) {
+            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || textHasChanged) {
                 copyStaticLayout = new StaticLayout(
                         dropCapText + copyText,
                         copyTextPaint,
@@ -310,10 +315,6 @@ public class DropCapView extends View {
         return lineBaseline - dHeight;
     }
 
-    private boolean copyTextIsDifferent() {
-        return !copyStaticLayout.getText().equals(dropCapText + copyText);
-    }
-
     @Override
     protected void onDraw(Canvas canvas) {
         if (shouldDisplayDropCap && enoughLinesForDropCap()) {
@@ -323,7 +324,9 @@ public class DropCapView extends View {
         } else {
             drawCopyWithoutDropCap(canvas);
         }
+        shouldDisplayDropCap = false;
         hasPaintChanged = false;
+        textHasChanged = false;
     }
 
     private void drawCopyWithoutDropCap(Canvas canvas) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -14,6 +14,11 @@ import android.view.View;
 
 public class DropCapView extends View {
 
+    private static final int TEXT_SET_INDEX = 0;
+    private static final int[] androidAttributeSet = {
+            android.R.attr.text
+    };
+
     private static final float SPACING_MULTIPLIER = 1.0f;
 
     private final TextPaint dropCapPaint = new TextPaint();
@@ -94,11 +99,20 @@ public class DropCapView extends View {
 
             copyTextPaint.setTextSize(copyTextSize);
             copyTextPaint.setColor(copyTextColor);
-
-            String text = typedArray.getString(R.styleable.DropCapView_text);
-            setText(text);
         } finally {
             typedArray.recycle();
+        }
+
+        TypedArray androidTypedArray = context.obtainStyledAttributes(attrs, androidAttributeSet);
+        if (androidTypedArray == null) {
+            return;
+        }
+
+        try {
+            String text = typedArray.getString(TEXT_SET_INDEX);
+            setText(text);
+        } finally {
+            androidTypedArray.recycle();
         }
     }
 

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -348,8 +348,8 @@ public class DropCapView extends View {
     }
 
     private void drawDropCap(Canvas canvas) {
-        float dropCapBaselineFromViewPortTop = dropCapBaseline + distanceFromViewPortTop;
-        canvas.drawText(dropCapStaticLayout.getText(), 0, 1, getPaddingLeft(), dropCapBaselineFromViewPortTop, dropCapPaint);
+        float dropCapBaselineFromCopyTop = dropCapBaseline + distanceFromViewPortTop;
+        canvas.drawText(dropCapStaticLayout.getText(), 0, 1, getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
     }
 
     private void drawCopyForDropCap(Canvas canvas) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -146,12 +146,12 @@ public class DropCapView extends View {
         invalidate();
     }
 
-    public void setDropCapTextSize(float textSize) {
-        if (textSize == dropCapPaint.getTextSize()) {
+    public void setDropCapTextSize(float textSizePx) {
+        if (textSizePx == dropCapPaint.getTextSize()) {
             return;
         }
 
-        dropCapPaint.setTextSize(textSize);
+        dropCapPaint.setTextSize(textSizePx);
         hasPaintChanged = true;
         requestLayout();
         invalidate();
@@ -176,12 +176,12 @@ public class DropCapView extends View {
         return copyTextPaint.getColor();
     }
 
-    public void setCopyTextSize(float textSize) {
-        if (textSize == copyTextPaint.getTextSize()) {
+    public void setCopyTextSize(float textSizePx) {
+        if (textSizePx == copyTextPaint.getTextSize()) {
             return;
         }
 
-        copyTextPaint.setTextSize(textSize);
+        copyTextPaint.setTextSize(textSizePx);
         hasPaintChanged = true;
         requestLayout();
         invalidate();

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -95,6 +95,8 @@ public class DropCapView extends View {
             copyTextPaint.setTextSize(copyTextSize);
             copyTextPaint.setColor(copyTextColor);
 
+            String text = typedArray.getString(R.styleable.DropCapView_text);
+            setText(text);
         } finally {
             typedArray.recycle();
         }

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -6,7 +6,6 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.support.annotation.ColorInt;
-import android.support.annotation.DimenRes;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
@@ -238,15 +237,7 @@ public class DropCapView extends View {
                     true
             );
 
-            int currentLineTop = 0;
-            for (int i = 0; i < dropCapStaticLayout.getLineCount(); i++) {
-                currentLineTop = dropCapStaticLayout.getLineTop(i);
-                if (currentLineTop >= dropCapBounds.height()) {
-                    numberOfLinesToSpan = i;
-                    i = dropCapStaticLayout.getLineCount();
-                }
-            }
-            dropCapLineHeight = currentLineTop;
+            calculateLinesToSpan();
         }
 
         if (numberOfLinesToSpan < 1) {
@@ -256,6 +247,20 @@ public class DropCapView extends View {
 
         float baseline = dropCapBounds.height() + getPaddingTop();
         dropCapBaseline = baseline - dropCapBounds.bottom;
+    }
+
+    private void calculateLinesToSpan() {
+        int currentLineTop = 0;
+        numberOfLinesToSpan = 0;
+
+        for (int i = 0; i < dropCapStaticLayout.getLineCount(); i++) {
+            currentLineTop = dropCapStaticLayout.getLineTop(i);
+            if (currentLineTop >= dropCapBounds.height()) {
+                numberOfLinesToSpan = i;
+                i = dropCapStaticLayout.getLineCount();
+            }
+        }
+        dropCapLineHeight = currentLineTop;
     }
 
     private void measureCopyFor(int totalWidth) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -297,7 +297,7 @@ public class DropCapView extends View {
     }
 
     private boolean enoughLinesForDropCap() {
-        return dropCapStaticLayout.getLineCount() > numberOfLinesToSpan;
+        return dropCapStaticLayout.getLineCount() > numberOfLinesToSpan && numberOfLinesToSpan > 0;
     }
 
     private float getCopyDistanceFromViewPortTop() {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -186,12 +186,21 @@ public class DropCapView extends View {
         return copyTextPaint.getColor();
     }
 
-    public void setCopyTextSize(float textSizePx) {
-        if (textSizePx == copyTextPaint.getTextSize()) {
+    public void setCopyTextSize(float textSizeSp) {
+        setCopyTextSize(TypedValue.COMPLEX_UNIT_SP, textSizeSp);
+    }
+
+    public void setCopyTextSize(int unit, float size) {
+        float sizeForDisplay = TypedValue.applyDimension(unit, size, getResources().getDisplayMetrics());
+        setRawCopyTextSize(sizeForDisplay);
+    }
+
+    private void setRawCopyTextSize(float size) {
+        if (size == copyTextPaint.getTextSize()) {
             return;
         }
 
-        copyTextPaint.setTextSize(textSizePx);
+        copyTextPaint.setTextSize(size);
         hasPaintChanged = true;
         requestLayout();
         invalidate();

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -124,14 +124,7 @@ public class DropCapView extends View {
         dropCapPaint.setAntiAlias(true);
         dropCapPaint.setSubpixelText(true);
 
-        nullLayouts();
-        requestLayout();
-        invalidate();
-    }
-
-    private void nullLayouts() {
-        copyStaticLayout = null;
-        dropCapStaticLayout = null;
+        performRemeasureAndRedraw();
     }
 
     public void setCopyFontType(String fontPath) {
@@ -144,9 +137,7 @@ public class DropCapView extends View {
         copyTextPaint.setAntiAlias(true);
         copyTextPaint.setSubpixelText(true);
 
-        nullLayouts();
-        requestLayout();
-        invalidate();
+        performRemeasureAndRedraw();
     }
 
     public void setDropCapTextSize(float textSizeSp) {
@@ -165,9 +156,7 @@ public class DropCapView extends View {
 
         dropCapPaint.setTextSize(size);
 
-        nullLayouts();
-        requestLayout();
-        invalidate();
+        performRemeasureAndRedraw();
     }
 
     public float getDropCapTextSize() {
@@ -180,6 +169,7 @@ public class DropCapView extends View {
         }
 
         dropCapPaint.setColor(color);
+
         invalidate();
     }
 
@@ -204,9 +194,7 @@ public class DropCapView extends View {
 
         copyTextPaint.setTextSize(size);
 
-        nullLayouts();
-        requestLayout();
-        invalidate();
+        performRemeasureAndRedraw();
     }
 
     public float getCopyTextSize() {
@@ -219,6 +207,7 @@ public class DropCapView extends View {
         }
 
         copyTextPaint.setColor(color);
+
         invalidate();
     }
 
@@ -240,9 +229,16 @@ public class DropCapView extends View {
             copyText = (text == null) ? "" : text;
         }
 
-        nullLayouts();
-        requestLayout();
-        invalidate();
+        performRemeasureAndRedraw();
+    }
+
+    private void performRemeasureAndRedraw() {
+        if (dropCapStaticLayout != null || copyStaticLayout != null) {
+            copyStaticLayout = null;
+            dropCapStaticLayout = null;
+            requestLayout();
+            invalidate();
+        }
     }
 
     private boolean isSameText(String text) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -64,39 +64,30 @@ public class DropCapView extends View {
 
         try {
             String dropCapFontPath = typedArray.getString(R.styleable.DropCapView_dropCapFontPath);
-            Typeface dropCapTypeface = typefaceFactory.createFrom(context, dropCapFontPath);
+            setDropCapFontType(dropCapFontPath);
 
             String copyFontPath = typedArray.getString(R.styleable.DropCapView_copyFontPath);
-            Typeface copyTypeface = typefaceFactory.createFrom(context, copyFontPath);
-
-            dropCapPaint.setTypeface(dropCapTypeface);
-            dropCapPaint.setAntiAlias(true);
-            dropCapPaint.setSubpixelText(true);
-
-            copyTextPaint.setTypeface(copyTypeface);
-            copyTextPaint.setAntiAlias(true);
-            copyTextPaint.setSubpixelText(true);
+            setCopyFontType(copyFontPath);
 
             int defaultLineSpacingExtra = 0;
             lineSpacingExtra = typedArray.getDimensionPixelSize(R.styleable.DropCapView_lineSpacingExtra, defaultLineSpacingExtra);
 
             int dropCapDefaultTextSize = getResources().getDimensionPixelSize(R.dimen.drop_cap_default_text_size);
             int dropCapTextSize = typedArray.getDimensionPixelSize(R.styleable.DropCapView_dropCapTextSize, dropCapDefaultTextSize);
+            setDropCapTextSize(TypedValue.COMPLEX_UNIT_PX, dropCapTextSize);
 
             int dropCapDefaultTextColor = getResources().getColor(R.color.drop_cap_default_text);
             int dropCapTextColor = typedArray.getColor(R.styleable.DropCapView_dropCapTextColor, dropCapDefaultTextColor);
+            setDropCapTextColor(dropCapTextColor);
 
             int copyDefaultTextSize = getResources().getDimensionPixelSize(R.dimen.drop_cap_copy_default_text_size);
             int copyTextSize = typedArray.getDimensionPixelSize(R.styleable.DropCapView_copyTextSize, copyDefaultTextSize);
+            setCopyTextSize(TypedValue.COMPLEX_UNIT_PX, copyTextSize);
 
             int copyDefaultTextColor = getResources().getColor(R.color.drop_cap_copy_default_text);
             int copyTextColor = typedArray.getColor(R.styleable.DropCapView_copyTextColor, copyDefaultTextColor);
+            setCopyTextColor(copyTextColor);
 
-            dropCapPaint.setTextSize(dropCapTextSize);
-            dropCapPaint.setColor(dropCapTextColor);
-
-            copyTextPaint.setTextSize(copyTextSize);
-            copyTextPaint.setColor(copyTextColor);
         } finally {
             typedArray.recycle();
         }

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -238,12 +238,12 @@ public class DropCapView extends View {
             );
 
             calculateLinesToSpan();
-        }
 
+            if (enoughLinesForDropCap()) {
+                float baseline = dropCapBounds.height() + getPaddingTop();
+                dropCapBaseline = baseline - dropCapBounds.bottom;
+            }
         }
-
-        float baseline = dropCapBounds.height() + getPaddingTop();
-        dropCapBaseline = baseline - dropCapBounds.bottom;
     }
 
     private void calculateLinesToSpan() {
@@ -276,10 +276,10 @@ public class DropCapView extends View {
                         lineSpacingExtra,
                         true
                 );
-            }
 
-            float translateBy = getCopyDistanceFromViewPortTop();
-            dropCapBaseline = dropCapBaseline + translateBy;
+                float translateBy = getCopyDistanceFromViewPortTop();
+                dropCapBaseline = dropCapBaseline + translateBy;
+            }
 
         } else {
             if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || textHasChanged) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -128,7 +128,7 @@ public class DropCapView extends View {
         requestLayout();
     }
 
-    public void setDropCapTextSize(@DimenRes float textSize) {
+    public void setDropCapTextSize(float textSize) {
         if (textSize == dropCapPaint.getTextSize()) {
             return;
         }
@@ -157,7 +157,7 @@ public class DropCapView extends View {
         return copyTextPaint.getColor();
     }
 
-    public void setCopyTextSize(@DimenRes float textSize) {
+    public void setCopyTextSize(float textSize) {
         if (textSize == copyTextPaint.getTextSize()) {
             return;
         }

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -37,7 +37,6 @@ public class DropCapView extends View {
     private int dropCapLineHeight;
     private float dropCapBaseline;
 
-    private boolean shouldDisplayDropCap;
     private boolean hasPaintChanged;
     private boolean textHasChanged;
 
@@ -194,11 +193,9 @@ public class DropCapView extends View {
         if (enoughTextForDropCap(text)) {
             dropCapText = String.valueOf(text.charAt(0));
             copyText = String.valueOf(text.subSequence(1, text.length()));
-            shouldDisplayDropCap = true;
         } else {
             dropCapText = String.valueOf('\0');
             copyText = (text == null) ? "" : text;
-            shouldDisplayDropCap = false;
         }
         requestLayout();
         invalidate();
@@ -214,10 +211,7 @@ public class DropCapView extends View {
         int horizontalPadding = getPaddingLeft() + getPaddingRight();
         int widthWithoutPadding = totalWidth - horizontalPadding;
 
-        if (shouldDisplayDropCap) {
-            measureDropCapFor(widthWithoutPadding);
-        }
-
+        measureDropCapFor(widthWithoutPadding);
         measureCopyFor(widthWithoutPadding);
 
         int desiredHeight = dropCapLineHeight + copyStaticLayout.getHeight() + getPaddingTop() + getPaddingBottom();
@@ -246,9 +240,6 @@ public class DropCapView extends View {
             calculateLinesToSpan();
         }
 
-        if (numberOfLinesToSpan < 1) {
-            shouldDisplayDropCap = false;
-            return;
         }
 
         float baseline = dropCapBounds.height() + getPaddingTop();
@@ -270,7 +261,7 @@ public class DropCapView extends View {
     }
 
     private void measureCopyFor(int totalWidth) {
-        if (shouldDisplayDropCap && enoughLinesForDropCap()) {
+        if (enoughLinesForDropCap()) {
             int lineStart = dropCapStaticLayout.getLineEnd(numberOfLinesToSpan - 1);
             int lineEnd = dropCapStaticLayout.getText().length();
             String remainingText = String.valueOf(dropCapStaticLayout.getText().subSequence(lineStart, lineEnd));
@@ -318,14 +309,13 @@ public class DropCapView extends View {
 
     @Override
     protected void onDraw(Canvas canvas) {
-        if (shouldDisplayDropCap && enoughLinesForDropCap()) {
+        if (enoughLinesForDropCap()) {
             drawDropCap(canvas);
             drawCopyForDropCap(canvas);
             drawRemainingCopy(canvas);
         } else {
             drawCopyWithoutDropCap(canvas);
         }
-        shouldDisplayDropCap = false;
         hasPaintChanged = false;
         textHasChanged = false;
     }

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -227,7 +227,7 @@ public class DropCapView extends View {
         int copyWidthForDropCap = width - dropCapWidth;
 
         if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != copyWidthForDropCap
-                || hasPaintChanged || textIsDifferent()) {
+                || hasPaintChanged || copyTextIsDifferent()) {
             dropCapStaticLayout = new StaticLayout(
                     dropCapText + copyText,
                     copyTextPaint,
@@ -280,7 +280,7 @@ public class DropCapView extends View {
             dropCapBaseline = dropCapBaseline + translateBy;
 
         } else {
-            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || textIsDifferent()) {
+            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || copyTextIsDifferent()) {
                 copyStaticLayout = new StaticLayout(
                         dropCapText + copyText,
                         copyTextPaint,
@@ -305,7 +305,7 @@ public class DropCapView extends View {
         return lineBaseline - dHeight;
     }
 
-    private boolean textIsDifferent() {
+    private boolean copyTextIsDifferent() {
         return !copyStaticLayout.getText().equals(dropCapText + copyText);
     }
 

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -118,6 +118,15 @@ public class DropCapView extends View {
         remeasureAndRedraw();
     }
 
+    private void remeasureAndRedraw() {
+        if (dropCapStaticLayout != null || copyStaticLayout != null) {
+            copyStaticLayout = null;
+            dropCapStaticLayout = null;
+            requestLayout();
+            invalidate();
+        }
+    }
+
     public void setCopyFontType(String fontPath) {
         Typeface typeface = typefaceFactory.createFrom(getContext(), fontPath);
         if (copyTextPaint.getTypeface() == typeface) {
@@ -221,15 +230,6 @@ public class DropCapView extends View {
         }
 
         remeasureAndRedraw();
-    }
-
-    private void remeasureAndRedraw() {
-        if (dropCapStaticLayout != null || copyStaticLayout != null) {
-            copyStaticLayout = null;
-            dropCapStaticLayout = null;
-            requestLayout();
-            invalidate();
-        }
     }
 
     private boolean isSameText(String text) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -15,11 +15,6 @@ import android.view.View;
 
 public class DropCapView extends View {
 
-    private static final int TEXT_SET_INDEX = 0;
-    private static final int[] androidAttributeSet = {
-            android.R.attr.text
-    };
-
     private static final float SPACING_MULTIPLIER = 1.0f;
 
     private final TextPaint dropCapPaint = new TextPaint();
@@ -88,20 +83,11 @@ public class DropCapView extends View {
             int copyTextColor = typedArray.getColor(R.styleable.DropCapView_copyTextColor, copyDefaultTextColor);
             setCopyTextColor(copyTextColor);
 
+            String text = typedArray.getString(R.styleable.DropCapView_android_text);
+            setText(text);
+
         } finally {
             typedArray.recycle();
-        }
-
-        TypedArray androidTypedArray = context.obtainStyledAttributes(attrs, androidAttributeSet);
-        if (androidTypedArray == null) {
-            return;
-        }
-
-        try {
-            String text = typedArray.getString(TEXT_SET_INDEX);
-            setText(text);
-        } finally {
-            androidTypedArray.recycle();
         }
     }
 

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -177,7 +177,6 @@ public class DropCapView extends View {
         }
 
         dropCapPaint.setColor(color);
-        hasPaintChanged = true;
         invalidate();
     }
 
@@ -216,7 +215,6 @@ public class DropCapView extends View {
         }
 
         copyTextPaint.setColor(color);
-        hasPaintChanged = true;
         invalidate();
     }
 

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -201,6 +201,7 @@ public class DropCapView extends View {
             shouldDisplayDropCap = false;
         }
         requestLayout();
+        invalidate();
     }
 
     private boolean enoughTextForDropCap(CharSequence text) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -111,6 +111,7 @@ public class DropCapView extends View {
 
         hasPaintChanged = true;
         requestLayout();
+        invalidate();
     }
 
     public void setCopyFontType(String fontPath) {
@@ -125,6 +126,7 @@ public class DropCapView extends View {
 
         hasPaintChanged = true;
         requestLayout();
+        invalidate();
     }
 
     public void setDropCapTextSize(float textSize) {
@@ -135,6 +137,7 @@ public class DropCapView extends View {
         dropCapPaint.setTextSize(textSize);
         hasPaintChanged = true;
         requestLayout();
+        invalidate();
     }
 
     public float getDropCapTextSize() {
@@ -164,6 +167,7 @@ public class DropCapView extends View {
         copyTextPaint.setTextSize(textSize);
         hasPaintChanged = true;
         requestLayout();
+        invalidate();
     }
 
     public float getCopyTextSize() {
@@ -266,7 +270,8 @@ public class DropCapView extends View {
             int lineEnd = dropCapStaticLayout.getText().length();
             String remainingText = String.valueOf(dropCapStaticLayout.getText().subSequence(lineStart, lineEnd));
 
-            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || !remainingText.equals(copyStaticLayout.getText())) {
+            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || hasPaintChanged
+                    || !remainingText.equals(copyStaticLayout.getText())) {
                 copyStaticLayout = new StaticLayout(
                         remainingText,
                         copyTextPaint,
@@ -282,7 +287,7 @@ public class DropCapView extends View {
             }
 
         } else {
-            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || textHasChanged) {
+            if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || textHasChanged || hasPaintChanged) {
                 copyStaticLayout = new StaticLayout(
                         dropCapText + copyText,
                         copyTextPaint,

--- a/drop-cap/library/src/main/res/values/attrs.xml
+++ b/drop-cap/library/src/main/res/values/attrs.xml
@@ -10,8 +10,6 @@
     <attr name="copyTextSize" format="dimension" />
     <attr name="copyTextColor" format="color" />
     <attr name="copyFontPath" format="string" />
-
-    <attr name="text" format="string" />
   </declare-styleable>
 
 </resources>

--- a/drop-cap/library/src/main/res/values/attrs.xml
+++ b/drop-cap/library/src/main/res/values/attrs.xml
@@ -10,6 +10,8 @@
     <attr name="copyTextSize" format="dimension" />
     <attr name="copyTextColor" format="color" />
     <attr name="copyFontPath" format="string" />
+
+    <attr name="android:text" />
   </declare-styleable>
 
 </resources>

--- a/drop-cap/library/src/main/res/values/attrs.xml
+++ b/drop-cap/library/src/main/res/values/attrs.xml
@@ -10,6 +10,8 @@
     <attr name="copyTextSize" format="dimension" />
     <attr name="copyTextColor" format="color" />
     <attr name="copyFontPath" format="string" />
+
+    <attr name="text" format="string" />
   </declare-styleable>
 
 </resources>

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
@@ -67,7 +67,7 @@ public class DropCapActivity extends Activity {
     private final OnTextSizeChangeListener onCopyTextSizeChanged = new OnTextSizeChangeListener() {
         @Override
         public void onSizeChanged(int newTextSize) {
-            dropCapView.setDropCapTextSize(TypedValue.COMPLEX_UNIT_PX, newTextSize);
+            dropCapView.setCopyTextSize(TypedValue.COMPLEX_UNIT_PX, newTextSize);
         }
     };
 

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
@@ -3,6 +3,7 @@ package com.novoda.dropcap.demo;
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.ColorInt;
+import android.util.TypedValue;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -59,14 +60,14 @@ public class DropCapActivity extends Activity {
     private final OnTextSizeChangeListener onDropCapTextSizeChanged = new OnTextSizeChangeListener() {
         @Override
         public void onSizeChanged(int newTextSize) {
-            dropCapView.setDropCapTextSize(newTextSize);
+            dropCapView.setDropCapTextSize(TypedValue.COMPLEX_UNIT_PX, newTextSize);
         }
     };
 
     private final OnTextSizeChangeListener onCopyTextSizeChanged = new OnTextSizeChangeListener() {
         @Override
         public void onSizeChanged(int newTextSize) {
-            dropCapView.setCopyTextSize(newTextSize);
+            dropCapView.setDropCapTextSize(TypedValue.COMPLEX_UNIT_PX, newTextSize);
         }
     };
 

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
@@ -29,9 +29,6 @@ public class DropCapActivity extends Activity {
         setContentView(R.layout.activity_drop_cap);
         dropCapView = (DropCapView) findViewById(R.id.view_drop_cap);
 
-        String dropCapText = getResources().getString(R.string.drop_cap_dummy_text);
-        dropCapView.setText(dropCapText);
-
         createTextSizeDialogDisplayers();
         createTextColorDialogDisplayers();
         createTypefaceDialogDisplayers();

--- a/drop-cap/sample/src/main/res/layout/activity_drop_cap.xml
+++ b/drop-cap/sample/src/main/res/layout/activity_drop_cap.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
@@ -14,7 +13,7 @@
       style="@style/DropCap"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      app:text="@string/drop_cap_dummy_text" />
+      android:text="@string/drop_cap_dummy_text" />
 
   </ScrollView>
 

--- a/drop-cap/sample/src/main/res/layout/activity_drop_cap.xml
+++ b/drop-cap/sample/src/main/res/layout/activity_drop_cap.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
@@ -12,7 +13,8 @@
       android:id="@+id/view_drop_cap"
       style="@style/DropCap"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content" />
+      android:layout_height="wrap_content"
+      app:text="@string/drop_cap_dummy_text" />
 
   </ScrollView>
 


### PR DESCRIPTION
#### Problem
When editing the size of the DropCap and changing the length of the text input it is possible that the DropCap will overlap the copy text (below).

| | | |
|:----:|----|----|
| **Before** |![drop_cap](https://cloud.githubusercontent.com/assets/3380092/19923174/1f8b13bc-a0de-11e6-908b-e2a0d994bc48.jpg)| |
| **After** | ![drop_cap](https://cloud.githubusercontent.com/assets/3380092/20004464/638380e8-a284-11e6-8c35-6c473069cd4d.png) | ![not_enough_text](https://cloud.githubusercontent.com/assets/3380092/20004465/6385c7d6-a284-11e6-875e-b1647968865b.png) |



The second problem occurs when editing the text to display. I wrongly assumed that a call to `requestLayout` would perform a `measure` and `draw` call...which it does...but...apparently a `requestLayout` is always paired with a call to `invalidate`. 

#### Solution
The overlapping text was a simple case of ensuring that the calculation to determine how far the DropCap should span for is calculated for each measure where the `DropCapStaticLayout` is remeasured.

Whenever performing any task that requires a remeasure and a redraw we should have the pair of calls `requestLayout` and `invalidate`. When performing a task that requires just a redraw then we should only use `invalidate`.