### PR TITLE
Tpbot/simplify movement

### DIFF
--- a/TelepresenceBot/movement-unit/movement-unit.ino
+++ b/TelepresenceBot/movement-unit/movement-unit.ino
@@ -39,30 +39,22 @@ void loop() {
     case (COMMAND_FORWARD):
       setRightDirection(FORWARD);
       setLeftDirection(FORWARD);
-    
-      setRightSpeed(MAX_SPEED);  
-      setLeftSpeed(MAX_SPEED);
+      setAllMotorsSpeed(MAX_SPEED);
       break;
     case (COMMAND_BACKWARD):
       setRightDirection(BACKWARD);
       setLeftDirection(BACKWARD);
-    
-      setRightSpeed(MAX_SPEED);  
-      setLeftSpeed(MAX_SPEED);
+      setAllMotorsSpeed(MAX_SPEED);
       break;   
    case (COMMAND_LEFT):
       setRightDirection(FORWARD);
       setLeftDirection(BACKWARD);
-    
-      setRightSpeed(MAX_SPEED);  
-      setLeftSpeed(MAX_SPEED);
+      setAllMotorsSpeed(MAX_SPEED);
       break;
     case (COMMAND_RIGHT):
       setRightDirection(BACKWARD);
       setLeftDirection(FORWARD);
-    
-      setRightSpeed(MAX_SPEED);  
-      setLeftSpeed(MAX_SPEED);
+      setAllMotorsSpeed(MAX_SPEED);
       break;
     case (COMMAND_TEST):
       testMotors();
@@ -73,8 +65,7 @@ void loop() {
 }
 
 void stopMotors() {
-  setRightSpeed(0);  
-  setLeftSpeed(0);
+  setAllMotorsSpeed(0);
   currentDirection = RELEASE;
   setRightDirection(RELEASE);
   setLeftDirection(RELEASE);
@@ -125,6 +116,11 @@ void setRightDirection(int direction) {
 void setLeftDirection(int direction) {
   motorLeft1.run(direction);
   motorLeft2.run(direction);
+}
+
+void setAllMotorsSpeed(int speed) {
+  setRightSpeed(speed);  
+  setLeftSpeed(speed);
 }
 
 void setRightSpeed(int speed) {

--- a/TelepresenceBot/movement-unit/movement-unit.ino
+++ b/TelepresenceBot/movement-unit/movement-unit.ino
@@ -35,10 +35,18 @@ void loop() {
 
   switch(inChar) {
     case (COMMAND_FORWARD):
-      increaseForward();
+      setRightDirection(FORWARD);
+      setLeftDirection(FORWARD);
+    
+      setRightSpeed(MAX_SPEED);  
+      setLeftSpeed(MAX_SPEED);
       break;
     case (COMMAND_BACKWARD):
-      increaseBackward();
+      setRightDirection(BACKWARD);
+      setLeftDirection(BACKWARD);
+    
+      setRightSpeed(MAX_SPEED);  
+      setLeftSpeed(MAX_SPEED);
       break;
     case (COMMAND_TEST):
       testMotors();
@@ -90,47 +98,6 @@ void testMotors() {
     setRightSpeed(i);  
     setLeftSpeed(i);  
     delay(3);
-  }
-}
-
-void increaseForward() {
-  if (currentSpeed == 0) {
-    currentDirection = FORWARD;
-    setRightDirection(FORWARD);
-    setLeftDirection(FORWARD);
-  }
-  if (currentDirection == FORWARD) {
-    currentSpeed = currentSpeed + DELTA_SPEED;
-  } else {
-    currentSpeed = currentSpeed - DELTA_SPEED;
-  }
-  enforceSpeedWithinLimits();
-  setRightSpeed(currentSpeed);  
-  setLeftSpeed(currentSpeed);
-}
-
-void increaseBackward() {
-  if (currentSpeed == 0) {
-    currentDirection = BACKWARD;
-    setRightDirection(BACKWARD);
-    setLeftDirection(BACKWARD);
-  }
-  if (currentDirection == BACKWARD) {
-    currentSpeed = currentSpeed + DELTA_SPEED;
-  } else {
-    currentSpeed = currentSpeed - DELTA_SPEED;
-  }
-  enforceSpeedWithinLimits();
-  setRightSpeed(currentSpeed);  
-  setLeftSpeed(currentSpeed);
-}
-
-void enforceSpeedWithinLimits() {
-  if (currentSpeed > MAX_SPEED) {
-    currentSpeed = MAX_SPEED;
-  }
-  if (currentSpeed < 0) {
-    currentSpeed = 0;
   }
 }
 

--- a/TelepresenceBot/movement-unit/movement-unit.ino
+++ b/TelepresenceBot/movement-unit/movement-unit.ino
@@ -8,6 +8,8 @@ AF_DCMotor motorLeft2(1);
 
 const char COMMAND_FORWARD = 'w';
 const char COMMAND_BACKWARD = 's';
+const char COMMAND_LEFT = 'a';
+const char COMMAND_RIGHT = 'd';
 const char COMMAND_TEST = 't';
 const unsigned long COMMAND_TIMEOUT = 100;
 const int MAX_SPEED = 255;
@@ -44,6 +46,20 @@ void loop() {
     case (COMMAND_BACKWARD):
       setRightDirection(BACKWARD);
       setLeftDirection(BACKWARD);
+    
+      setRightSpeed(MAX_SPEED);  
+      setLeftSpeed(MAX_SPEED);
+      break;   
+   case (COMMAND_LEFT):
+      setRightDirection(FORWARD);
+      setLeftDirection(BACKWARD);
+    
+      setRightSpeed(MAX_SPEED);  
+      setLeftSpeed(MAX_SPEED);
+      break;
+    case (COMMAND_RIGHT):
+      setRightDirection(BACKWARD);
+      setLeftDirection(FORWARD);
     
       setRightSpeed(MAX_SPEED);  
       setLeftSpeed(MAX_SPEED);

--- a/TelepresenceBot/movement-unit/movement-unit.ino
+++ b/TelepresenceBot/movement-unit/movement-unit.ino
@@ -13,10 +13,7 @@ const char COMMAND_RIGHT = 'd';
 const char COMMAND_TEST = 't';
 const unsigned long COMMAND_TIMEOUT = 100;
 const int MAX_SPEED = 255;
-const int DELTA_SPEED = 50;
 
-int currentDirection = RELEASE;
-int currentSpeed = 0;
 unsigned long lastCommand;
 
 void setup() {
@@ -66,7 +63,6 @@ void loop() {
 
 void stopMotors() {
   setAllMotorsSpeed(0);
-  currentDirection = RELEASE;
   setRightDirection(RELEASE);
   setLeftDirection(RELEASE);
 }


### PR DESCRIPTION
Before we were gradually accelerating, in the Arduino movement module, when we received the `FORWARD` command, and decelerating when receiving the `BACKWARD` command.
After some tests with the actual model, I saw that this acceleration is not really necessary (the max speed is not exactly _Ludicrous speed_).
Removing the acceleration methods greatly simplified the sketch, and also allowed to easily add support for steering commands.
Remember that our bot will steer like it was a tank with tracks