### PR TITLE
PR-272/PT-298: Use testing verb correctly in custom subjects for static-analysis-plugin

### DIFF
--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/LogsSubject.groovy
@@ -1,9 +1,11 @@
 package com.novoda.test
 
 import com.google.common.truth.FailureStrategy
+import com.google.common.truth.StringSubject
 import com.google.common.truth.Subject
 import com.google.common.truth.SubjectFactory
 import com.google.common.truth.Truth
+import com.google.common.truth.TruthJUnit
 
 import javax.annotation.Nullable
 
@@ -25,51 +27,56 @@ class LogsSubject extends Subject<LogsSubject, Logs> {
         Truth.assertAbout(FACTORY).that(logs)
     }
 
+    public static LogsSubject assumeThat(Logs logs) {
+        TruthJUnit.assume().about(FACTORY).that(logs)
+    }
+
     LogsSubject(FailureStrategy failureStrategy, @Nullable Logs actual) {
         super(failureStrategy, actual)
     }
 
+    private StringSubject getOutputSubject() {
+        check().that(actual().output)
+    }
+
     public void doesNotContainLimitExceeded() {
-        Truth.assertThat(actual().output).doesNotContain(VIOLATIONS_LIMIT_EXCEEDED)
+        outputSubject.doesNotContain(VIOLATIONS_LIMIT_EXCEEDED)
     }
 
     public void containsLimitExceeded(int errors, int warnings) {
-        Truth.assertThat(actual().output).contains("$VIOLATIONS_LIMIT_EXCEEDED by $errors errors, $warnings warnings.")
+        outputSubject.contains("$VIOLATIONS_LIMIT_EXCEEDED by $errors errors, $warnings warnings.")
     }
 
     public void doesNotContainCheckstyleViolations() {
-        Truth.assertThat(actual().output).doesNotContain(CHECKSTYLE_VIOLATIONS_FOUND)
+        outputSubject.doesNotContain(CHECKSTYLE_VIOLATIONS_FOUND)
     }
 
     public void doesNotContainPmdViolations() {
-        Truth.assertThat(actual().output).doesNotContain(PMD_VIOLATIONS_FOUND)
+        outputSubject.doesNotContain(PMD_VIOLATIONS_FOUND)
     }
 
     public void doesNotContainFindbugsViolations() {
-        Truth.assertThat(actual().output).doesNotContain(FINDBUGS_VIOLATIONS_FOUND)
+        outputSubject.doesNotContain(FINDBUGS_VIOLATIONS_FOUND)
     }
 
     public void containsCheckstyleViolations(int errors, int warnings, File... reports) {
-        def output = Truth.assertThat(actual().output)
-        output.contains("$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
+        outputSubject.contains("$CHECKSTYLE_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
         for (File report : reports) {
-            output.contains(report.path)
+            outputSubject.contains(report.path)
         }
     }
 
     public void containsPmdViolations(int errors, int warnings, File... reports) {
-        def output = Truth.assertThat(actual().output)
-        output.contains("$PMD_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
+        outputSubject.contains("$PMD_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
         for (File report : reports) {
-            output.contains(report.path)
+            outputSubject.contains(report.path)
         }
     }
 
     public void containsFindbugsViolations(int errors, int warnings, File... reports) {
-        def output = Truth.assertThat(actual().output)
-        output.contains("$FINDBUGS_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
+        outputSubject.contains("$FINDBUGS_VIOLATIONS_FOUND ($errors errors, $warnings warnings). See the reports at:\n")
         for (File report : reports) {
-            output.contains(report.path)
+            outputSubject.contains(report.path)
         }
     }
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/PenaltyExtensionSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/PenaltyExtensionSubject.groovy
@@ -8,12 +8,11 @@ import com.novoda.staticanalysis.PenaltyExtension
 import javax.annotation.Nullable
 
 import static com.google.common.truth.Truth.assertAbout
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume
 
 class PenaltyExtensionSubject extends Subject<PenaltyExtensionSubject, PenaltyExtension> {
 
     private static final SubjectFactory<PenaltyExtensionSubject, PenaltyExtension> FACTORY = newFactory()
-
     private static SubjectFactory<PenaltyExtensionSubject, PenaltyExtension> newFactory() {
         new SubjectFactory<PenaltyExtensionSubject, PenaltyExtension>() {
             @Override
@@ -23,20 +22,25 @@ class PenaltyExtensionSubject extends Subject<PenaltyExtensionSubject, PenaltyEx
         }
     }
 
-    private PenaltyExtensionSubject(FailureStrategy failureStrategy, @Nullable PenaltyExtension actual) {
-        super(failureStrategy, actual)
-    }
-
     public static PenaltyExtensionSubject assertThat(PenaltyExtension extension) {
         assertAbout(FACTORY).that(extension)
     }
 
+
+    public static PenaltyExtensionSubject assumeThat(PenaltyExtension extension) {
+        assume().about(FACTORY).that(extension)
+    }
+
+    private PenaltyExtensionSubject(FailureStrategy failureStrategy, @Nullable PenaltyExtension actual) {
+        super(failureStrategy, actual)
+    }
+
     public void hasMaxWarnings(int maxWarnings) {
-        assertThat(actual().maxWarnings).isEqualTo(maxWarnings)
+        check().that(actual().maxWarnings).isEqualTo(maxWarnings)
     }
 
     public void hasMaxErrors(int maxErrors) {
-        assertThat(actual().maxErrors).isEqualTo(maxErrors)
+        check().that(actual().maxErrors).isEqualTo(maxErrors)
     }
 
 }

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProjectSubject.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/test/TestProjectSubject.groovy
@@ -25,10 +25,6 @@ class TestProjectSubject extends Subject<TestProjectSubject, TestProject> {
     }
 
     public void isAndroidProject() {
-        if (!(actual() instanceof TestAndroidProject)) {
-            failureStrategy.fail(String.format('project was instance of <%s>, but was instance of <%s> instead',
-                    TestAndroidProject.simpleName,
-                    actual().getClass().simpleName))
-        }
+        check().that(actual()).isInstanceOf(TestAndroidProject)
     }
 }


### PR DESCRIPTION
> Tracked in JIRA by [PT-298](https://novoda.atlassian.net/browse/PT-298)

### Scope of the PR

We are using [`Truth`](https://github.com/google/truth) as assertion framework in our tests. This allows us to offering extensions to the assertions API tailored to the targets of our tests. We noticed in few places the implementation was incorrectly forcing assertions defeating the whole ["_We've made failure a strategy_"](https://github.com/google/truth#truth) mantra.

### Considerations/Implementation Details

- Amended the custom `Subject`s to retrieve the current testing verb (ie: `assert` vs `assume`) instead of enforcing one in the implementation. This is possible via [`Subject#check()`](http://google.github.io/truth/api/latest/com/google/common/truth/Subject.html#check()), that allows to chain other `Subject` within our custom propositional logic
- Removed custom failure in `TestProjectSubject` in favour of the simple [`Subject#instanceOf()`](http://google.github.io/truth/api/latest/com/google/common/truth/Subject.html#isInstanceOf(java.lang.Class)) check available out-of-the-box.

#### Testing

Refactoring only. We checked tests are still passing.

> Paired with @eduardb 