### PR TITLE
Test gradle-diff-task-dependencies

### DIFF
--- a/gradle-diff-task-dependencies/plugin/build.gradle
+++ b/gradle-diff-task-dependencies/plugin/build.gradle
@@ -2,4 +2,8 @@ apply plugin: 'groovy'
 
 dependencies {
     compile gradleApi()
+
+    testCompile gradleTestKit()
+    testCompile 'org.mockito:mockito-core:2.5.3'
+    testCompile 'com.google.truth:truth:0.30'
 }

--- a/gradle-diff-task-dependencies/plugin/src/main/groovy/com/novoda/gradle/diffdependencytask/ConditionalDependencyEvaluator.groovy
+++ b/gradle-diff-task-dependencies/plugin/src/main/groovy/com/novoda/gradle/diffdependencytask/ConditionalDependencyEvaluator.groovy
@@ -2,7 +2,7 @@ package com.novoda.gradle.diffdependencytask
 
 import java.util.regex.Pattern
 
-class ConditionalDependencyEvaluator implements GroovyCallable<Void> {
+class ConditionalDependencyEvaluator implements GroovyCallable<Set<ConditionalDependency>> {
 
     private final GroovyCallable<List<String>> changedFilesProvider
     private final ConditionalDependencyRepository repository
@@ -15,20 +15,18 @@ class ConditionalDependencyEvaluator implements GroovyCallable<Void> {
     }
 
     @Override
-    Void call() throws Exception {
+    Set<ConditionalDependency> call() throws Exception {
         def changedFiles = changedFilesProvider()
-        def dependencyMap = repository.conditionalDependencies
+        def dependencyMap = repository.getConditionalDependencies()
         def matchedDependencies = new HashSet<ConditionalDependency>()
 
-        dependencyMap.keySet().forEach {
+        dependencyMap.keySet().each {
             if (changedFilesContainPattern(changedFiles, it)) {
                 matchedDependencies.addAll(dependencyMap[it])
             }
         }
 
-        matchedDependencies.forEach {
-            it.task.dependsOn(it.dependentTasks)
-        }
+        return matchedDependencies
     }
 
     private static boolean changedFilesContainPattern(List<String> changedFiles, Pattern pattern) {

--- a/gradle-diff-task-dependencies/plugin/src/main/groovy/com/novoda/gradle/diffdependencytask/DiffDependencyTaskPlugin.groovy
+++ b/gradle-diff-task-dependencies/plugin/src/main/groovy/com/novoda/gradle/diffdependencytask/DiffDependencyTaskPlugin.groovy
@@ -17,7 +17,7 @@ class DiffDependencyTaskPlugin implements Plugin<Project> {
         project.extensions.add(TASK_CONFIG_PROPERTY_NAME, config)
 
         project.tasks.all { task ->
-            task.ext.onDiffDependsOn = { def patterns, Object... tasks ->
+            task.ext.onDiffDependsOn = { patterns, Object... tasks ->
                 if (patterns instanceof Pattern) {
                      patterns = [patterns]
                 }
@@ -33,7 +33,11 @@ class DiffDependencyTaskPlugin implements Plugin<Project> {
                     config.conditionalDependencyRepository
             )
 
-            evaluator()
+            def matchedDependencies = evaluator()
+
+            matchedDependencies.forEach {
+                it.task.dependsOn(it.dependentTasks)
+            }
         }
 
     }

--- a/gradle-diff-task-dependencies/plugin/src/main/groovy/com/novoda/gradle/diffdependencytask/MemoryConditionalDependencyRepository.groovy
+++ b/gradle-diff-task-dependencies/plugin/src/main/groovy/com/novoda/gradle/diffdependencytask/MemoryConditionalDependencyRepository.groovy
@@ -9,16 +9,16 @@ class MemoryConditionalDependencyRepository implements ConditionalDependencyRepo
         }
     }
 
-    private Map<String, List<ConditionalDependency>> conditionalDependencies = new LinkedHashMap<>()
+    private Map<String, List<ConditionalDependency>> conditionalDependenciesMap = new LinkedHashMap<>()
 
     public void add(ConditionalDependency conditionalDependency) {
         conditionalDependency.patterns.toList().forEach {
-            conditionalDependencies.multiPut(it, conditionalDependency)
+            conditionalDependenciesMap.multiPut(it, conditionalDependency)
         }
     }
 
     @Override
     Map<String, List<ConditionalDependency>> getConditionalDependencies() {
-        conditionalDependencies
+        conditionalDependenciesMap
     }
 }

--- a/gradle-diff-task-dependencies/plugin/src/test/groovy/com/novoda/gradle/diffdependencytask/ConditionalDependencyEvaluatorTest.groovy
+++ b/gradle-diff-task-dependencies/plugin/src/test/groovy/com/novoda/gradle/diffdependencytask/ConditionalDependencyEvaluatorTest.groovy
@@ -1,0 +1,104 @@
+package com.novoda.gradle.diffdependencytask
+
+import org.junit.Before
+import org.junit.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+
+import static com.google.common.truth.Truth.assertThat
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+
+class ConditionalDependencyEvaluatorTest {
+
+    @Mock
+    private ConditionalDependencyRepository dependenciesRepository
+    @Mock
+    private GroovyCallable<List<String>> changedFilesProvider
+    @InjectMocks
+    private ConditionalDependencyEvaluator evaluator
+
+    public static final ANY_TASK = null
+    public static final ConditionalDependency BUILD_GRADLE_DEPENDENCY =
+            new ConditionalDependency(ANY_TASK, [~'build\\.gradle'], 'banana')
+    public static final ConditionalDependency ANDROID_DEPENDENCY =
+            new ConditionalDependency(ANY_TASK, [~'android/.*'], 'testAndroid')
+    public static final ConditionalDependency APPLE_DEPENDENCY =
+            new ConditionalDependency(ANY_TASK, [~'apple/.*'], 'testApple')
+
+    @Before
+    void setUp() {
+        initMocks(this)
+    }
+
+    @Test
+    void whenDependenciesAreEmpty_andNoFilesWereChanged_shouldReturnNoTasks() {
+        when(dependenciesRepository.getConditionalDependencies()).thenReturn([:])
+        when(changedFilesProvider.call()).thenReturn([])
+
+        Set<ConditionalDependency> actualDependencies = evaluator.call()
+
+        assertThat(actualDependencies).isEmpty()
+    }
+
+    @Test
+    void whenDependenciesAreEmpty_andSomeFilesWereChanged_shouldReturnNoTasks() {
+        when(dependenciesRepository.getConditionalDependencies()).thenReturn([:])
+        when(changedFilesProvider.call()).thenReturn(['build.gradle', 'src/main/kotlin/com/novoda/sample/Banana.kt'])
+
+        Set<ConditionalDependency> actualDependencies = evaluator.call()
+
+        assertThat(actualDependencies).isEmpty()
+    }
+
+    @Test
+    void whenDependenciesAreSet_andNoFilesWereChanged_shouldReturnNoTasks() {
+        when(dependenciesRepository.getConditionalDependencies()).thenReturn([
+                (~'build\\.gradle'): [BUILD_GRADLE_DEPENDENCY]
+        ])
+        when(changedFilesProvider.call()).thenReturn([])
+
+        Set<ConditionalDependency> actualDependencies = evaluator.call()
+
+        assertThat(actualDependencies).isEmpty()
+    }
+
+    @Test
+    void whenDependenciesAreSet_andOnlyMatchingFilesWereChanged_shouldReturnAllTasks() {
+        when(dependenciesRepository.getConditionalDependencies()).thenReturn([
+                (~'build\\.gradle'): [BUILD_GRADLE_DEPENDENCY]
+        ])
+        when(changedFilesProvider.call()).thenReturn(['build.gradle'])
+
+        Set<ConditionalDependency> actualDependencies = evaluator.call()
+
+        assertThat(actualDependencies).containsExactly(BUILD_GRADLE_DEPENDENCY)
+    }
+
+    @Test
+    void whenDependenciesAreSet_andSomeMatchingFilesWereChanged_shouldReturnOnlyMatchingTasks() {
+        when(dependenciesRepository.getConditionalDependencies()).thenReturn([
+                (~'build\\.gradle'): [BUILD_GRADLE_DEPENDENCY],
+                (~'android/.*')    : [ANDROID_DEPENDENCY],
+                (~'apple/.*')      : [APPLE_DEPENDENCY]
+        ])
+        when(changedFilesProvider.call()).thenReturn(['build.gradle', 'android/settings.gradle'])
+
+        Set<ConditionalDependency> actualDependencies = evaluator.call()
+
+        assertThat(actualDependencies).containsExactly(BUILD_GRADLE_DEPENDENCY, ANDROID_DEPENDENCY)
+    }
+
+    @Test
+    void whenDependenciesAreSet_andFilesWithSameNamesWereChangedAtDifferentPaths_shouldReturnOnlyTasksForSpecificPath() {
+        when(dependenciesRepository.getConditionalDependencies()).thenReturn([
+                (~'build\\.gradle'): [BUILD_GRADLE_DEPENDENCY],
+                (~'android/.*')    : [ANDROID_DEPENDENCY]
+        ])
+        when(changedFilesProvider.call()).thenReturn(['android/build.gradle'])
+
+        Set<ConditionalDependency> actualDependencies = evaluator.call()
+
+        assertThat(actualDependencies).containsExactly(ANDROID_DEPENDENCY)
+    }
+}

--- a/gradle-diff-task-dependencies/plugin/src/test/groovy/com/novoda/gradle/diffdependencytask/ConditionalDependencyEvaluatorTest.groovy
+++ b/gradle-diff-task-dependencies/plugin/src/test/groovy/com/novoda/gradle/diffdependencytask/ConditionalDependencyEvaluatorTest.groovy
@@ -2,7 +2,6 @@ package com.novoda.gradle.diffdependencytask
 
 import org.junit.Before
 import org.junit.Test
-import org.mockito.InjectMocks
 import org.mockito.Mock
 
 import static com.google.common.truth.Truth.assertThat
@@ -12,10 +11,10 @@ import static org.mockito.MockitoAnnotations.initMocks
 class ConditionalDependencyEvaluatorTest {
 
     @Mock
-    private ConditionalDependencyRepository dependenciesRepository
-    @Mock
     private GroovyCallable<List<String>> changedFilesProvider
-    @InjectMocks
+    @Mock
+    private ConditionalDependencyRepository dependenciesRepository
+
     private ConditionalDependencyEvaluator evaluator
 
     public static final ANY_TASK = null
@@ -29,6 +28,7 @@ class ConditionalDependencyEvaluatorTest {
     @Before
     void setUp() {
         initMocks(this)
+        evaluator = new ConditionalDependencyEvaluator(changedFilesProvider, dependenciesRepository)
     }
 
     @Test


### PR DESCRIPTION
The differential task dependencies plugin for Gradle lacks some basic testing for the evaluation logic.

This PR introduces some refactoring that make testing easier without actually building sample Gradle projects.

After this PR is merged, we will release a first version of the plugin, so it can be used in our projects.