### PR TITLE
PT-272/PT-277: Integrate Findbugs in static-analysis-plugin

### DIFF
--- a/static-analysis-plugin/README.md
+++ b/static-analysis-plugin/README.md
@@ -20,5 +20,5 @@ Tool | Android | Java
 :----:|:--------:|:--------:
 `Checkstyle` | :white_check_mark: | :white_check_mark:
 `PMD` | :white_check_mark: | :white_check_mark:
-`FindBugs` | :x: | :x:
+`FindBugs` | :white_check_mark: | :white_check_mark:
 <br/>

--- a/static-analysis-plugin/plugin/build.gradle
+++ b/static-analysis-plugin/plugin/build.gradle
@@ -22,6 +22,9 @@ sourceSets {
             srcDir file('fixtures/pmd/priority3')
             srcDir file('fixtures/pmd/priority4')
             srcDir file('fixtures/pmd/priority5')
+            srcDir file('fixtures/findbugs/high')
+            srcDir file('fixtures/findbugs/medium')
+            srcDir file('fixtures/findbugs/low')
         }
     }
 }

--- a/static-analysis-plugin/plugin/fixtures/findbugs/high/HighPriorityViolator.java
+++ b/static-analysis-plugin/plugin/fixtures/findbugs/high/HighPriorityViolator.java
@@ -1,0 +1,9 @@
+public class HighPriorityViolator {
+
+    public void impossibleCast() {
+        final Object doubleValue = Double.valueOf(1.0);
+        final Long value = (Long) doubleValue;
+        System.out.println("   - " + value);
+    }
+
+}

--- a/static-analysis-plugin/plugin/fixtures/findbugs/low/LowPriorityViolator.java
+++ b/static-analysis-plugin/plugin/fixtures/findbugs/low/LowPriorityViolator.java
@@ -1,0 +1,5 @@
+public class LowPriorityViolator {
+    public boolean equals(Object o) {
+        return this == o;
+    }
+}

--- a/static-analysis-plugin/plugin/fixtures/findbugs/medium/MediumPriorityViolator.java
+++ b/static-analysis-plugin/plugin/fixtures/findbugs/medium/MediumPriorityViolator.java
@@ -1,0 +1,7 @@
+public class MediumPriorityViolator {
+    private String foo;
+
+    public MediumPriorityViolator(String foo) {
+        this.foo = foo;
+    }
+}

--- a/static-analysis-plugin/plugin/fixtures/findbugs/reports/sample.xml
+++ b/static-analysis-plugin/plugin/fixtures/findbugs/reports/sample.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<BugCollection version="3.0.1" sequence="0" timestamp="1478529260684" analysisTimestamp="1478529260722" release="">
+  <Project projectName="">
+    <Jar>
+      static-analysis-plugin/plugin/build/test-projects/1478529252563/build/classes/main/HighPriorityViolator.class
+    </Jar>
+    <Jar>
+      static-analysis-plugin/plugin/build/test-projects/1478529252563/build/classes/main/LowPriorityViolator.class
+    </Jar>
+    <Jar>
+      static-analysis-plugin/plugin/build/test-projects/1478529252563/build/classes/main/MediumPriorityViolator.class
+    </Jar>
+    <SrcDir>static-analysis-plugin/plugin/fixtures/findbugs/low/LowPriorityViolator.java
+    </SrcDir>
+    <SrcDir>
+      static-analysis-plugin/plugin/fixtures/findbugs/medium/MediumPriorityViolator.java
+    </SrcDir>
+    <SrcDir>static-analysis-plugin/plugin/fixtures/findbugs/high/HighPriorityViolator.java
+    </SrcDir>
+  </Project>
+  <BugInstance type="BC_IMPOSSIBLE_CAST" priority="1" rank="9" abbrev="BC" category="CORRECTNESS">
+    <Class classname="HighPriorityViolator">
+      <SourceLine classname="HighPriorityViolator" start="1" end="7" sourcefile="HighPriorityViolator.java"
+        sourcepath="HighPriorityViolator.java" />
+    </Class>
+    <Method classname="HighPriorityViolator" name="impossibleCast" signature="()V" isStatic="false">
+      <SourceLine classname="HighPriorityViolator" start="4" end="7" startBytecode="0" endBytecode="16"
+        sourcefile="HighPriorityViolator.java" sourcepath="HighPriorityViolator.java" />
+    </Method>
+    <Type descriptor="Ljava/lang/Double;" role="TYPE_FOUND">
+      <SourceLine classname="java.lang.Double" start="49" end="1053" sourcefile="Double.java"
+        sourcepath="java/lang/Double.java" />
+    </Type>
+    <Type descriptor="Ljava/lang/Long;" role="TYPE_EXPECTED">
+      <SourceLine classname="java.lang.Long" start="54" end="1615" sourcefile="Long.java"
+        sourcepath="java/lang/Long.java" />
+    </Type>
+    <LocalVariable name="doubleValue" register="1" pc="5" role="LOCAL_VARIABLE_VALUE_OF" />
+    <SourceLine classname="HighPriorityViolator" start="5" end="5" startBytecode="6" endBytecode="6"
+      sourcefile="HighPriorityViolator.java" sourcepath="HighPriorityViolator.java" />
+  </BugInstance>
+  <BugInstance type="HE_EQUALS_USE_HASHCODE" priority="3" rank="19" abbrev="HE" category="BAD_PRACTICE">
+    <Class classname="LowPriorityViolator">
+      <SourceLine classname="LowPriorityViolator" start="1" end="3" sourcefile="LowPriorityViolator.java"
+        sourcepath="LowPriorityViolator.java" />
+    </Class>
+    <Method classname="LowPriorityViolator" name="equals" signature="(Ljava/lang/Object;)Z" isStatic="false">
+      <SourceLine classname="LowPriorityViolator" start="3" end="3" startBytecode="0" endBytecode="73"
+        sourcefile="LowPriorityViolator.java" sourcepath="LowPriorityViolator.java" />
+    </Method>
+  </BugInstance>
+  <BugInstance type="URF_UNREAD_FIELD" priority="2" rank="18" abbrev="UrF" category="PERFORMANCE">
+    <Class classname="MediumPriorityViolator">
+      <SourceLine classname="MediumPriorityViolator" start="4" end="6" sourcefile="MediumPriorityViolator.java"
+        sourcepath="MediumPriorityViolator.java" />
+    </Class>
+    <Field classname="MediumPriorityViolator" name="foo" signature="Ljava/lang/String;" isStatic="false">
+      <SourceLine classname="MediumPriorityViolator" sourcefile="MediumPriorityViolator.java"
+        sourcepath="MediumPriorityViolator.java" />
+    </Field>
+    <SourceLine classname="MediumPriorityViolator" start="5" end="5" startBytecode="6" endBytecode="6"
+      sourcefile="MediumPriorityViolator.java" sourcepath="MediumPriorityViolator.java" />
+  </BugInstance>
+  <Errors errors="0" missingClasses="0"></Errors>
+  <FindBugsSummary timestamp="Mon, 7 Nov 2016 15:34:20 +0100" total_classes="3" referenced_classes="16" total_bugs="3"
+    total_size="19" num_packages="1" java_version="1.8.0_102" vm_version="25.102-b14" cpu_seconds="4.66"
+    clock_seconds="1.51" peak_mbytes="112.24" alloc_mbytes="1820.50" gc_seconds="0.04" priority_3="1" priority_2="1"
+    priority_1="1">
+    <PackageStats package="" total_bugs="3" total_types="3" total_size="19" priority_3="1" priority_2="1"
+      priority_1="1">
+      <ClassStats class="HighPriorityViolator" sourceFile="HighPriorityViolator.java" interface="false" size="8"
+        bugs="1" priority_1="1" />
+      <ClassStats class="LowPriorityViolator" sourceFile="LowPriorityViolator.java" interface="false" size="5" bugs="1"
+        priority_3="1" />
+      <ClassStats class="MediumPriorityViolator" sourceFile="MediumPriorityViolator.java" interface="false" size="6"
+        bugs="1" priority_2="1" />
+    </PackageStats>
+    <FindBugsProfile>
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine" totalMilliseconds="323"
+        invocations="336" avgMicrosecondsPerInvocation="962" maxMicrosecondsPerInvocation="30204"
+        standardDeviationMircosecondsPerInvocation="2932" />
+      <ClassProfile name="edu.umd.cs.findbugs.util.TopologicalSort" totalMilliseconds="70" invocations="303"
+        avgMicrosecondsPerInvocation="233" maxMicrosecondsPerInvocation="8377"
+        standardDeviationMircosecondsPerInvocation="724" />
+      <ClassProfile name="edu.umd.cs.findbugs.detect.FieldItemSummary" totalMilliseconds="59" invocations="16"
+        avgMicrosecondsPerInvocation="3715" maxMicrosecondsPerInvocation="18686"
+        standardDeviationMircosecondsPerInvocation="4920" />
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.MethodGenFactory" totalMilliseconds="57"
+        invocations="5" avgMicrosecondsPerInvocation="11422" maxMicrosecondsPerInvocation="55743"
+        standardDeviationMircosecondsPerInvocation="22161" />
+      <ClassProfile name="edu.umd.cs.findbugs.OpcodeStack$JumpInfoFactory" totalMilliseconds="51" invocations="68"
+        avgMicrosecondsPerInvocation="756" maxMicrosecondsPerInvocation="7920"
+        standardDeviationMircosecondsPerInvocation="1319" />
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.JavaClassAnalysisEngine" totalMilliseconds="41"
+        invocations="32" avgMicrosecondsPerInvocation="1299" maxMicrosecondsPerInvocation="23298"
+        standardDeviationMircosecondsPerInvocation="4145" />
+      <ClassProfile name="edu.umd.cs.findbugs.detect.FindNoSideEffectMethods" totalMilliseconds="39" invocations="16"
+        avgMicrosecondsPerInvocation="2472" maxMicrosecondsPerInvocation="10403"
+        standardDeviationMircosecondsPerInvocation="3205" />
+      <ClassProfile name="edu.umd.cs.findbugs.detect.OverridingEqualsNotSymmetrical" totalMilliseconds="27"
+        invocations="16" avgMicrosecondsPerInvocation="1727" maxMicrosecondsPerInvocation="12931"
+        standardDeviationMircosecondsPerInvocation="3235" />
+      <ClassProfile name="edu.umd.cs.findbugs.detect.FindOpenStream" totalMilliseconds="26" invocations="3"
+        avgMicrosecondsPerInvocation="8713" maxMicrosecondsPerInvocation="26089"
+        standardDeviationMircosecondsPerInvocation="12286" />
+      <ClassProfile name="edu.umd.cs.findbugs.detect.NoteDirectlyRelevantTypeQualifiers" totalMilliseconds="26"
+        invocations="16" avgMicrosecondsPerInvocation="1631" maxMicrosecondsPerInvocation="10411"
+        standardDeviationMircosecondsPerInvocation="2508" />
+      <ClassProfile name="edu.umd.cs.findbugs.detect.FunctionsThatMightBeMistakenForProcedures" totalMilliseconds="24"
+        invocations="16" avgMicrosecondsPerInvocation="1533" maxMicrosecondsPerInvocation="5715"
+        standardDeviationMircosecondsPerInvocation="1914" />
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassDataAnalysisEngine" totalMilliseconds="21"
+        invocations="337" avgMicrosecondsPerInvocation="65" maxMicrosecondsPerInvocation="1195"
+        standardDeviationMircosecondsPerInvocation="93" />
+      <ClassProfile name="edu.umd.cs.findbugs.detect.BuildObligationPolicyDatabase" totalMilliseconds="20"
+        invocations="16" avgMicrosecondsPerInvocation="1250" maxMicrosecondsPerInvocation="6185"
+        standardDeviationMircosecondsPerInvocation="1733" />
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.TypeDataflowFactory" totalMilliseconds="18"
+        invocations="5" avgMicrosecondsPerInvocation="3687" maxMicrosecondsPerInvocation="15942"
+        standardDeviationMircosecondsPerInvocation="6151" />
+    </FindBugsProfile>
+  </FindBugsSummary>
+  <ClassFeatures></ClassFeatures>
+  <History></History>
+</BugCollection>

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/QuietLogger.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/QuietLogger.groovy
@@ -4,9 +4,9 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.slf4j.Marker
 
-class QuietLogger implements Logger {
+enum QuietLogger implements Logger {
 
-    public static final QuietLogger INSTANCE = new QuietLogger()
+    INSTANCE
 
     private QuietLogger() {
         // no instance

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -1,5 +1,6 @@
 package com.novoda.staticanalysis
 
+import com.novoda.staticanalysis.findbugs.FindbugsConfigurator
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -8,6 +9,7 @@ import org.gradle.api.Task
 class StaticAnalysisPlugin implements Plugin<Project> {
     private final CheckstyleConfigurator checkstyleConfigurator = new CheckstyleConfigurator()
     private final PmdConfigurator pmdConfigurator = new PmdConfigurator()
+    private final FindbugsConfigurator findbugsConfigurator = new FindbugsConfigurator()
 
     @Override
     void apply(Project project) {
@@ -20,6 +22,7 @@ class StaticAnalysisPlugin implements Plugin<Project> {
         }
         checkstyleConfigurator.configure(project, allViolations.create('Checkstyle'), extension, evaluateViolations)
         pmdConfigurator.configure(project, allViolations.create('PMD'), extension, evaluateViolations)
+        findbugsConfigurator.configure(project, allViolations.create('Findbugs'), extension, evaluateViolations)
         project.afterEvaluate {
             project.tasks['check'].dependsOn evaluateViolations
         }

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FinbugsViolationsEvaluator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FinbugsViolationsEvaluator.groovy
@@ -1,0 +1,30 @@
+package com.novoda.staticanalysis.findbugs
+
+import groovy.util.slurpersupport.GPathResult
+
+class FinbugsViolationsEvaluator {
+
+    private final GPathResult xml
+
+    FinbugsViolationsEvaluator(File report) {
+        this(new XmlSlurper().parse(report))
+    }
+
+    FinbugsViolationsEvaluator(GPathResult xml) {
+        this.xml = xml
+    }
+
+    int errorsCount() {
+        count('@priority_1')
+    }
+
+    private int count(String attr) {
+        def count = xml.FindBugsSummary[attr]
+        count == "" ? 0 : count.toInteger()
+    }
+
+    int warningsCount() {
+        count("@priority_2") + count("@priority_3")
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
@@ -38,7 +38,7 @@ class FindbugsConfigurator {
             evaluateReports(xmlReportFile, htmlReportFile, violations)
         }
 
-        project.tasks.create("${findBugs.name}GenerateHtmlReport", GenerateHtmlReport) { GenerateHtmlReport generateHtmlReport ->
+        project.tasks.create("generate${findBugs.name.capitalize()}HtmlReport", GenerateHtmlReport) { GenerateHtmlReport generateHtmlReport ->
             generateHtmlReport.xmlReportFile = xmlReportFile
             generateHtmlReport.htmlReportFile = htmlReportFile
             generateHtmlReport.classpath = findBugs.findbugsClasspath

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
@@ -26,6 +26,15 @@ class FindbugsConfigurator {
         }
     }
 
+    private void configureExtension(FindBugsExtension extension, List<String> excludes, Closure config) {
+        extension.with {
+            toolVersion = '3.0.1'
+            ext.exclude = { String filter -> excludes.add(filter) }
+            config.delegate = it
+            config()
+        }
+    }
+
     private void configureAndroidIfNeeded(Project project) {
         boolean isAndroidApp = project.plugins.hasPlugin('com.android.application')
         boolean isAndroidLib = project.plugins.hasPlugin('com.android.library')
@@ -71,15 +80,6 @@ class FindbugsConfigurator {
             generateHtmlReport.classpath = findBugs.findbugsClasspath
             generateHtmlReport.dependsOn findBugs
             evaluateViolations.dependsOn generateHtmlReport
-        }
-    }
-
-    private void configureExtension(FindBugsExtension extension, List<String> excludes, Closure config) {
-        extension.with {
-            toolVersion = '3.0.1'
-            ext.exclude = { String filter -> excludes.add(filter) }
-            config.delegate = it
-            config()
         }
     }
 

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
@@ -61,7 +61,10 @@ class FindbugsConfigurator {
         findBugs.doLast {
             evaluateReports(xmlReportFile, htmlReportFile, violations)
         }
+        createHtmlReportTask(project, findBugs, xmlReportFile, htmlReportFile, evaluateViolations)
+    }
 
+    private GenerateHtmlReport createHtmlReportTask(Project project, FindBugs findBugs, File xmlReportFile, File htmlReportFile, evaluateViolations) {
         project.tasks.create("generate${findBugs.name.capitalize()}HtmlReport", GenerateHtmlReport) { GenerateHtmlReport generateHtmlReport ->
             generateHtmlReport.xmlReportFile = xmlReportFile
             generateHtmlReport.htmlReportFile = htmlReportFile

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
@@ -1,0 +1,41 @@
+package com.novoda.staticanalysis.findbugs
+
+import com.novoda.staticanalysis.StaticAnalysisExtension
+import com.novoda.staticanalysis.Violations
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.quality.FindBugs
+import org.gradle.api.plugins.quality.FindBugsExtension
+
+class FindbugsConfigurator {
+
+    void configure(Project project, Violations violations, StaticAnalysisExtension extension, Task evaluateViolations) {
+        extension.ext.findbugs = { Closure config ->
+            project.apply plugin: QuietFindbugsPlugin
+            List<String> excludes = []
+            configureExtension(project.extensions.findByType(FindBugsExtension), excludes, config)
+            project.afterEvaluate {
+                project.tasks.withType(FindBugs) { FindBugs findBugs ->
+                    configureTask(project, findBugs, evaluateViolations, violations)
+                }
+            }
+        }
+    }
+
+    private void configureTask(Project project, FindBugs findBugs, Task evaluateViolations, Violations violations) {
+        findBugs.effort = 'max'
+        findBugs.reportLevel = 'low'
+        findBugs.ignoreFailures = true
+        findBugs.reports.xml.enabled = true
+        findBugs.reports.html.enabled = false
+        evaluateViolations.dependsOn findBugs
+    }
+
+    private void configureExtension(FindBugsExtension extension, List<String> excludes, Closure config) {
+        extension.with {
+            toolVersion = '3.0.1'
+            config.delegate = it
+            config()
+        }
+    }
+}

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/FindbugsConfigurator.groovy
@@ -19,18 +19,19 @@ class FindbugsConfigurator {
             configureExtension(project.extensions.findByType(FindBugsExtension), excludes, config)
             project.afterEvaluate {
                 project.tasks.withType(FindBugs) { FindBugs findBugs ->
-                    configureTask(project, findBugs, evaluateViolations, violations)
+                    configureTask(project, findBugs, evaluateViolations, violations, excludes)
                 }
             }
         }
     }
 
-    private void configureTask(Project project, FindBugs findBugs, Task evaluateViolations, Violations violations) {
+    private void configureTask(Project project, FindBugs findBugs, Task evaluateViolations, Violations violations, List<String> excludes) {
         findBugs.effort = 'max'
         findBugs.reportLevel = 'low'
         findBugs.ignoreFailures = true
         findBugs.reports.xml.enabled = true
         findBugs.reports.html.enabled = false
+        findBugs.exclude(excludes)
         File xmlReportFile = findBugs.reports.xml.destination
         File htmlReportFile = new File(xmlReportFile.absolutePath - '.xml' + '.html')
         findBugs.doLast {
@@ -49,6 +50,7 @@ class FindbugsConfigurator {
     private void configureExtension(FindBugsExtension extension, List<String> excludes, Closure config) {
         extension.with {
             toolVersion = '3.0.1'
+            ext.exclude = { String filter -> excludes.add(filter) }
             config.delegate = it
             config()
         }

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/QuietFindbugsPlugin.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/findbugs/QuietFindbugsPlugin.groovy
@@ -1,0 +1,22 @@
+package com.novoda.staticanalysis.findbugs
+
+import com.novoda.staticanalysis.QuietLogger
+import org.gradle.api.logging.Logger
+import org.gradle.api.plugins.quality.FindBugs
+import org.gradle.api.plugins.quality.FindBugsPlugin
+
+public class QuietFindbugsPlugin extends FindBugsPlugin {
+
+    @Override
+    protected Class<FindBugs> getTaskType() {
+        Task
+    }
+
+    static class Task extends FindBugs {
+        @Override
+        public Logger getLogger() {
+            QuietLogger.INSTANCE
+        }
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION
 import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION
 import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_MEDIUM_VIOLATION
 import static com.novoda.test.LogsSubject.assertThat
@@ -40,6 +41,79 @@ class FindbugsIntegrationTest {
         assertThat(result.logs).containsLimitExceeded(0, 2)
         assertThat(result.logs).containsFindbugsViolations(0, 2,
                 result.buildFile('reports/findbugs/main.html'))
+    }
+
+    @Test
+    public void shouldFailBuildWhenFindbugsErrorsOverTheThreshold() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 0
+                }''')
+                .withFindbugs('findbugs {}')
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(1, 0)
+        assertThat(result.logs).containsFindbugsViolations(1, 0,
+                result.buildFile('reports/findbugs/main.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenNoFindbugsWarningsOrErrorsEncounteredAndNoThresholdTrespassed() {
+        TestProject.Result result = projectRule.newProject()
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 0
+                }''')
+                .withFindbugs('findbugs {}')
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).doesNotContainFindbugsViolations()
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenFindbugsWarningsAndErrorsEncounteredAndNoThresholdTrespassed() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
+                .withSourceSet('main2', SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 100
+                    maxWarnings = 100
+                }''')
+                .withFindbugs('findbugs {}')
+                .build('check')
+
+        assertThat(result.logs).doesNotContainLimitExceeded()
+        assertThat(result.logs).containsFindbugsViolations(1, 2,
+                result.buildFile('reports/findbugs/main.html'),
+                result.buildFile('reports/findbugs/main2.html'))
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenFindbugsConfiguredToNotIgnoreFailures() {
+        projectRule.newProject()
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
+                .withSourceSet('main2', SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 100
+                    maxWarnings = 100
+                }''')
+                .withFindbugs('findbugs { ignoreFailures = false }')
+                .build('check')
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenFindbugsNotConfigured() {
+        projectRule.newProject()
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
+                .withSourceSet('main2', SOURCES_WITH_HIGH_VIOLATION)
+                .withPenalty('''{
+                    maxErrors = 0
+                    maxWarnings = 0
+                }''')
+                .build('check')
     }
 
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
@@ -1,6 +1,5 @@
 package com.novoda.staticanalysis
 
-import com.novoda.test.Fixtures
 import com.novoda.test.TestProject
 import com.novoda.test.TestProjectRule
 import org.junit.Rule
@@ -8,6 +7,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION
+import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_MEDIUM_VIOLATION
 import static com.novoda.test.LogsSubject.assertThat
 
 @RunWith(Parameterized.class)
@@ -28,15 +29,17 @@ class FindbugsIntegrationTest {
     @Test
     public void shouldFailBuildWhenFindbugsWarningsOverTheThreshold() {
         TestProject.Result result = projectRule.newProject()
-                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION, Fixtures.Findbugs.SOURCES_WITH_MEDIUM_VIOLATION)
+                .withSourceSet('main', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
                 .withPenalty('''{
-                    maxWarnings 0
-                    maxErrors 0
+                    maxErrors = 0
+                    maxWarnings = 0
                 }''')
                 .withFindbugs('findbugs {}')
                 .buildAndFail('check')
 
         assertThat(result.logs).containsLimitExceeded(0, 2)
+        assertThat(result.logs).containsFindbugsViolations(0, 2,
+                result.buildFile('reports/findbugs/main.html'))
     }
 
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
@@ -1,0 +1,42 @@
+package com.novoda.staticanalysis
+
+import com.novoda.test.Fixtures
+import com.novoda.test.TestProject
+import com.novoda.test.TestProjectRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static com.novoda.test.LogsSubject.assertThat
+
+@RunWith(Parameterized.class)
+class FindbugsIntegrationTest {
+
+    @Parameterized.Parameters
+    public static List<Object[]> rules() {
+        return [TestProjectRule.forJavaProject()].collect { [it] as Object[] }
+    }
+
+    @Rule
+    public final TestProjectRule projectRule
+
+    FindbugsIntegrationTest(TestProjectRule projectRule) {
+        this.projectRule = projectRule
+    }
+
+    @Test
+    public void shouldFailBuildWhenFindbugsWarningsOverTheThreshold() {
+        TestProject.Result result = projectRule.newProject()
+                .withSourceSet('main', Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION, Fixtures.Findbugs.SOURCES_WITH_MEDIUM_VIOLATION)
+                .withPenalty('''{
+                    maxWarnings 0
+                    maxErrors 0
+                }''')
+                .withFindbugs('findbugs {}')
+                .buildAndFail('check')
+
+        assertThat(result.logs).containsLimitExceeded(0, 2)
+    }
+
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/FindbugsIntegrationTest.groovy
@@ -7,9 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_HIGH_VIOLATION
-import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_LOW_VIOLATION
-import static com.novoda.test.Fixtures.Findbugs.SOURCES_WITH_MEDIUM_VIOLATION
+import static com.novoda.test.Fixtures.Findbugs.*
 import static com.novoda.test.LogsSubject.assertThat
 
 @RunWith(Parameterized.class)
@@ -17,7 +15,7 @@ class FindbugsIntegrationTest {
 
     @Parameterized.Parameters
     public static List<Object[]> rules() {
-        return [TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
+        return [TestProjectRule.forJavaProject(), TestProjectRule.forAndroidProject()].collect { [it] as Object[] }
     }
 
     @Rule
@@ -79,8 +77,8 @@ class FindbugsIntegrationTest {
                 .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
                 .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)
                 .withPenalty('''{
-                    maxErrors = 100
-                    maxWarnings = 100
+                    maxErrors = 10
+                    maxWarnings = 10
                 }''')
                 .withFindbugs('findbugs {}')
                 .build('check')
@@ -97,8 +95,8 @@ class FindbugsIntegrationTest {
                 .withSourceSet('debug', SOURCES_WITH_LOW_VIOLATION, SOURCES_WITH_MEDIUM_VIOLATION)
                 .withSourceSet('release', SOURCES_WITH_HIGH_VIOLATION)
                 .withPenalty('''{
-                    maxErrors = 100
-                    maxWarnings = 100
+                    maxErrors = 10
+                    maxWarnings = 10
                 }''')
                 .withFindbugs('findbugs { ignoreFailures = false }')
                 .build('check')

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/PmdIntegrationTest.groovy
@@ -96,7 +96,7 @@ public class PmdIntegrationTest {
     }
 
     /**
-     * We found out PMD sometimes ... the same violation twice, but with different priority.
+     * We found out PMD sometimes detects the same violation twice, but with different priority.
      * The issue seems related to the customisation of a rule coming from one of the predefined rule sets.
      */
     @Test

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/findbugs/FindbugsViolationsEvaluatorTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/findbugs/FindbugsViolationsEvaluatorTest.groovy
@@ -1,0 +1,30 @@
+package com.novoda.staticanalysis.findbugs
+
+import com.novoda.test.Fixtures
+import org.junit.Before
+import org.junit.Test
+
+import static com.google.common.truth.Truth.assertThat
+
+class FindbugsViolationsEvaluatorTest {
+    private FinbugsViolationsEvaluator evaluator
+
+    @Before
+    public void setUp() {
+        evaluator = new FinbugsViolationsEvaluator(Fixtures.Findbugs.SAMPLE_REPORT)
+    }
+
+    @Test
+    public void shouldCountAllWarningsWithPriority1AsErrors() {
+        int count = evaluator.errorsCount()
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldCountAllWarningsWithPriority2And3AsWarnings() {
+        int count = evaluator.warningsCount()
+
+        assertThat(count).isEqualTo(2);
+    }
+}

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -38,6 +38,7 @@ public final class Fixtures {
         public static final File SOURCES_WITH_HIGH_VIOLATION = new File(FIXTURES_DIR, 'findbugs/high')
         public static final File SOURCES_WITH_MEDIUM_VIOLATION = new File(FIXTURES_DIR, 'findbugs/medium')
         public static final File SOURCES_WITH_LOW_VIOLATION = new File(FIXTURES_DIR, 'findbugs/low')
+        public static final File SAMPLE_REPORT = new File(FIXTURES_DIR, 'findbugs/reports/sample.xml')
     }
 
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/Fixtures.groovy
@@ -34,4 +34,10 @@ public final class Fixtures {
         public static final File SAMPLE_REPORT = new File(FIXTURES_DIR, 'pmd/reports/sample.xml')
     }
 
+    public final static class Findbugs {
+        public static final File SOURCES_WITH_HIGH_VIOLATION = new File(FIXTURES_DIR, 'findbugs/high')
+        public static final File SOURCES_WITH_MEDIUM_VIOLATION = new File(FIXTURES_DIR, 'findbugs/medium')
+        public static final File SOURCES_WITH_LOW_VIOLATION = new File(FIXTURES_DIR, 'findbugs/low')
+    }
+
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -13,6 +13,7 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
     private static final String VIOLATIONS_LIMIT_EXCEEDED = "Violations limit exceeded"
     private static final String CHECKSTYLE_VIOLATIONS_FOUND = "Checkstyle rule violations were found"
     private static final String PMD_VIOLATIONS_FOUND = "PMD rule violations were found"
+    private static final String FINDBUGS_VIOLATIONS_FOUND = "Findbugs rule violations were found"
     private static final SubjectFactory<LogsSubject, Logs> FACTORY = new SubjectFactory<LogsSubject, Logs>() {
         @Override
         LogsSubject getSubject(FailureStrategy failureStrategy, Logs logs) {
@@ -55,6 +56,14 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
     public void containsPmdViolations(int errors, int warnings, File... reports) {
         def output = Truth.assertThat(actual().output)
         output.contains("$PMD_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
+        for (File report : reports) {
+            output.contains(report.path)
+        }
+    }
+
+    public void containsFindbugsViolations(int errors, int warnings, File... reports) {
+        def output = Truth.assertThat(actual().output)
+        output.contains("$FINDBUGS_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
         for (File report : reports) {
             output.contains(report.path)
         }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -45,6 +45,10 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
         Truth.assertThat(actual().output).doesNotContain(PMD_VIOLATIONS_FOUND)
     }
 
+    public void doesNotContainFindbugsViolations() {
+        Truth.assertThat(actual().output).doesNotContain(FINDBUGS_VIOLATIONS_FOUND)
+    }
+
     public void containsCheckstyleViolations(int errors, int warnings, File... reports) {
         def output = Truth.assertThat(actual().output)
         output.contains("$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProject.groovy
@@ -10,6 +10,7 @@ staticAnalysis {
     ${(project.penalty ?: '').replace('            ', '')}
     ${(project.checkstyle ?: '').replace('        ', '    ')}
     ${(project.pmd ?: '').replace('        ', '    ')}
+    ${(project.findbugs ?: '').replace('        ', '    ')}
 }
 """
     }
@@ -21,6 +22,7 @@ staticAnalysis {
     String penalty
     String checkstyle
     String pmd
+    String findbugs
 
     TestProject(Closure<String> template) {
         this.template = template
@@ -77,6 +79,11 @@ staticAnalysis {
 
     public TestProject withPmd(String pmd) {
         this.pmd = pmd
+        return this
+    }
+
+    public TestProject withFindbugs(String findbugs) {
+        this.findbugs = findbugs
         return this
     }
 

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProjectSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProjectSubject.groovy
@@ -1,0 +1,34 @@
+package com.novoda.test
+
+import com.google.common.truth.*
+
+import javax.annotation.Nullable
+
+class TestProjectSubject extends Subject<TestProjectSubject, TestProject> {
+
+    private static final SubjectFactory<TestProjectSubject, TestProject> FACTORY = newFactory()
+    private static SubjectFactory<TestProjectSubject, TestProject> newFactory() {
+        new SubjectFactory<TestProjectSubject, TestProject>() {
+            @Override
+            TestProjectSubject getSubject(FailureStrategy failureStrategy, TestProject testProject) {
+                return new TestProjectSubject(failureStrategy, testProject)
+            }
+        }
+    }
+
+    private TestProjectSubject(FailureStrategy failureStrategy, @Nullable TestProject testProject) {
+        super(failureStrategy, testProject)
+    }
+
+    public static TestProjectSubject assumeThat(TestProject testProject) {
+        TruthJUnit.assume().about(FACTORY).that(testProject)
+    }
+
+    public void isAndroidProject() {
+        if (!(actual() instanceof TestAndroidProject)) {
+            failureStrategy.fail(String.format('project was instance of <%s>, but was instance of <%s> instead',
+                    TestAndroidProject.simpleName,
+                    actual().getClass().simpleName))
+        }
+    }
+}


### PR DESCRIPTION
> Tracked in JIRA by [PT-277](https://novoda.atlassian.net/browse/PT-277)

### Scope of the PR

We want to use the `static-analysis-plugin` to easily integrate FindBugs in a Java or Android project. Features should be in parity with the current Checkstyle and PMD integration:
- evaluation of violations grouped as warnings or errors
- introduce exclude filters to ignore paths from the FindBugs analysis
- logging facilities detailing limits exceeded and relevant reports
- disable FindBugs integration if no configuration provided

### Considerations/Implementation Details

- Added fixtures for both rules and java files to be used in integration tests.
- Introduced `FindBugsViolationsEvaluator` as delegate used to evaluate violations listed in the FindBugs xml reports. Apparently FindBugs supports three level of warnings (from higher to lower: `priority_1`, `priority_2` and `priority_3`). We decided to consider `priority_1` as errors, while other violations are collected as warnings.
- Introduced a custom task to workaround the limitation in FindBugs where only one type of report can be enabled at time (xml or html). The task uses the `PrintingBugReporter` available in findBugs to generate the html report from an xml one.
- Introduced `QuietFindbugsPlugin` as custom implementation of `FindBugsPlugin` enforcing a quiet logger for its output. Unfortunately the `metaClass` trick used in the other configurators didn't work in this case, no clue why 😕 .
- Introduced `FindBugsConfigurator` to delegate configuration of FindBugs for Java/Android projects
- Amended `TestProject` builder to generate FindBugs configuration closure when provided.
- Amended `LogsSubject` to account for output from FindBugs analysis

**NOTE:** to make FindBugs work in Android projects we had to change the approach used in other configurators. Given the tool is analysing bytecode we had to take in account variants instead of source sets, following the way the Android Gradle plugin collects compiled classes. This also implies that source sets that are shared across variants (eg: `main`) will contribute to the final count of violations for each of the variants in the project. Right now we have documented this behaviour in one of the integration tests, but we are planning to workaround the issue in a follow-up PR.

#### Testing

- FindBugs configuration and evaluation is checked via `FindBugsIntegrationTest`
- Evaluation of violations in FindBugs xml reports is checked via `FindBugsViolationsEvaluatorTest`

> paired with @eduardb 