### PR TITLE
Tpbot/Repeat commands

### DIFF
--- a/TelepresenceBot/mobile/src/main/res/layout-land/activity_human.xml
+++ b/TelepresenceBot/mobile/src/main/res/layout-land/activity_human.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="horizontal"
+  tools:context="com.novoda.tpbot.human.HumanActivity">
+
+  <com.novoda.tpbot.SelfDestructingMessageView
+    android:id="@+id/bot_controller_debug_view"
+    style="@style/Controller.DebugText"
+    android:layout_width="0dp"
+    android:layout_height="match_parent"
+    android:layout_weight="50"
+    tools:text="This is some text yo" />
+
+  <com.novoda.tpbot.human.ControllerView
+    android:id="@+id/bot_controller_direction_view"
+    android:layout_width="0dp"
+    android:layout_height="match_parent"
+    android:layout_weight="50"
+    android:background="?colorPrimary" />
+
+</LinearLayout>

--- a/TelepresenceBot/movement-unit/movement-unit.ino
+++ b/TelepresenceBot/movement-unit/movement-unit.ino
@@ -9,11 +9,13 @@ AF_DCMotor motorLeft2(1);
 const char COMMAND_FORWARD = 'w';
 const char COMMAND_BACKWARD = 's';
 const char COMMAND_TEST = 't';
+const unsigned long COMMAND_TIMEOUT = 100;
 const int MAX_SPEED = 255;
 const int DELTA_SPEED = 50;
 
 int currentDirection = RELEASE;
 int currentSpeed = 0;
+unsigned long lastCommand;
 
 void setup() {
   Serial.begin(9600);           
@@ -22,9 +24,13 @@ void setup() {
 
 void loop() {
   if (Serial.available() == 0) {
+    if (millis() - lastCommand > COMMAND_TIMEOUT) {
+      stopMotors();
+    }
     return;
   }
-  
+
+  lastCommand = millis();
   char inChar = Serial.read();
 
   switch(inChar) {
@@ -40,6 +46,14 @@ void loop() {
     default:
        Serial.println("Unknown command " + inChar);
   }
+}
+
+void stopMotors() {
+  setRightSpeed(0);  
+  setLeftSpeed(0);
+  currentDirection = RELEASE;
+  setRightDirection(RELEASE);
+  setLeftDirection(RELEASE);
 }
 
 void testMotors() {


### PR DESCRIPTION
When we will connect the controller UI with the movement unit, it will be good to stop moving the bot as soon as the user releases the control button.
To do so, before we were sending a `onDirectionPressed` and `onDirectionReleased` commands, but I think it will be more reliable to continuously send a direction command while a button is pressed and stop sending as soon as it's released.
On the movement unit we adopt a mirrored mechanism, starting a timeout after each direction command, so that if we keep receiving them we continue in the same direction, otherwise we stop moving.
This should give us more reliability in case of loss of connection for example.

![device-2016-12-16-132257](https://cloud.githubusercontent.com/assets/3942812/21264276/bd97e4e2-c39b-11e6-8586-cdccc6827355.gif)
