### PR TITLE
PT-294: Integrate bintray-release plugin to publish static-analysis-plugin artifact

### DIFF
--- a/static-analysis-plugin/build.gradle
+++ b/static-analysis-plugin/build.gradle
@@ -3,6 +3,9 @@ subprojects {
         repositories {
             jcenter()
         }
+        dependencies {
+            classpath 'com.novoda:bintray-release:0.4.0'
+        }
     }
 
     repositories {

--- a/static-analysis-plugin/gradle/publish.gradle
+++ b/static-analysis-plugin/gradle/publish.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'com.novoda.bintray-release'
+publish {
+    userOrg = 'novoda'
+    groupId = 'com.novoda'
+    artifactId = 'static-analysis-plugin'
+    publishVersion = '0.1'
+    website = 'https://github.com/novoda/spikes/tree/master/static-analysis-plugin'
+}
+

--- a/static-analysis-plugin/plugin/build.gradle
+++ b/static-analysis-plugin/plugin/build.gradle
@@ -4,6 +4,7 @@ repositories {
 
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
+apply from: rootProject.file('gradle/publish.gradle')
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7


### PR DESCRIPTION
> Tracked in JIRA by [PT-294](https://novoda.atlassian.net/browse/PT-294)

### Scope of the PR

We want to integrate the plugin in some of the running projects in Novoda. For this we need to publish an artifact to Bintray.

### Considerations/Implementation Details

The publishing configuration will use the [`bintray-release`](https://github.com/novoda/bintray-release/) plugin. The current version of the plugin is set to `0.1`. The artifact will be deployed via our Jenkins as usual.

#### Testing
Manually checked the artifact is created correctly along with the `pom.xml` when the `bintrayUpload` task is executed.

> Paired with @eduardb 