### PR TITLE
Ensure Command plugin is applied

### DIFF
--- a/monkey-runner/README.md
+++ b/monkey-runner/README.md
@@ -5,11 +5,13 @@ Provides gradle closure to configure the monkey runner.
 
 ## Description
 
-Decorates the [Android monkey](https://developer.android.com/studio/test/monkey.html) with the [monkey trap](https://github.com/novoda/spikes/tree/master/MonkeyTrap/), which is designed to block the monkey from accessing the system notifications tray (and the quick toggles).
+Decorates the [Android monkey](https://developer.android.com/studio/test/monkey.html) with the [monkey trap](https://github.com/novoda/spikes/tree/master/MonkeyTrap/),
+ which is designed to block the monkey from accessing the system notifications tray (and the quick toggles).
 
 ## Adding to project
 
-It's necessary to have the monkey trap installed on all the devices you want to use this monkey runner on:
+In case you want the monkey trap running, it's necessary to have it installed on all the devices you want to use 
+monkey runner with. You can easily ensure this with:
 
 ```bash
 wget https://raw.githubusercontent.com/novoda/spikes/master/MonkeyTrap/apk/app-debug.apk
@@ -22,7 +24,8 @@ rm app-debug.apk
 
 You can run this as part of your CI job before starting the monkey runner.
 
-In your Android module's `build.gradle`:
+In your Android module's `build.gradle`, add this plugin as a dependency, apply it and configure it. Be sure you also apply
+ the `android-command` plugin (which `monkey-runner` depends on):
 
 ```groovy
 buildscript {
@@ -41,6 +44,7 @@ buildscript {
 
 ...
 
+apply plugin: 'com.novoda.android-command'
 apply plugin: 'com.novoda.monkey-runner'
 
 ...

--- a/monkey-runner/dependencies.gradle
+++ b/monkey-runner/dependencies.gradle
@@ -6,8 +6,8 @@ ext {
     ]
 
     versions = [
-            androidBuildTools : '24.0.1',
-            androidSupportLibs: '24.1.1'
+            androidBuildTools : '25.0.2',
+            androidSupportLibs: '25.1.0'
     ]
 
     libraries = [

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -4,14 +4,17 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public class MonkeyConfigurationPlugin implements Plugin<Project> {
+class MonkeyConfigurationPlugin implements Plugin<Project> {
 
     private static final String TASK_NAME = 'runMonkeyAll'
 
     @Override
-    public void apply(Project project) {
+    void apply(Project project) {
         ensureAndroidPluginAppliedTo(project)
         ensureCommandPluginAppliedTo(project)
+
+        //Plugin<Project> commandPlugin = new AndroidCommandPlugin();
+        //commandPlugin.apply(project)
 
         MonkeyRunnerExtension extension = project.extensions.create(MonkeyRunnerExtension.NAME, MonkeyRunnerExtension)
         extension.setDefaultsForOptionalProperties()

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -11,6 +11,8 @@ public class MonkeyConfigurationPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         ensureAndroidPluginAppliedTo(project)
+        ensureCommandPluginAppliedTo(project)
+
         MonkeyRunnerExtension extension = project.extensions.create(MonkeyRunnerExtension.NAME, MonkeyRunnerExtension)
         extension.setDefaultsForOptionalProperties()
 
@@ -24,9 +26,18 @@ public class MonkeyConfigurationPlugin implements Plugin<Project> {
     }
 
     private static void ensureAndroidPluginAppliedTo(Project project) {
-        boolean missingAndroidPlugin = !project.plugins.hasPlugin('com.android.application')
-        if (missingAndroidPlugin) {
-            throw new GradleException('monkey runner plugin can only be applied after the Android plugin')
+        ensurePluginIsApplied('com.android.application', project)
+    }
+
+    private static void ensureCommandPluginAppliedTo(Project project) {
+        ensurePluginIsApplied('android-command', project)
+    }
+
+    private static void ensurePluginIsApplied(String plugin, Project project) {
+        boolean isMissingPlugin = !project.plugins.hasPlugin(plugin)
+        if (isMissingPlugin) {
+            throw new GradleException("monkey runner plugin can only be applied after the ${plugin} plugin.\n" +
+                    "In your build.gradle: apply plugin: '${plugin}'")
         }
     }
 

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -13,9 +13,6 @@ class MonkeyConfigurationPlugin implements Plugin<Project> {
         ensureAndroidPluginAppliedTo(project)
         ensureCommandPluginAppliedTo(project)
 
-        //Plugin<Project> commandPlugin = new AndroidCommandPlugin();
-        //commandPlugin.apply(project)
-
         MonkeyRunnerExtension extension = project.extensions.create(MonkeyRunnerExtension.NAME, MonkeyRunnerExtension)
         extension.setDefaultsForOptionalProperties()
 

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyRunnerExtension.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyRunnerExtension.groovy
@@ -1,6 +1,6 @@
 package com.novoda.monkey
 
-public class MonkeyRunnerExtension {
+class MonkeyRunnerExtension {
 
     public static final String NAME = 'monkeyRunner'
 

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
@@ -6,25 +6,25 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
 import org.junit.Test
 
-public class MonkeyConfigurationPluginTest {
+class MonkeyConfigurationPluginTest {
 
     private Project project
 
     @Before
-    public void setUp() {
+    void setUp() {
         project = ProjectBuilder.builder().build()
         project.apply plugin: 'com.android.application'
     }
 
     @Test(expected = GradleException.class)
-    public void givenAndroidPluginNotApplied_whenApplyingMonkey_thenItThrowsException() {
+    void givenAndroidPluginNotApplied_whenApplyingMonkey_thenItThrowsException() {
         project = ProjectBuilder.builder().build()
 
         project.apply plugin: MonkeyConfigurationPlugin
     }
 
     @Test
-    public void givenAndroidPluginApplied_whenApplyingMonkey_thenItDoesNotThrowException() {
+    void givenAndroidPluginApplied_whenApplyingMonkey_thenItDoesNotThrowException() {
         project.apply plugin: MonkeyConfigurationPlugin
     }
 }

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
@@ -34,7 +34,7 @@ class MonkeyConfigurationPluginTest {
     @Test
     void givenPluginsApplied_whenApplyingMonkey_thenItDoesNotThrowException() {
         project.apply plugin: 'com.android.application'
-        project.apply plugin: 'android-command'
+        project.apply plugin: 'com.novoda.android-command'
 
         project.apply plugin: MonkeyConfigurationPlugin
 

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
@@ -13,18 +13,30 @@ class MonkeyConfigurationPluginTest {
     @Before
     void setUp() {
         project = ProjectBuilder.builder().build()
-        project.apply plugin: 'com.android.application'
     }
 
     @Test(expected = GradleException.class)
     void givenAndroidPluginNotApplied_whenApplyingMonkey_thenItThrowsException() {
-        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'android-command'
 
         project.apply plugin: MonkeyConfigurationPlugin
+
+    }
+
+    @Test(expected = GradleException.class)
+    void givenCommandPluginNotApplied_whenApplyingMonkey_thenItThrowsException() {
+        project.apply plugin: 'com.android.application'
+
+        project.apply plugin: MonkeyConfigurationPlugin
+
     }
 
     @Test
-    void givenAndroidPluginApplied_whenApplyingMonkey_thenItDoesNotThrowException() {
+    void givenPluginsApplied_whenApplyingMonkey_thenItDoesNotThrowException() {
+        project.apply plugin: 'com.android.application'
+        project.apply plugin: 'android-command'
+
         project.apply plugin: MonkeyConfigurationPlugin
+
     }
 }

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyRunnerExtensionTest.groovy
@@ -8,19 +8,19 @@ class MonkeyRunnerExtensionTest {
     private MonkeyRunnerExtension extension
 
     @Before
-    public void setUp() {
+    void setUp() {
         extension = new MonkeyRunnerExtension()
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void whenNoTaskDependencySpecified_thenItThrows() {
+    void whenNoTaskDependencySpecified_thenItThrows() {
         extension.packageNameFilter = 'com.package'
 
         extension.ensureMandatoryPropertiesPresent()
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void whenNoPackageNameFilterSpecified_thenItThrows() {
+    void whenNoPackageNameFilterSpecified_thenItThrows() {
         extension.taskDependency = 'someTask'
 
         extension.ensureMandatoryPropertiesPresent()

--- a/monkey-runner/sample/app/build.gradle
+++ b/monkey-runner/sample/app/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'android-command'
 apply plugin: com.novoda.monkey.MonkeyConfigurationPlugin
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion versions.androidBuildTools
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.novoda.monkey"
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -20,8 +20,7 @@ android {
     }
 
     dependencies {
-        compile libraries.appCompat
-        compile libraries.androidV13Support
+        compile 'com.android.support:appcompat-v7:25.1.0'
     }
 
 }

--- a/monkey-runner/sample/app/build.gradle
+++ b/monkey-runner/sample/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: com.novoda.monkey.MonkeyConfigurationPlugin
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    buildToolsVersion versions.androidBuildTools
 
     defaultConfig {
         applicationId "com.novoda.monkey"
@@ -20,7 +20,8 @@ android {
     }
 
     dependencies {
-        compile 'com.android.support:appcompat-v7:25.1.0'
+        compile libraries.appCompat
+        compile libraries.androidV13Support
     }
 
 }


### PR DESCRIPTION
The monkey runner plugin depends on the android command one. Currently, if you don't apply the command plugin you get a cryptic/not very helpful error message: `Error:Could not get unknown property 'command' for object of type com.android.build.gradle.AppExtension`.

By ensuring the plugin is applied first (just like what's already happening with the android plugin) we can provide a better error message.