### PR TITLE
Add Novoda ESLint rules for NodeJS projects

### DIFF
--- a/eslint-config-novoda/.eslintrc.json
+++ b/eslint-config-novoda/.eslintrc.json
@@ -1,0 +1,34 @@
+{
+  "extends": "eslint:recommended",
+  "plugins": [
+    "standard",
+    "promise",
+    "jasmine",
+    "json"
+  ],
+  "env": {
+    "es6": true,
+    "node": true,
+    "jasmine": true
+  },
+  "rules": {
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": "error",
+    "keyword-spacing": "error",
+    "brace-style": "error",
+    "prefer-const": "error",
+    "indent": [
+      "error",
+      4,
+      {
+        "ObjectExpression": "first",
+        "ArrayExpression": "first",
+        "SwitchCase": 1
+      }
+    ],
+    "eqeqeq": "error"
+  }
+}

--- a/eslint-config-novoda/README.md
+++ b/eslint-config-novoda/README.md
@@ -1,0 +1,43 @@
+eslint-config-novoda
+====================
+
+_Shared ESLint rules for Novoda NodeJS projects tested with Jasmine._
+
+## How to install
+
+```
+$ npm install --save-dev \
+    eslint \
+    eslint-plugin-jasmine \
+    eslint-plugin-json \
+    eslint-plugin-promise \
+    eslint-config-standard \
+    eslint-config-novoda
+```
+
+## How to use
+
+In your project folder, create  `.eslintrc.json` file with the following content:
+
+```json
+{
+    "extends": "eslint-config-novoda"
+}
+```
+
+Running `eslint` from that folder will apply the shared Novoda rules.
+
+You can still customise some rules by changing your `.eslintrc.json`.
+
+## Default rules
+
+* ES6 is enabled by default
+* The project is assumed to be a NodeJS project
+* Jasmine globals are automatically accepted
+* Only single quotes are accepted
+* Semi-colons are mandatory
+* Proper spacing between keywords is enforced
+* Braces must be followed by a new line
+* `const` must be used anywhere the variable never changes
+* Indentation must be with 4 spaces
+* Triple equals `===` must always be used

--- a/eslint-config-novoda/index.js
+++ b/eslint-config-novoda/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./.eslintrc.json');

--- a/eslint-config-novoda/package.json
+++ b/eslint-config-novoda/package.json
@@ -13,10 +13,10 @@
     "name": "Francesco Pontillo",
     "email": "francesco@novoda.com"
   }],
-  "homepage": "https://github.com/novoda/eslint-config-novoda",
+  "homepage": "https://github.com/novoda/spikes/tree/eslint-config-novoda",
   "repository": {
     "type": "git",
-    "url": "https://github.com/novoda/eslint-config-novoda.git"
+    "url": "https://github.com/novoda/spikes.git"
   },
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/eslint-config-novoda/package.json
+++ b/eslint-config-novoda/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "eslint-config-novoda",
+  "version": "1.0.0",
+  "description": "ESLint default configuration for Novoda packages",
+  "main": "index.js",
+  "keywords": [
+    "eslint",
+    "eslintconfig",
+    "novoda",
+    "config"
+  ],
+  "contributors": [{
+    "name": "Francesco Pontillo",
+    "email": "francesco@novoda.com"
+  }],
+  "homepage": "https://github.com/novoda/eslint-config-novoda",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/novoda/eslint-config-novoda.git"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "eslint": ">=3.12.0",
+    "eslint-plugin-jasmine": ">=2.2.0",
+    "eslint-plugin-json": ">=1.2.0",
+    "eslint-plugin-promise": ">=3.3.0",
+    "eslint-config-standard": ">=6.2.0"
+  }
+}


### PR DESCRIPTION
A few Novoda projects now use NodeJS as environment. Most of the times pull requests are all about coding guidelines and standards that have to be enforced manually.

Most of our NodeJS projects now use ESLint, but the configuration is still project-local and has to be repeated across all repositories.

This PR aims at publishing a `npm` module with our agreed-upon style.
Please read the `README` for a detailed explanation of what rules are being enforced, and how.

Read [this link](http://eslint.org/docs/developer-guide/shareable-configs) to understand how to create shareable configurations like this one.

**NOTE**: as of now, the module is not published on `npm` yet. In order to test it in your projects, clone this branch and do a `npm link`. Then, in your project, run `npm link eslint-config-novoda`: this will create a symlink between this project and yours in `node_modules`.