### PR TITLE
TpBot: Observer

### DIFF
--- a/TelepresenceBot/mobile/build.gradle
+++ b/TelepresenceBot/mobile/build.gradle
@@ -33,4 +33,6 @@ dependencies {
     compile 'com.novoda:notils-android:3.0.2'
     compile 'com.android.support:recyclerview-v7:24.2.1'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-all:1.10.19'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -17,9 +17,12 @@ public abstract class Observable<T> {
         if (observer == null) {
             throw new DeveloperError("You cannot attach a null observer");
         }
-        if (!observers.contains(observer)) {
-            observers.add(observer);
+
+        if (observers.contains(observer)) {
+            return this;
         }
+
+        observers.add(observer);
 
         return this;
     }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -29,20 +29,9 @@ public abstract class Observable<T> {
         observers.remove(observer);
     }
 
-    protected void notifyOf(T newValue) {
-        Observer<T>[] observersCopy;
-
-        synchronized (this) {
-            if (hasNotChanged()) {
-                return;
-            }
-
-            observersCopy = observers.toArray(new Observer[observers.size()]);
-            clearChanged();
-        }
-
-        for (int i = observersCopy.length - 1; i >= 0; i--) {
-            observersCopy[i].update(newValue);
+    protected synchronized void notifyOf(T newValue) {
+        for (int i = observers.size() - 1; i >= 0; i--) {
+            observers.get(i).update(newValue);
         }
     }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -13,22 +13,22 @@ public abstract class Observable<T> {
         observers = new ArrayList<>();
     }
 
-    public synchronized Observable<T> addObserver(Observer<T> o) {
-        if (o == null) {
-            throw new DeveloperError("Did you forget to add an observer for this observable?");
+    public synchronized Observable<T> attach(Observer<T> observer) {
+        if (observer == null) {
+            throw new DeveloperError("Did you forget to add an observer for this Observable?");
         }
-        if (!observers.contains(o)) {
-            observers.add(o);
+        if (!observers.contains(observer)) {
+            observers.add(observer);
         }
         start();
         return this;
     }
 
-    public synchronized void deleteObserver(Observer o) {
-        observers.remove(o);
+    public synchronized void detach(Observer observer) {
+        observers.remove(observer);
     }
 
-    public void notifyObservers(T arg) {
+    public void notify(T arg) {
         Observer<T>[] observersCopy;
 
         synchronized (this) {

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -28,7 +28,7 @@ public abstract class Observable<T> {
         observers.remove(observer);
     }
 
-    protected void notify(T arg) {
+    protected void notifyOf(T newValue) {
         Observer<T>[] observersCopy;
 
         synchronized (this) {
@@ -41,7 +41,7 @@ public abstract class Observable<T> {
         }
 
         for (int i = observersCopy.length - 1; i >= 0; i--) {
-            observersCopy[i].update(arg);
+            observersCopy[i].update(newValue);
         }
     }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -1,0 +1,74 @@
+package com.novoda.tpbot.support;
+
+import com.novoda.notils.exception.DeveloperError;
+
+import java.util.ArrayList;
+
+public abstract class Observable<T> {
+
+    private boolean changed = false;
+    private final ArrayList<Observer<T>> observers;
+
+    public Observable() {
+        observers = new ArrayList<>();
+    }
+
+    public synchronized Observable<T> addObserver(Observer<T> o) {
+        if (o == null) {
+            throw new DeveloperError("Did you forget to add an observer for this observable?");
+        }
+        if (!observers.contains(o)) {
+            observers.add(o);
+        }
+        start();
+        return this;
+    }
+
+    public synchronized void deleteObserver(Observer o) {
+        observers.remove(o);
+    }
+
+    public void notifyObservers(T arg) {
+        Observer<T>[] observersCopy;
+
+        synchronized (this) {
+            if (hasNotChanged()) {
+                return;
+            }
+
+            observersCopy = observers.toArray(new Observer[observers.size()]);
+            clearChanged();
+        }
+
+        for (int i = observersCopy.length - 1; i >= 0; i--) {
+            observersCopy[i].update(arg);
+        }
+    }
+
+    public synchronized boolean hasChanged() {
+        return changed;
+    }
+
+    public synchronized void deleteObservers() {
+        observers.clear();
+    }
+
+    private synchronized void setChanged() {
+        changed = true;
+    }
+
+    private synchronized void clearChanged() {
+        changed = false;
+    }
+
+    private synchronized boolean hasNotChanged() {
+        return !changed;
+    }
+
+    public synchronized int countObservers() {
+        return observers.size();
+    }
+
+    public abstract void start();
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -9,7 +9,7 @@ public abstract class Observable<T> {
     private boolean changed = false;
     private final ArrayList<Observer<T>> observers;
 
-    public Observable() {
+    protected Observable() {
         observers = new ArrayList<>();
     }
 
@@ -20,7 +20,7 @@ public abstract class Observable<T> {
         if (!observers.contains(observer)) {
             observers.add(observer);
         }
-        start();
+
         return this;
     }
 
@@ -28,7 +28,7 @@ public abstract class Observable<T> {
         observers.remove(observer);
     }
 
-    public void notify(T arg) {
+    protected void notify(T arg) {
         Observer<T>[] observersCopy;
 
         synchronized (this) {
@@ -45,15 +45,11 @@ public abstract class Observable<T> {
         }
     }
 
-    public synchronized boolean hasChanged() {
-        return changed;
-    }
-
-    public synchronized void deleteObservers() {
+    protected synchronized void deleteObservers() {
         observers.clear();
     }
 
-    private synchronized void setChanged() {
+    protected synchronized void setChanged() {
         changed = true;
     }
 
@@ -65,10 +61,6 @@ public abstract class Observable<T> {
         return !changed;
     }
 
-    public synchronized int countObservers() {
-        return observers.size();
-    }
-
-    public abstract void start();
+    public abstract Observable<T> start();
 
 }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -18,11 +18,9 @@ public abstract class Observable<T> {
             throw new DeveloperError("You cannot attach a null observer");
         }
 
-        if (observers.contains(observer)) {
-            return this;
+        if (!observers.contains(observer)) {
+            observers.add(observer);
         }
-
-        observers.add(observer);
 
         return this;
     }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -15,7 +15,7 @@ public abstract class Observable<T> {
 
     public synchronized Observable<T> attach(Observer<T> observer) {
         if (observer == null) {
-            throw new DeveloperError("Did you forget to add an observer for this Observable?");
+            throw new DeveloperError("You cannot attach a null observer");
         }
         if (!observers.contains(observer)) {
             observers.add(observer);

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 
 public abstract class Observable<T> {
 
-    private boolean changed = false;
+    private boolean hasChanged = false;
     private final ArrayList<Observer<T>> observers;
 
     protected Observable() {
@@ -50,15 +50,15 @@ public abstract class Observable<T> {
     }
 
     protected synchronized void setChanged() {
-        changed = true;
+        hasChanged = true;
     }
 
     private synchronized void clearChanged() {
-        changed = false;
+        hasChanged = false;
     }
 
     private synchronized boolean hasNotChanged() {
-        return !changed;
+        return !hasChanged;
     }
 
     public abstract Observable<T> start();

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -45,7 +45,7 @@ public abstract class Observable<T> {
         }
     }
 
-    protected synchronized void deleteObservers() {
+    protected synchronized void detachObservers() {
         observers.clear();
     }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observer.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Observer.java
@@ -1,0 +1,7 @@
+package com.novoda.tpbot.support;
+
+public interface Observer<T> {
+
+    void update(T updatedValue);
+
+}

--- a/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/support/ObservableTest.java
+++ b/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/support/ObservableTest.java
@@ -36,7 +36,7 @@ public class ObservableTest {
     public void givenAnObservable_withMultipleObservers_whenDetachingAllObservers_thenObserversAreNotNotifiedOfEmissions() {
         Observable<Result> observable = givenObservableWithMultipleObservers();
 
-        observable.deleteObservers();
+        observable.detachObservers();
         observable.start();
 
         verifyZeroInteractions(observer);

--- a/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/support/ObservableTest.java
+++ b/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/support/ObservableTest.java
@@ -65,7 +65,7 @@ public class ObservableTest {
         @Override
         public Observable<Result> start() {
             setChanged();
-            notify(EXPECTED_RESULT);
+            notifyOf(EXPECTED_RESULT);
             return this;
         }
 

--- a/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/support/ObservableTest.java
+++ b/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/support/ObservableTest.java
@@ -1,0 +1,73 @@
+package com.novoda.tpbot.support;
+
+import com.novoda.tpbot.Result;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class ObservableTest {
+
+    private static final Result EXPECTED_RESULT = Result.from("result");
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private Observer<Result> observer;
+    @Mock
+    private Observer<Result> additionalObserver;
+
+    @Test
+    public void givenAnObservable_whenAttachingAnObserver_thenObserverIsNotifiedOfEmissions() {
+        new TestObservable()
+                .attach(observer)
+                .start();
+
+        verify(observer).update(EXPECTED_RESULT);
+    }
+
+    @Test
+    public void givenAnObservable_withMultipleObservers_whenDetachingAllObservers_thenObserversAreNotNotifiedOfEmissions() {
+        Observable<Result> observable = givenObservableWithMultipleObservers();
+
+        observable.deleteObservers();
+        observable.start();
+
+        verifyZeroInteractions(observer);
+        verifyZeroInteractions(additionalObserver);
+    }
+
+    @Test
+    public void givenAnObservable_withMultipleObservers_whenDetachingAnObserver_thenRemainingObserverAreNotifiedOfEmissions() throws Exception {
+        Observable<Result> observable = givenObservableWithMultipleObservers();
+
+        observable.detach(additionalObserver);
+        observable.start();
+
+        verify(observer).update(EXPECTED_RESULT);
+        verifyZeroInteractions(additionalObserver);
+    }
+
+    private Observable<Result> givenObservableWithMultipleObservers() {
+        return new TestObservable()
+                .attach(observer)
+                .attach(additionalObserver);
+    }
+
+    private class TestObservable extends Observable<Result> {
+
+        @Override
+        public Observable<Result> start() {
+            setChanged();
+            notify(EXPECTED_RESULT);
+            return this;
+        }
+
+    }
+}


### PR DESCRIPTION
#### Problem
We want to be able to perform an asynchronous call but keep it as far away from the `Presenter` as possible. 


#### Solution
Implement `Observer` pattern to supply results to the `Presenter` when a new value is emitted by the `TpService`.

The `Presenter` and `Service` are coming up in the next PR so bare with me 👅 This also gave me the opportunity to implement a simple `Observer` rather than using Rx, which I haven't done before 😄 