### PR TITLE
[NNP] PT-392: up to date check support

### DIFF
--- a/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
+++ b/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
@@ -28,7 +28,7 @@ class GeneratePackageAnnotationsTask extends DefaultTask {
 
             def file = new File(dir, 'package-info.java')
             if (file.createNewFile()) {
-                def packageName = packagePath.replaceFirst('/', '').replaceAll('/', '.')
+                def packageName = packagePath.replaceAll('/', '.')
                 file.write(createAnnotationDefinition(packageName))
             }
         }
@@ -41,11 +41,11 @@ class GeneratePackageAnnotationsTask extends DefaultTask {
         sourceSets.each { sourceSet ->
             sourceSet.java.srcDirs.findAll {
                 it.exists()
-            }.each { srcDir ->
+            }.each { File srcDir ->
 
                 project.fileTree(srcDir).visit { FileVisitDetails details ->
                     if (details.file.file) {
-                        def packagePath = details.file.parent.replace(srcDir.absolutePath, '')
+                        def packagePath = srcDir.toPath().relativize(details.file.parentFile.toPath()).toString()
                         packages << packagePath
                     }
                 }

--- a/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
+++ b/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
@@ -42,10 +42,10 @@ class GeneratePackageAnnotationsTask extends DefaultTask {
             sourceSet.java.srcDirs.findAll {
                 it.exists()
             }.each { File srcDir ->
-
                 project.fileTree(srcDir).visit { FileVisitDetails details ->
-                    if (details.file.file) {
-                        def packagePath = srcDir.toPath().relativize(details.file.parentFile.toPath()).toString()
+                    def file = details.file
+                    if (file.file) {
+                        def packagePath = srcDir.toPath().relativize(file.parentFile.toPath()).toString()
                         packages << packagePath
                     }
                 }

--- a/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
+++ b/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
@@ -1,19 +1,27 @@
 package com.novoda.gradle.nonnull
 
+import groovy.transform.Memoized
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileVisitDetails
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class GeneratePackageAnnotationsTask extends DefaultTask {
 
+    @Input
+    Set<String> packages;
+
+    @OutputDirectory
     def outputDir
+
     def sourceSets
 
     @TaskAction
     void generatePackageAnnotations() {
         description = "Annotates the source packages with @ParametersAreNonnullByDefault"
 
-        Set<String> packages = packages()
+        Set<String> packages = getPackages()
         packages.each { packagePath ->
             def dir = new File(outputDir, packagePath)
             dir.mkdirs()
@@ -26,7 +34,8 @@ class GeneratePackageAnnotationsTask extends DefaultTask {
         }
     }
 
-    Set<String> packages() {
+    @Memoized
+    Set<String> getPackages() {
         Set<String> packages = []
 
         sourceSets.each { sourceSet ->

--- a/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
+++ b/gradle-nonnull-plugin/plugin/src/main/groovy/com.novoda.gradle.nonnull/GeneratePackageAnnotationsTask.groovy
@@ -13,10 +13,24 @@ class GeneratePackageAnnotationsTask extends DefaultTask {
     void generatePackageAnnotations() {
         description = "Annotates the source packages with @ParametersAreNonnullByDefault"
 
-        sourceSets.each {
-            Set<String> packages = []
+        Set<String> packages = packages()
+        packages.each { packagePath ->
+            def dir = new File(outputDir, packagePath)
+            dir.mkdirs()
 
-            it.java.srcDirs.findAll {
+            def file = new File(dir, 'package-info.java')
+            if (file.createNewFile()) {
+                def packageName = packagePath.replaceFirst('/', '').replaceAll('/', '.')
+                file.write(createAnnotationDefinition(packageName))
+            }
+        }
+    }
+
+    Set<String> packages() {
+        Set<String> packages = []
+
+        sourceSets.each { sourceSet ->
+            sourceSet.java.srcDirs.findAll {
                 it.exists()
             }.each { srcDir ->
 
@@ -27,18 +41,8 @@ class GeneratePackageAnnotationsTask extends DefaultTask {
                     }
                 }
             }
-
-            packages.each { packagePath ->
-                def dir = new File(outputDir, packagePath)
-                dir.mkdirs()
-
-                def file = new File(dir, 'package-info.java')
-                if (file.createNewFile()) {
-                    def packageName = packagePath.replaceFirst('/', '').replaceAll('/', '.')
-                    file.write(createAnnotationDefinition(packageName))
-                }
-            }
         }
+        packages
     }
 
     static def createAnnotationDefinition(packageName) {


### PR DESCRIPTION
## Problem

Currently, we plugin works on java and android modules. 👍 
But the task runs in every build process. This is not something we want to have.

If no package structure has changed, we don't want to run again. 

## Solution

A field called `packages` created with annotation `@Input`
The code block that computes the packages is extracted into a `@Memoized` getter method: `getPackages`


## Tests

- A test is added that runs the project again and asserts that we get the UP-TO-DATE check
- Another test is added that adds a new file to a new package and asserts that we didn't get UP-TO-DATE check. 

Paired with @tobiasheine 