### PR TITLE
PT-272/PT-276: Integrate PMD

### DIFF
--- a/static-analysis-plugin/README.md
+++ b/static-analysis-plugin/README.md
@@ -19,8 +19,6 @@ have been completed. The table below summarises the current status.
 Tool | Android | Java
 :----:|:--------:|:--------:
 `Checkstyle` | :white_check_mark: | :white_check_mark:
-`JaCoCo` | :x: | :x:
-`PMD` | :x: | :x:
+`PMD` | :white_check_mark: | :white_check_mark:
 `FindBugs` | :x: | :x:
-`Lint` | :x: | :x:
 <br/>

--- a/static-analysis-plugin/plugin/build.gradle
+++ b/static-analysis-plugin/plugin/build.gradle
@@ -17,6 +17,11 @@ sourceSets {
         java {
             srcDir file('fixtures/checkstyle/warnings')
             srcDir file('fixtures/checkstyle/errors')
+            srcDir file('fixtures/pmd/priority1')
+            srcDir file('fixtures/pmd/priority2')
+            srcDir file('fixtures/pmd/priority3')
+            srcDir file('fixtures/pmd/priority4')
+            srcDir file('fixtures/pmd/priority5')
         }
     }
 }

--- a/static-analysis-plugin/plugin/fixtures/pmd/config/rules.xml
+++ b/static-analysis-plugin/plugin/fixtures/pmd/config/rules.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd"
+  name="Test ruleset">
+
+  <!-- priority 1 -->
+  <rule ref="rulesets/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal"/>
+
+  <!-- priority 2 -->
+  <rule ref="rulesets/java/basic.xml/BrokenNullCheck"/>
+
+  <!-- priority 3 -->
+  <rule ref="rulesets/java/basic.xml/UnconditionalIfStatement"/>
+
+  <!-- priority 4 -->
+  <rule ref="rulesets/java/basic.xml/ExtendsObject"/>
+
+  <!-- priority 5 -->
+  <rule ref="rulesets/java/basic.xml/BooleanInstantiation">
+    <priority>5</priority>
+  </rule>
+
+</ruleset>

--- a/static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java
+++ b/static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java
@@ -1,0 +1,4 @@
+public class Priority1Violator { //Should be final
+    private Priority1Violator() {
+    }
+}

--- a/static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java
+++ b/static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java
@@ -1,0 +1,9 @@
+public class Priority2Violator {
+    public void foo(String string) {
+        // should be &&
+        if (string != null || !string.equals("")) {
+            System.out.println(string);
+        }
+        System.out.println("bar");
+    }
+}

--- a/static-analysis-plugin/plugin/fixtures/pmd/priority3/Priority3Violator.java
+++ b/static-analysis-plugin/plugin/fixtures/pmd/priority3/Priority3Violator.java
@@ -1,0 +1,7 @@
+public class Priority3Violator {
+    public void foo() {
+        if (true) {        // fixed conditional, not recommended
+            System.out.println("bar");
+        }
+    }
+}

--- a/static-analysis-plugin/plugin/fixtures/pmd/priority4/Priority4Violator.java
+++ b/static-analysis-plugin/plugin/fixtures/pmd/priority4/Priority4Violator.java
@@ -1,0 +1,2 @@
+public class Priority4Violator extends Object { // not required
+}

--- a/static-analysis-plugin/plugin/fixtures/pmd/priority5/Priority5Violator.java
+++ b/static-analysis-plugin/plugin/fixtures/pmd/priority5/Priority5Violator.java
@@ -1,0 +1,3 @@
+public class Priority5Violator {
+    Boolean buz = Boolean.valueOf(false);    // ...., just reference Boolean.FALSE;
+}

--- a/static-analysis-plugin/plugin/fixtures/pmd/reports/sample.xml
+++ b/static-analysis-plugin/plugin/fixtures/pmd/reports/sample.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pmd version="5.5.1" timestamp="2016-11-02T17:37:41.144">
+  <file name="static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java">
+    <violation beginline="1" endline="4" begincolumn="8" endcolumn="1" rule="ClassWithOnlyPrivateConstructorsShouldBeFinal" ruleset="Design"
+      externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ClassWithOnlyPrivateConstructorsShouldBeFinal"
+      priority="1">
+      A class which only has private constructors should be final
+    </violation>
+  </file>
+  <file name="static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java">
+    <violation beginline="4" endline="6" begincolumn="9" endcolumn="9" rule="BrokenNullCheck" ruleset="Basic" class="Priority2Violator" method="foo"
+      externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BrokenNullCheck" priority="2">
+      Method call on object which may be null
+    </violation>
+    <violation beginline="4" endline="6" begincolumn="9" endcolumn="9" rule="BrokenNullCheck" ruleset="Basic" class="Priority2Violator" method="foo"
+      externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BrokenNullCheck" priority="2">
+      Method call on object which may be null
+    </violation>
+  </file>
+</pmd>

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/CheckstyleConfigurator.groovy
@@ -16,7 +16,7 @@ class CheckstyleConfigurator {
             project.extensions.findByType(CheckstyleExtension).with {
                 toolVersion = '7.1.2'
                 ext.exclude = { String filter ->
-                    excludes.addAll(filter)
+                    excludes.add(filter)
                 }
                 config.delegate = it
                 config()

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
@@ -11,8 +11,12 @@ class PmdConfigurator {
 
     void configure(Project project, Violations violations, Task evaluateViolations) {
         project.apply plugin: 'pmd'
+        List<String> excludes = []
         project.extensions.findByType(PmdExtension).with {
             toolVersion = '5.5.1'
+            ext.exclude = { String filter ->
+                 excludes.add(filter)
+            }
         }
         project.afterEvaluate {
             project.tasks.withType(Pmd) { pmd ->
@@ -20,6 +24,7 @@ class PmdConfigurator {
                 pmd.ignoreFailures = true
                 pmd.rulePriority = 5
                 pmd.metaClass.getLogger = { QuietLogger.INSTANCE }
+                pmd.exclude(excludes)
                 pmd.doLast {
                     File xmlReportFile = pmd.reports.xml.destination
                     File htmlReportFile = new File(xmlReportFile.absolutePath - '.xml' + '.html')

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
@@ -1,0 +1,45 @@
+package com.novoda.staticanalysis
+
+import com.novoda.staticanalysis.PmdViolationsEvaluator.PmdViolation
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.quality.Pmd
+import org.gradle.api.plugins.quality.PmdExtension
+import org.gradle.internal.logging.ConsoleRenderer
+
+class PmdConfigurator {
+
+    void configure(Project project, Violations violations, Task evaluateViolations) {
+        project.apply plugin: 'pmd'
+        project.extensions.findByType(PmdExtension).with {
+            toolVersion = '5.5.1'
+        }
+        project.afterEvaluate {
+            project.tasks.withType(Pmd) { pmd ->
+                pmd.group = 'verification'
+                pmd.ignoreFailures = true
+                pmd.rulePriority = 5
+                pmd.metaClass.getLogger = { QuietLogger.INSTANCE }
+                pmd.doLast {
+                    File xmlReportFile = pmd.reports.xml.destination
+                    File htmlReportFile = new File(xmlReportFile.absolutePath - '.xml' + '.html')
+
+                    PmdViolationsEvaluator evaluator = new PmdViolationsEvaluator(xmlReportFile)
+                    Map<String, Integer> result = evaluator.collectViolations().inject([errors: 0, warnings: 0]) {
+                        LinkedHashMap<String, Integer> map, PmdViolation violation ->
+                            if (violation.isError()) {
+                                map['errors'] += 1
+                            } else {
+                                map['warnings'] += 1
+                            }
+                            map
+                    }
+                    String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile ?: xmlReportFile)
+                    violations.addViolations(result['errors'], result['warnings'], reportUrl)
+                }
+                evaluateViolations.dependsOn pmd
+            }
+        }
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
@@ -23,23 +23,25 @@ class PmdConfigurator {
                 pmd.doLast {
                     File xmlReportFile = pmd.reports.xml.destination
                     File htmlReportFile = new File(xmlReportFile.absolutePath - '.xml' + '.html')
-
-                    PmdViolationsEvaluator evaluator = new PmdViolationsEvaluator(xmlReportFile)
-                    Map<String, Integer> result = evaluator.collectViolations().inject([errors: 0, warnings: 0]) {
-                        LinkedHashMap<String, Integer> map, PmdViolation violation ->
-                            if (violation.isError()) {
-                                map['errors'] += 1
-                            } else {
-                                map['warnings'] += 1
-                            }
-                            map
-                    }
-                    String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile ?: xmlReportFile)
-                    violations.addViolations(result['errors'], result['warnings'], reportUrl)
+                    evaluateReports(xmlReportFile, htmlReportFile, violations)
                 }
                 evaluateViolations.dependsOn pmd
             }
         }
+    }
+
+    private void evaluateReports(File xmlReportFile, File htmlReportFile, Violations violations) {
+        PmdViolationsEvaluator evaluator = new PmdViolationsEvaluator(xmlReportFile)
+        int errors = 0, warnings = 0
+        evaluator.collectViolations().each { PmdViolation violation ->
+            if (violation.isError()) {
+                errors += 1
+            } else {
+                warnings += 1
+            }
+        }
+        String reportUrl = new ConsoleRenderer().asClickableFileUrl(htmlReportFile ?: xmlReportFile)
+        violations.addViolations(errors, warnings, reportUrl)
     }
 
 }

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdConfigurator.groovy
@@ -15,17 +15,21 @@ class PmdConfigurator {
             List<String> excludes = []
             configureExtension(project.extensions.findByType(PmdExtension), excludes, config)
             project.afterEvaluate {
-                boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
-                boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
-                if (isAndroidApp || isAndroidLib) {
-                    def variants = isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants
-                    configureAndroid(project, variants)
-                }
+                configureAndroidIfNeeded(project)
                 project.tasks.withType(Pmd) { pmd ->
                     configureTask(pmd, violations, excludes)
                     evaluateViolations.dependsOn pmd
                 }
             }
+        }
+    }
+
+    private void configureAndroidIfNeeded(Project project) {
+        boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
+        boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
+        if (isAndroidApp || isAndroidLib) {
+            def variants = isAndroidApp ? project.android.applicationVariants : project.android.libraryVariants
+            configureAndroid(project, variants)
         }
     }
 

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
@@ -17,7 +17,8 @@ class PmdViolationsEvaluator {
     Set<PmdViolation> collectViolations() {
         Collection files = xml.'**'.findAll { node -> node.name() == 'file' }
         files.inject(new HashSet<PmdViolation>()) { HashSet<PmdViolation> violations, file ->
-            violations += file.'**'.findAll { violation -> violation.name() == 'violation' }
+            violations += file.'**'
+                    .findAll { violation -> violation.name() == 'violation' }
                     .collect { violation -> new PmdViolation(violation, file.@name as String) }
             violations
         }

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
@@ -77,15 +77,16 @@ class PmdViolationsEvaluator {
 
             PmdViolation that = (PmdViolation) o
 
-            if (beginColumn != that.beginColumn) return false
-            if (beginLine != that.beginLine) return false
-            if (className != that.className) return false
-            if (endColumn != that.endColumn) return false
-            if (endLine != that.endLine) return false
+            if (!beginColumn.equals(that.beginColumn)) return false
+            if (!beginLine.equals(that.beginLine)) return false
+            if (!className.equals(that.className)) return false
+            if (!endColumn.equals(that.endColumn)) return false
+            if (!endLine.equals(that.endLine)) return false
             if (methodName != that.methodName) return false
-            if (priority != that.priority) return false
-            if (rule != that.rule) return false
-            if (ruleSet != that.ruleSet) return false
+            if (methodName != null && that.methodName != null && !methodName.equals(that.methodName)) return false
+            if (!priority.equals(that.priority)) return false
+            if (!rule.equals(that.rule)) return false
+            if (!ruleSet.equals(that.ruleSet)) return false
 
             return true
         }

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
@@ -37,7 +37,7 @@ class PmdViolationsEvaluator {
 
         PmdViolation(def violation, String file) {
             this(violation.@beginline as String,
-                    violation.@endline as String, \
+                    violation.@endline as String,
                     violation.@begincolumn as String,
                     violation.@endcolumn as String,
                     violation.@rule as String,

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/PmdViolationsEvaluator.groovy
@@ -1,0 +1,122 @@
+package com.novoda.staticanalysis
+
+import groovy.util.slurpersupport.GPathResult
+
+class PmdViolationsEvaluator {
+
+    private final GPathResult xml
+
+    PmdViolationsEvaluator(File report) {
+        this(new XmlSlurper().parse(report))
+    }
+
+    PmdViolationsEvaluator(GPathResult xml) {
+        this.xml = xml
+    }
+
+    Set<PmdViolation> collectViolations() {
+        Collection files = xml.'**'.findAll { node -> node.name() == 'file' }
+        files.inject(new HashSet<PmdViolation>()) { HashSet<PmdViolation> violations, file ->
+            violations += file.'**'.findAll { violation -> violation.name() == 'violation' }
+                    .collect { violation -> new PmdViolation(violation, file.@name as String) }
+            violations
+        }
+    }
+
+    static class PmdViolation {
+        String beginLine
+        String endLine
+        String beginColumn
+        String endColumn
+        String rule
+        String ruleSet
+        String className
+        String methodName
+        String priority
+
+        PmdViolation(def violation, String file) {
+            this(violation.@beginline as String,
+                    violation.@endline as String, \
+                    violation.@begincolumn as String,
+                    violation.@endcolumn as String,
+                    violation.@rule as String,
+                    violation.@ruleset as String,
+                    file,
+                    violation.@method as String,
+                    violation.@priority as String)
+        }
+
+        PmdViolation(String beginLine,
+                     String endLine,
+                     String beginColumn,
+                     String endColumn,
+                     String rule,
+                     String ruleSet,
+                     String className,
+                     String methodName,
+                     String priority) {
+            this.beginLine = beginLine
+            this.endLine = endLine
+            this.beginColumn = beginColumn
+            this.endColumn = endColumn
+            this.rule = rule
+            this.ruleSet = ruleSet
+            this.className = className
+            this.methodName = methodName
+            this.priority = priority
+        }
+
+        boolean isError() {
+            priority == '1' || priority == '2'
+        }
+
+        boolean equals(o) {
+            if (this.is(o)) return true
+            if (getClass() != o.class) return false
+
+            PmdViolation that = (PmdViolation) o
+
+            if (beginColumn != that.beginColumn) return false
+            if (beginLine != that.beginLine) return false
+            if (className != that.className) return false
+            if (endColumn != that.endColumn) return false
+            if (endLine != that.endLine) return false
+            if (methodName != that.methodName) return false
+            if (priority != that.priority) return false
+            if (rule != that.rule) return false
+            if (ruleSet != that.ruleSet) return false
+
+            return true
+        }
+
+        int hashCode() {
+            int result
+            result = beginLine.hashCode()
+            result = 31 * result + endLine.hashCode()
+            result = 31 * result + beginColumn.hashCode()
+            result = 31 * result + endColumn.hashCode()
+            result = 31 * result + rule.hashCode()
+            result = 31 * result + ruleSet.hashCode()
+            result = 31 * result + className.hashCode()
+            result = 31 * result + (methodName != null ? methodName.hashCode() : 0)
+            result = 31 * result + priority.hashCode()
+            return result
+        }
+
+        @Override
+        public String toString() {
+            return "PmdViolation{" +
+                    "beginLine='" + beginLine + '\'' +
+                    ", endLine='" + endLine + '\'' +
+                    ", beginColumn='" + beginColumn + '\'' +
+                    ", endColumn='" + endColumn + '\'' +
+                    ", rule='" + rule + '\'' +
+                    ", ruleSet='" + ruleSet + '\'' +
+                    ", className='" + className + '\'' +
+                    ", methodName='" + methodName + '\'' +
+                    ", priority='" + priority + '\'' +
+                    "} " + super.toString();
+        }
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -19,7 +19,7 @@ class StaticAnalysisPlugin implements Plugin<Project> {
             task.allViolations = allViolations
         }
         checkstyleConfigurator.configure(project, allViolations.create('Checkstyle'), extension, evaluateViolations)
-        pmdConfigurator.configure(project, allViolations.create('PMD'), evaluateViolations)
+        pmdConfigurator.configure(project, allViolations.create('PMD'), extension, evaluateViolations)
         project.afterEvaluate {
             project.tasks['check'].dependsOn evaluateViolations
         }

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.Task
 
 class StaticAnalysisPlugin implements Plugin<Project> {
     private final CheckstyleConfigurator checkstyleConfigurator = new CheckstyleConfigurator()
+    private final PmdConfigurator pmdConfigurator = new PmdConfigurator()
 
     @Override
     void apply(Project project) {
@@ -18,6 +19,7 @@ class StaticAnalysisPlugin implements Plugin<Project> {
             task.allViolations = allViolations
         }
         checkstyleConfigurator.configure(project, allViolations.create('Checkstyle'), extension, evaluateViolations)
+        pmdConfigurator.configure(project, allViolations.create('PMD'), evaluateViolations)
         project.afterEvaluate {
             project.tasks['check'].dependsOn evaluateViolations
         }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
@@ -13,9 +13,6 @@ import static com.novoda.test.LogsSubject.assertThat
 @RunWith(Parameterized.class)
 public class CheckstyleIntegrationTest {
 
-    private static final String EMPTY_MODULES = '''<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-<module name="Checker"/>
-'''
     public static final String DEFAULT_CONFIG = "configFile new File('${Fixtures.Checkstyle.MODULES.path}')"
 
     @Parameterized.Parameters

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
@@ -106,7 +106,7 @@ public class CheckstyleIntegrationTest {
                     maxWarnings 1
                     maxErrors 1
                 }''')
-                .withCheckstyle(checkstyle(DEFAULT_CONFIG, "ignoreFailures false"))
+                .withCheckstyle(checkstyle(DEFAULT_CONFIG, "ignoreFailures = false"))
                 .build('check')
     }
 

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/CheckstyleIntegrationTest.groovy
@@ -97,23 +97,6 @@ public class CheckstyleIntegrationTest {
     }
 
     @Test
-    public void shouldNotFailBuildWhenNoCheckstyleWarningsOrErrorsEncounteredAccordingToCustomModules() {
-        TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)
-                .withSourceSet('test', Fixtures.Checkstyle.SOURCES_WITH_ERRORS)
-                .withFile(EMPTY_MODULES, 'checkstyle.xml')
-                .withPenalty('''{
-                    maxWarnings 0
-                    maxErrors 0
-                }''')
-                .withCheckstyle(checkstyle("configFile project.file('checkstyle.xml')"))
-                .build('check')
-
-        assertThat(result.logs).doesNotContainLimitExceeded()
-        assertThat(result.logs).doesNotContainCheckstyleViolations()
-    }
-
-    @Test
     public void shouldNotFailBuildWhenCheckstyleConfiguredToNotIgnoreFailures() {
         projectRule.newProject()
                 .withSourceSet('main', Fixtures.Checkstyle.SOURCES_WITH_WARNINGS)

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
@@ -145,6 +145,21 @@ public class PmdIntegrationTest {
         assertThat(result.logs).doesNotContainPmdViolations()
     }
 
+    @Test
+    public void shouldNotFailBuildWhenPmdNotConfigured() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withSourceSet('main2', Fixtures.Pmd.SOURCES_WITH_PRIORITY_2_VIOLATION)
+                .withPenalty('''{
+                    maxWarnings 0
+                    maxErrors 0
+                }''')
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).doesNotContainPmdViolations()
+    }
+
     private String pmd(String rules, String... configs) {
         """pmd {
             ruleSetFiles = $rules

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
@@ -15,7 +15,7 @@ public class PmdIntegrationTest {
 
     @Parameterized.Parameters
     public static List<Object[]> rules() {
-        return [TestProjectRule.forJavaProject()].collect { [it] as Object[] }
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
     }
 
     @Rule

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
@@ -129,10 +129,26 @@ public class PmdIntegrationTest {
                 .build('check')
     }
 
+    @Test
+    public void shouldNotFailBuildWhenPmdConfiguredToIgnoreFaultySourceSets() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withSourceSet('main2', Fixtures.Pmd.SOURCES_WITH_PRIORITY_2_VIOLATION)
+                .withPenalty('''{
+                    maxWarnings 0
+                    maxErrors 0
+                }''')
+                .withPmd(pmd("project.files('${Fixtures.Pmd.RULES.path}')", "exclude 'Priority1Violator.java'", "exclude 'Priority2Violator.java'"))
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).doesNotContainPmdViolations()
+    }
+
     private String pmd(String rules, String... configs) {
         """pmd {
             ruleSetFiles = $rules
-            ${configs.join('\\n\\t\\t\\t')}
+            ${configs.join('\n\t\t\t')}
         }"""
     }
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
@@ -1,0 +1,51 @@
+package com.novoda.staticanalysis
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static com.novoda.test.LogsSubject.assertThat
+
+@RunWith(Parameterized.class)
+public class PmdIntegrationTest {
+
+    @Parameterized.Parameters
+    public static List<Object[]> rules() {
+        return [TestProjectRule.forJavaProject()].collect { [it] as Object[] }
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    public PmdIntegrationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    public void shouldFailBuildWhenPmdErrorOverTheThreshold() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Pmd.SOURCES_WITH_PRIORITY_1_VIOLATION)
+                .withSourceSet('main2', Fixtures.Pmd.SOURCES_WITH_PRIORITY_2_VIOLATION)
+                .withPenalty('''{
+                    maxWarnings 0
+                    maxErrors 0
+                }''')
+                .withPmd(pmd("project.files('${Fixtures.Pmd.RULES.path}')"))
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(2, 0)
+        assertThat(result.logs).containsPmdViolations(2, 0,
+                result.buildFile('reports/pmd/main.html'),
+                result.buildFile('reports/pmd/main2.html'))
+    }
+
+    private String pmd(String rules) {
+        """pmd {
+            ruleSetFiles = $rules
+        }"""
+    }
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdViolationsEvaluatorTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdViolationsEvaluatorTest.groovy
@@ -1,0 +1,44 @@
+package com.novoda.staticanalysis
+
+import org.junit.Before
+import org.junit.Test
+
+import static com.google.common.truth.Truth.assertThat
+import static com.novoda.staticanalysis.PmdViolationsEvaluator.PmdViolation
+
+public class PmdViolationsEvaluatorTest {
+
+    String xml = '''<?xml version="1.0" encoding="UTF-8"?>
+<pmd version="5.5.1" timestamp="2016-11-02T17:37:41.144">
+<file name="/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java">
+<violation beginline="1" endline="4" begincolumn="8" endcolumn="1" rule="ClassWithOnlyPrivateConstructorsShouldBeFinal" ruleset="Design" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ClassWithOnlyPrivateConstructorsShouldBeFinal" priority="1">
+A class which only has private constructors should be final
+</violation>
+</file>
+<file name="/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java">
+<violation beginline="4" endline="6" begincolumn="9" endcolumn="9" rule="BrokenNullCheck" ruleset="Basic" class="Priority2Violator" method="foo" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BrokenNullCheck" priority="2">
+Method call on object which may be null
+</violation>
+<violation beginline="4" endline="6" begincolumn="9" endcolumn="9" rule="BrokenNullCheck" ruleset="Basic" class="Priority2Violator" method="foo" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BrokenNullCheck" priority="2">
+Method call on object which may be null
+</violation>
+</file>
+</pmd>'''
+    private PmdViolationsEvaluator evaluator
+
+    @Before
+    public void setUp() {
+        evaluator = new PmdViolationsEvaluator(new XmlSlurper().parseText(xml))
+    }
+
+    @Test
+    public void shouldCollectDistinctViolationFromReport() {
+        def expected = [new PmdViolation('1', '4', '8', '1', 'ClassWithOnlyPrivateConstructorsShouldBeFinal', 'Design', '/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java', '', '1'),
+                        new PmdViolation('4', '6', '9', '9', 'BrokenNullCheck', 'Basic', '/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java', 'foo', '2')]
+
+        Set<PmdViolation> violations = evaluator.collectViolations()
+
+        assertThat(violations).containsExactlyElementsIn(expected)
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdViolationsEvaluatorTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdViolationsEvaluatorTest.groovy
@@ -1,5 +1,6 @@
 package com.novoda.staticanalysis
 
+import com.novoda.test.Fixtures
 import org.junit.Before
 import org.junit.Test
 
@@ -8,27 +9,11 @@ import static com.novoda.staticanalysis.PmdViolationsEvaluator.PmdViolation
 
 public class PmdViolationsEvaluatorTest {
 
-    String xml = '''<?xml version="1.0" encoding="UTF-8"?>
-<pmd version="5.5.1" timestamp="2016-11-02T17:37:41.144">
-<file name="/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java">
-<violation beginline="1" endline="4" begincolumn="8" endcolumn="1" rule="ClassWithOnlyPrivateConstructorsShouldBeFinal" ruleset="Design" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ClassWithOnlyPrivateConstructorsShouldBeFinal" priority="1">
-A class which only has private constructors should be final
-</violation>
-</file>
-<file name="/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java">
-<violation beginline="4" endline="6" begincolumn="9" endcolumn="9" rule="BrokenNullCheck" ruleset="Basic" class="Priority2Violator" method="foo" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BrokenNullCheck" priority="2">
-Method call on object which may be null
-</violation>
-<violation beginline="4" endline="6" begincolumn="9" endcolumn="9" rule="BrokenNullCheck" ruleset="Basic" class="Priority2Violator" method="foo" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BrokenNullCheck" priority="2">
-Method call on object which may be null
-</violation>
-</file>
-</pmd>'''
     private PmdViolationsEvaluator evaluator
 
     @Before
     public void setUp() {
-        evaluator = new PmdViolationsEvaluator(new XmlSlurper().parseText(xml))
+        evaluator = new PmdViolationsEvaluator(new XmlSlurper().parse(Fixtures.Pmd.SAMPLE_REPORT))
     }
 
     @Test

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdViolationsEvaluatorTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdViolationsEvaluatorTest.groovy
@@ -18,8 +18,8 @@ public class PmdViolationsEvaluatorTest {
 
     @Test
     public void shouldCollectDistinctViolationFromReport() {
-        def expected = [new PmdViolation('1', '4', '8', '1', 'ClassWithOnlyPrivateConstructorsShouldBeFinal', 'Design', '/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java', '', '1'),
-                        new PmdViolation('4', '6', '9', '9', 'BrokenNullCheck', 'Basic', '/Users/toto/novoda/spikes/static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java', 'foo', '2')]
+        def expected = [new PmdViolation('1', '4', '8', '1', 'ClassWithOnlyPrivateConstructorsShouldBeFinal', 'Design', 'static-analysis-plugin/plugin/fixtures/pmd/priority1/Priority1Violator.java', '', '1'),
+                        new PmdViolation('4', '6', '9', '9', 'BrokenNullCheck', 'Basic', 'static-analysis-plugin/plugin/fixtures/pmd/priority2/Priority2Violator.java', 'foo', '2')]
 
         Set<PmdViolation> violations = evaluator.collectViolations()
 

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -31,6 +31,7 @@ public final class Fixtures {
         public static final File SOURCES_WITH_PRIORITY_3_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority3')
         public static final File SOURCES_WITH_PRIORITY_4_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority4')
         public static final File SOURCES_WITH_PRIORITY_5_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority5')
+        public static final File SAMPLE_REPORT = new File(FIXTURES_DIR, 'pmd/reports/sample.xml')
     }
 
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -24,5 +24,13 @@ public final class Fixtures {
         }
     }
 
+    public final static class Pmd {
+        public static final File RULES = new File(FIXTURES_DIR, 'pmd/config/rules.xml')
+        public static final File SOURCES_WITH_PRIORITY_1_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority1')
+        public static final File SOURCES_WITH_PRIORITY_2_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority2')
+        public static final File SOURCES_WITH_PRIORITY_3_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority3')
+        public static final File SOURCES_WITH_PRIORITY_4_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority4')
+        public static final File SOURCES_WITH_PRIORITY_5_VIOLATION = new File(FIXTURES_DIR, 'pmd/priority5')
+    }
 
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -40,6 +40,10 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
         Truth.assertThat(actual().output).doesNotContain(CHECKSTYLE_VIOLATIONS_FOUND)
     }
 
+    public void doesNotContainPmdViolations() {
+        Truth.assertThat(actual().output).doesNotContain(PMD_VIOLATIONS_FOUND)
+    }
+
     public void containsCheckstyleViolations(int errors, int warnings, File... reports) {
         def output = Truth.assertThat(actual().output)
         output.contains("$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -12,6 +12,7 @@ import static com.novoda.test.TestProject.Result.Logs;
 class LogsSubject extends Subject<LogsSubject, Logs> {
     private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
     private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle rule violations were found"
+    private static final String PMD_VIOLATIONS_FOUND = "PMD rule violations were found"
     private static final SubjectFactory<LogsSubject, Logs> FACTORY = new SubjectFactory<LogsSubject, Logs>() {
         @Override
         LogsSubject getSubject(FailureStrategy failureStrategy, Logs logs) {
@@ -42,6 +43,14 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
     public void containsCheckstyleViolations(int errors, int warnings, File... reports) {
         def output = Truth.assertThat(actual().output)
         output.contains("$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
+        for (File report : reports) {
+            output.contains(report.path)
+        }
+    }
+
+    public void containsPmdViolations(int errors, int warnings, File... reports) {
+        def output = Truth.assertThat(actual().output)
+        output.contains("$PMD_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
         for (File report : reports) {
             output.contains(report.path)
         }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -9,6 +9,7 @@ abstract class TestProject {
 staticAnalysis {
     ${(project.penalty ?: '').replace('            ', '')}
     ${(project.checkstyle ?: '').replace('        ', '    ')}
+    ${(project.pmd ?: '').replace('        ', '    ')}
 }
 """
     }
@@ -19,6 +20,7 @@ staticAnalysis {
     Map<String, List<File>> sourceSets = [main: []]
     String penalty
     String checkstyle
+    String pmd
 
     TestProject(Closure<String> template) {
         this.template = template
@@ -73,13 +75,17 @@ staticAnalysis {
         return this
     }
 
+    public TestProject withPmd(String pmd) {
+        this.pmd = pmd
+        return this
+    }
+
     public Result build(String... arguments) {
         BuildResult buildResult = newRunner(arguments).build()
         createResult(buildResult)
     }
 
     private GradleRunner newRunner(String... arguments) {
-        withFile(Fixtures.Checkstyle.MODULES, 'config/checkstyle/checkstyle.xml')
         new File(projectDir, 'build.gradle').text = template.call(this)
         List<String> defaultArgs = defaultArguments()
         List<String> args = new ArrayList<>(arguments.size() + defaultArgs.size())


### PR DESCRIPTION
> Tracked in JIRA by [PT-276](https://novoda.atlassian.net/browse/PT-276)

### Scope of the PR

We want to use the `static-analysis-plugin` to easily integrate PMD in a Java or Android project. Features should be in parity with the current Checkstyle integration:
- evaluation of violations grouped as warnings or errors
- introduce exclude filters to ignore paths from the PMD analysis
- logging facilities detailing limits exceeded and relevant reports
- disable PMD integration if no configuration provided

### Considerations/Implementation Details

- Added fixtures for both rules and java files to be used in integration tests.
- Introduced `PmdViolationsEvaluator` as delegate used to evaluate violations listed in the PMD reports.
- Introduced `PmdConfigurator` to delegate configuration of PMD for Java/Android projects
- Amended `TestProject` builder to generate PMD configuration closure when provided.
- Amended `LogsSubject` to account for output from PMD analysis

> **NOTE:** We noticed PMD sometimes raise the exact same violations multiple times in the same report. We fixed the issue introducing `PmdViolationsEvaluator`, to collect only distinct violations for our final evaluation. Unfortunately we also spotted sometimes the same violations is reported again with a different priority, but we couldn't find an apparent reason for it. We assume it's related to the fact PMD doesn't cope well with redefining the priority of a rule included in one of default rulesets. We should then expect then the same violation can be contribute twice against the errors/warnings thresholds.

#### Testing

- PMD configuration and evaluation is checked via `PmdIntegrationTest`
- Evaluation of violations in PMD reports is checked via `PmdViolationsEvaluatorTest`


> Paired with @eduardb 