### PR TITLE
[monkey-runner] Increase version to 1.0.0 for release

### DIFF
--- a/monkey-runner/README.md
+++ b/monkey-runner/README.md
@@ -75,6 +75,18 @@ Run the following to start the monkey on all connected devices:
 ./gradlew runMonkeyAll
 ```
 
+## Changelog
+
+### 0.0.1
+
+- initial release
+
+### 1.0.0
+
+- Make categories optional & introduce `useMonkeyTrap` property in order to control whether the session should use the trap or not (https://github.com/novoda/spikes/pull/155)
+- Update command plugin (https://github.com/novoda/spikes/pull/251)
+- Ensure command plugin applied (https://github.com/novoda/spikes/pull/260)
+
 ## Links
 
 Here are a list of useful links:

--- a/monkey-runner/README.md
+++ b/monkey-runner/README.md
@@ -83,7 +83,7 @@ Run the following to start the monkey on all connected devices:
 
 ### 1.0.0
 
-- Make categories optional & introduce `useMonkeyTrap` property in order to control whether the session should use the trap or not ([#55](https://github.com/novoda/spikes/pull/155))
+- Make categories optional & introduce `useMonkeyTrap` property in order to control whether the session should use the trap or not ([#155](https://github.com/novoda/spikes/pull/155))
 - Update command plugin ([#251](https://github.com/novoda/spikes/pull/251))
 - Ensure command plugin applied ([#260](https://github.com/novoda/spikes/pull/260))
 

--- a/monkey-runner/README.md
+++ b/monkey-runner/README.md
@@ -83,9 +83,9 @@ Run the following to start the monkey on all connected devices:
 
 ### 1.0.0
 
-- Make categories optional & introduce `useMonkeyTrap` property in order to control whether the session should use the trap or not (https://github.com/novoda/spikes/pull/155)
-- Update command plugin (https://github.com/novoda/spikes/pull/251)
-- Ensure command plugin applied (https://github.com/novoda/spikes/pull/260)
+- Make categories optional & introduce `useMonkeyTrap` property in order to control whether the session should use the trap or not ([#55](https://github.com/novoda/spikes/pull/155))
+- Update command plugin ([#251](https://github.com/novoda/spikes/pull/251))
+- Ensure command plugin applied ([#260](https://github.com/novoda/spikes/pull/260))
 
 ## Links
 

--- a/monkey-runner/build.gradle
+++ b/monkey-runner/build.gradle
@@ -17,5 +17,5 @@ subprojects {
     repositories {
         jcenter()
     }
-    version = '0.0.1'
+    version = '1.0.0'
 }


### PR DESCRIPTION
We haven't released monkey runner since its initial version.

There's been three PRs since:

- Make categories optional & introduce `useMonkeyTrap` property in order to control whether the session should use the trap or not (https://github.com/novoda/spikes/pull/155)
- Update command plugin (https://github.com/novoda/spikes/pull/251)
- Ensure command plugin applied (https://github.com/novoda/spikes/pull/260)

This PR bumps to 1.0.0 (since it's being used in projects) and adds a changelog until we get it's own repo. (Can then migrate that info to the releases branch, and/or keep a changelog file)