### PR TITLE
TpBot: Add a TextViewWithForeground

### DIFF
--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/TextViewWithForeground.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/TextViewWithForeground.java
@@ -39,16 +39,19 @@ public class TextViewWithForeground extends TextView {
             if (resourceId == INVALID_RESOURCE_ID) {
                 return;
             }
-            final Drawable drawable = getDrawable(resourceId);
+            final Drawable drawable = getDrawableFor(resourceId);
             updateForegroundWith(drawable);
-            createHotspotTouchListener();
+
+            if (isLollipopOrAfter()) {
+                createHotspotTouchListener();
+            }
 
         } finally {
             styledAttributes.recycle();
         }
     }
 
-    private Drawable getDrawable(int resourceId) {
+    private Drawable getDrawableFor(int resourceId) {
         if (isLollipopOrAfter()) {
             return getDrawableLollipop(getResources(), resourceId);
         } else {

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/TextViewWithForeground.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/TextViewWithForeground.java
@@ -1,0 +1,96 @@
+package com.novoda.tpbot.support;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+import com.novoda.tpbot.R;
+
+public class TextViewWithForeground extends TextView {
+
+    private static final int INVALID_RESOURCE_ID = 0;
+    private Drawable foreground;
+
+    public TextViewWithForeground(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        extractForegroundFrom(context, attrs);
+    }
+
+    private void extractForegroundFrom(Context context, AttributeSet attrs) {
+        TypedArray styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.TextViewWithForeground);
+
+        if (styledAttributes == null) {
+            return;
+        }
+
+        try {
+            int resourceId = styledAttributes.getResourceId(R.styleable.TextViewWithForeground_foreground, INVALID_RESOURCE_ID);
+
+            if (resourceId == INVALID_RESOURCE_ID) {
+                return;
+            }
+            Drawable drawable = getResources().getDrawable(resourceId);
+            updateForegroundWith(drawable);
+
+        } finally {
+            styledAttributes.recycle();
+        }
+    }
+
+    private void updateForegroundWith(Drawable foreground) {
+        this.foreground = foreground;
+        if (foreground == null) {
+            setWillNotDraw(true);
+        } else {
+            setWillNotDraw(false);
+            foreground.setCallback(this);
+            if (foreground.isStateful()) {
+                foreground.setState(getDrawableState());
+            }
+        }
+        requestLayout();
+        invalidate();
+    }
+
+    @Override
+    protected boolean verifyDrawable(@NonNull Drawable who) {
+        return super.verifyDrawable(who) || who.equals(foreground);
+    }
+
+    @Override
+    public void jumpDrawablesToCurrentState() {
+        super.jumpDrawablesToCurrentState();
+        if (foreground != null) {
+            foreground.jumpToCurrentState();
+        }
+    }
+
+    @Override
+    protected void drawableStateChanged() {
+        super.drawableStateChanged();
+        if (foreground != null && foreground.isStateful()) {
+            foreground.setState(getDrawableState());
+        }
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        if (foreground != null) {
+            foreground.setBounds(0, 0, getMeasuredWidth(), getMeasuredHeight());
+        }
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        super.draw(canvas);
+        if (foreground != null) {
+            foreground.draw(canvas);
+        }
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/res/drawable-v21/landing_option_foreground.xml
+++ b/TelepresenceBot/mobile/src/main/res/drawable-v21/landing_option_foreground.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+  android:color="@color/black_12">
+
+  <item
+    android:id="@android:id/mask"
+    android:drawable="@android:color/white" />
+
+</ripple>

--- a/TelepresenceBot/mobile/src/main/res/drawable/landing_option_foreground.xml
+++ b/TelepresenceBot/mobile/src/main/res/drawable/landing_option_foreground.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_pressed="true" android:drawable="@color/black_12" />
+  <item android:state_focused="true" android:drawable="@color/black_10" />
+  <item android:drawable="@color/transparent" />
+</selector>

--- a/TelepresenceBot/mobile/src/main/res/layout/activity_landing.xml
+++ b/TelepresenceBot/mobile/src/main/res/layout/activity_landing.xml
@@ -13,6 +13,7 @@
     android:layout_height="0dp"
     android:layout_weight="100"
     android:background="@android:color/holo_green_light"
+    android:foreground="@drawable/landing_option_foreground"
     android:text="@string/bot"
     android:gravity="center"
     android:textSize="24sp" />
@@ -23,6 +24,7 @@
     android:layout_height="0dp"
     android:layout_weight="100"
     android:background="@android:color/holo_blue_light"
+    android:foreground="@drawable/landing_option_foreground"
     android:text="@string/human"
     android:gravity="center"
     android:textSize="24sp" />

--- a/TelepresenceBot/mobile/src/main/res/layout/activity_landing.xml
+++ b/TelepresenceBot/mobile/src/main/res/layout/activity_landing.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/activity_tp_bot"
   android:layout_width="match_parent"
@@ -7,24 +8,24 @@
   tools:context="com.novoda.tpbot.landing.LandingActivity"
   android:orientation="vertical">
 
-  <TextView
+  <com.novoda.tpbot.support.TextViewWithForeground
     android:id="@+id/bot_selection"
     android:layout_width="match_parent"
     android:layout_height="0dp"
     android:layout_weight="100"
     android:background="@android:color/holo_green_light"
-    android:foreground="@drawable/landing_option_foreground"
+    app:foreground="@drawable/landing_option_foreground"
     android:text="@string/bot"
     android:gravity="center"
     android:textSize="24sp" />
 
-  <TextView
+  <com.novoda.tpbot.support.TextViewWithForeground
     android:id="@+id/human_selection"
     android:layout_width="match_parent"
     android:layout_height="0dp"
     android:layout_weight="100"
     android:background="@android:color/holo_blue_light"
-    android:foreground="@drawable/landing_option_foreground"
+    app:foreground="@drawable/landing_option_foreground"
     android:text="@string/human"
     android:gravity="center"
     android:textSize="24sp" />

--- a/TelepresenceBot/mobile/src/main/res/values/attrs.xml
+++ b/TelepresenceBot/mobile/src/main/res/values/attrs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <attr name="foreground" format="reference" />
+
+  <declare-styleable name="TextViewWithForeground">
+    <attr name="foreground" />
+  </declare-styleable>
+
+</resources>

--- a/TelepresenceBot/mobile/src/main/res/values/colors.xml
+++ b/TelepresenceBot/mobile/src/main/res/values/colors.xml
@@ -5,4 +5,9 @@
   <color name="colorAccent">#FF4081</color>
   <color name="retro_font_green">#7CB342</color>
   <color name="terminal_dark_blue">#263238</color>
+
+  <color name="transparent">#00000000</color>
+  <color name="black_10">#1A000000</color>
+  <color name="black_12">#1F000000</color>
+
 </resources>

--- a/TelepresenceBot/mobile/src/main/res/values/styles.xml
+++ b/TelepresenceBot/mobile/src/main/res/values/styles.xml
@@ -10,17 +10,16 @@
   <style name="Landing">
     <item name="android:textSize">24sp</item>
     <item name="android:gravity">center</item>
+    <item name="foreground">@drawable/landing_option_foreground</item>
   </style>
 
   <style name="Landing.Human">
     <item name="android:background">@android:color/holo_blue_light</item>
-    <item name="foreground">@drawable/landing_option_foreground</item>
     <item name="android:text">@string/human</item>
   </style>
 
   <style name="Landing.Bot">
     <item name="android:background">@android:color/holo_green_light</item>
-    <item name="foreground">@drawable/landing_option_foreground</item>
     <item name="android:text">@string/bot</item>
   </style>
 


### PR DESCRIPTION
#### Problem
We have a landing screen but the clickable items do not have any touch states. 

#### Solution
Rather than wrapping the items in a view that handles foreground (FrameLayout) we'll create a `TextView` that can support a `foreground`.

#### Screen Capture
![tp_foreground mp4](https://cloud.githubusercontent.com/assets/3380092/20790095/d27cd23a-b7ae-11e6-83b8-9fcb3185eb18.gif)
