### PR TITLE
Move classes to subpackages

### DIFF
--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/EvaluateViolationsTask.groovy
@@ -1,5 +1,6 @@
 package com.novoda.staticanalysis
 
+import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/StaticAnalysisPlugin.groovy
@@ -1,6 +1,9 @@
 package com.novoda.staticanalysis
 
-import com.novoda.staticanalysis.findbugs.FindbugsConfigurator
+import com.novoda.staticanalysis.internal.checkstyle.CheckstyleConfigurator
+import com.novoda.staticanalysis.internal.findbugs.FindbugsConfigurator
+import com.novoda.staticanalysis.internal.Violations
+import com.novoda.staticanalysis.internal.pmd.PmdConfigurator
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/QuietLogger.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/QuietLogger.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal
 
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Violations.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/Violations.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis;
+package com.novoda.staticanalysis.internal;
 
 class Violations {
     private final String toolName

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleConfigurator.groovy
@@ -1,5 +1,8 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal.checkstyle
 
+import com.novoda.staticanalysis.internal.QuietLogger
+import com.novoda.staticanalysis.StaticAnalysisExtension
+import com.novoda.staticanalysis.internal.Violations
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FinbugsViolationsEvaluator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FinbugsViolationsEvaluator.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis.findbugs
+package com.novoda.staticanalysis.internal.findbugs
 
 import groovy.util.slurpersupport.GPathResult
 

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsConfigurator.groovy
@@ -1,7 +1,7 @@
-package com.novoda.staticanalysis.findbugs
+package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.staticanalysis.StaticAnalysisExtension
-import com.novoda.staticanalysis.Violations
+import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.quality.FindBugs

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/QuietFindbugsPlugin.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/findbugs/QuietFindbugsPlugin.groovy
@@ -1,6 +1,6 @@
-package com.novoda.staticanalysis.findbugs
+package com.novoda.staticanalysis.internal.findbugs
 
-import com.novoda.staticanalysis.QuietLogger
+import com.novoda.staticanalysis.internal.QuietLogger
 import org.gradle.api.logging.Logger
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.plugins.quality.FindBugsPlugin

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdConfigurator.groovy
@@ -1,6 +1,8 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal.pmd
 
-import com.novoda.staticanalysis.PmdViolationsEvaluator.PmdViolation
+import com.novoda.staticanalysis.internal.QuietLogger
+import com.novoda.staticanalysis.StaticAnalysisExtension
+import com.novoda.staticanalysis.internal.Violations
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Pmd
@@ -80,7 +82,7 @@ class PmdConfigurator {
     private void evaluateReports(File xmlReportFile, File htmlReportFile, Violations violations) {
         PmdViolationsEvaluator evaluator = new PmdViolationsEvaluator(xmlReportFile)
         int errors = 0, warnings = 0
-        evaluator.collectViolations().each { PmdViolation violation ->
+        evaluator.collectViolations().each { PmdViolationsEvaluator.PmdViolation violation ->
             if (violation.isError()) {
                 errors += 1
             } else {

--- a/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdViolationsEvaluator.groovy
+++ b/static-analysis-plugin/plugin/src/main/groovy/com/novoda/staticanalysis/internal/pmd/PmdViolationsEvaluator.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal.pmd
 
 import groovy.util.slurpersupport.GPathResult
 

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/checkstyle/CheckstyleIntegrationTest.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal.checkstyle
 
 import com.novoda.test.Fixtures
 import com.novoda.test.TestProject

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsIntegrationTest.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.test.TestProject
 import com.novoda.test.TestProjectRule

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsViolationsEvaluatorTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/findbugs/FindbugsViolationsEvaluatorTest.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis.findbugs
+package com.novoda.staticanalysis.internal.findbugs
 
 import com.novoda.test.Fixtures
 import org.junit.Before

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdIntegrationTest.groovy
@@ -1,4 +1,4 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal.pmd
 
 import com.novoda.test.Fixtures
 import com.novoda.test.TestProject

--- a/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdViolationsEvaluatorTest.groovy
+++ b/static-analysis-plugin/plugin/src/test/groovy/com/novoda/staticanalysis/internal/pmd/PmdViolationsEvaluatorTest.groovy
@@ -1,11 +1,11 @@
-package com.novoda.staticanalysis
+package com.novoda.staticanalysis.internal.pmd
 
 import com.novoda.test.Fixtures
 import org.junit.Before
 import org.junit.Test
 
 import static com.google.common.truth.Truth.assertThat
-import static com.novoda.staticanalysis.PmdViolationsEvaluator.PmdViolation
+import static com.novoda.staticanalysis.internal.pmd.PmdViolationsEvaluator.PmdViolation
 
 public class PmdViolationsEvaluatorTest {
 


### PR DESCRIPTION
> Tracked in JIRA by [PT-299](https://novoda.atlassian.net/browse/PT-299)

### Scope of the PR

Almost all of the classes (except for some related to Findbugs - @mr-archano was a visionary) were in the main package, making it a bit hard to identify the different tools that this plugin uses.

### Considerations/Implementation Details

- Create a subpackage for each of the tools (PMD, Findbugs and Checkstyle) under an `internal` subpackage, and move the classes to the adequate package

| Before | After |
| ----- | ----- |
| ![screenshot 2016-11-09 11 12 14](https://cloud.githubusercontent.com/assets/2426348/20135017/f68f058c-a66d-11e6-9f7c-4cc6a0430229.png) | ![screenshot 2016-11-09 11 11 07](https://cloud.githubusercontent.com/assets/2426348/20135022/fb529c0a-a66d-11e6-8877-8c5a2db43726.png) |



#### Testing

Refactoring only. Tests are still passing.

> Paired with @mr-archano  