### PR TITLE
static-analysis-plugin/Fix for "FileNotFoundException"

### DIFF
--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestAndroidProject.groovy
@@ -38,7 +38,10 @@ ${formatExtension(project)}
 
     TestAndroidProject() {
         super(TEMPLATE)
-        withFile(Fixtures.LOCAL_PROPERTIES, 'local.properties')
+        File localProperties = Fixtures.LOCAL_PROPERTIES
+        if (localProperties.exists()) {
+            withFile(localProperties, 'local.properties')
+        }
     }
 
     private static String formatSourceSets(TestProject project) {


### PR DESCRIPTION
The Android project tests are failing because `local.properties` can't be found. 

To fix the problem, try to include the file only if it exists.

Paired with @mr-archano 