### PR TITLE
[monkey-trap] Fix NullPointerException caused by Service recreation

### DIFF
--- a/MonkeyTrap/app/build.gradle
+++ b/MonkeyTrap/app/build.gradle
@@ -2,14 +2,16 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 25
-  buildToolsVersion "23.0.3"
+  buildToolsVersion '25.0.2'
+
   defaultConfig {
-    applicationId "com.novoda.monkeytrap"
+    applicationId 'com.novoda.monkeytrap'
     minSdkVersion 16
     targetSdkVersion 25
     versionCode 1
-    versionName "1.0"
+    versionName '1.0'
   }
+
   buildTypes {
     release {
       minifyEnabled false

--- a/MonkeyTrap/app/src/main/java/com/novoda/monkeytrap/OverlayService.java
+++ b/MonkeyTrap/app/src/main/java/com/novoda/monkeytrap/OverlayService.java
@@ -1,13 +1,12 @@
 package com.novoda.monkeytrap;
 
-import static android.view.View.GONE;
-import static android.view.View.VISIBLE;
-
 import android.app.Service;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.IBinder;
 import android.view.WindowManager;
+
+import static android.view.View.VISIBLE;
 
 public class OverlayService extends Service {
 
@@ -50,23 +49,27 @@ public class OverlayService extends Service {
         super.onCreate();
         instance = this;
         windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
-
-        overlayView = new OverlayView(this);
-        overlayView.setBackgroundColor(Color.parseColor("#30A4D9"));
-        overlayView.setImageResource(R.drawable.novoda);
-        windowManager.addView(overlayView, OverlayView.createLayoutParams(getResources()));
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if (overlayView != null) {
-            overlayView.setVisibility(shouldShow(intent) ? VISIBLE : GONE);
+        if (shouldShow(intent)) {
+            addOverlay();
+        } else {
+            stopSelf();
         }
-        return super.onStartCommand(intent, flags, startId);
+        return START_NOT_STICKY;
     }
 
     private boolean shouldShow(Intent intent) {
         return intent.getBooleanExtra(EXTRA_SHOW, true);
+    }
+
+    private void addOverlay() {
+        overlayView = new OverlayView(this);
+        overlayView.setBackgroundColor(Color.parseColor("#30A4D9"));
+        overlayView.setImageResource(R.drawable.novoda);
+        windowManager.addView(overlayView, OverlayView.createLayoutParams(getResources()));
     }
 
     @Override

--- a/MonkeyTrap/gradle/wrapper/gradle-wrapper.properties
+++ b/MonkeyTrap/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
This PR fixes a crash where the service is re-created with a null Intent. 

This is the default behavior when the resources are scarce (e.g someone plays Pokemon Go) on a device.

Yes, I still play and whenever I open the game, I see MonkeyTrap crashes. 

Our service was long-living which is not really necessary when the overlay is not shown.

Now we add the view only when we have the show command.
We stop the Service completely when we have the hide command. This also removes the overlay automatically.