### PR TITLE
[monkey-runner] Apply command plugin by default

### DIFF
--- a/monkey-runner/README.md
+++ b/monkey-runner/README.md
@@ -24,8 +24,7 @@ rm app-debug.apk
 
 You can run this as part of your CI job before starting the monkey runner.
 
-In your Android module's `build.gradle`, add this plugin as a dependency, apply it and configure it. Be sure you also apply
- the `android-command` plugin (which `monkey-runner` depends on):
+In your Android module's `build.gradle`, add this plugin as a dependency, apply it and configure it:
 
 ```groovy
 buildscript {
@@ -44,7 +43,6 @@ buildscript {
 
 ...
 
-apply plugin: 'com.novoda.android-command'
 apply plugin: 'com.novoda.monkey-runner'
 
 ...

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -12,10 +12,7 @@ class MonkeyConfigurationPlugin implements Plugin<Project> {
     void apply(Project project) {
         ensureAndroidPluginAppliedTo(project)
 
-        project.configure(project) {
-            //noinspection GroovyAssignabilityCheck
-            apply plugin: 'com.novoda.android-command'
-        }
+        project.apply plugin: 'com.novoda.android-command'
 
         MonkeyRunnerExtension extension = project.extensions.create(MonkeyRunnerExtension.NAME, MonkeyRunnerExtension)
         extension.setDefaultsForOptionalProperties()

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -33,10 +33,6 @@ class MonkeyConfigurationPlugin implements Plugin<Project> {
         ensurePluginIsApplied('com.android.application', project)
     }
 
-    private static void ensureCommandPluginAppliedTo(Project project) {
-        ensurePluginIsApplied('android-command', project)
-    }
-
     private static void ensurePluginIsApplied(String plugin, Project project) {
         boolean isMissingPlugin = !project.plugins.hasPlugin(plugin)
         if (isMissingPlugin) {

--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -11,7 +11,11 @@ class MonkeyConfigurationPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         ensureAndroidPluginAppliedTo(project)
-        ensureCommandPluginAppliedTo(project)
+
+        project.configure(project) {
+            //noinspection GroovyAssignabilityCheck
+            apply plugin: 'com.novoda.android-command'
+        }
 
         MonkeyRunnerExtension extension = project.extensions.create(MonkeyRunnerExtension.NAME, MonkeyRunnerExtension)
         extension.setDefaultsForOptionalProperties()

--- a/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
+++ b/monkey-runner/plugin/src/test/groovy/com/novoda/monkey/MonkeyConfigurationPluginTest.groovy
@@ -16,15 +16,14 @@ class MonkeyConfigurationPluginTest {
     }
 
     @Test(expected = GradleException.class)
-    void givenAndroidPluginNotApplied_whenApplyingMonkey_thenItThrowsException() {
-        project.apply plugin: 'android-command'
+    void givenNoPluginsAreApplied_whenApplyingMonkey_thenItThrowsException() {
 
         project.apply plugin: MonkeyConfigurationPlugin
 
     }
 
-    @Test(expected = GradleException.class)
-    void givenCommandPluginNotApplied_whenApplyingMonkey_thenItThrowsException() {
+    @Test
+    void givenCommandPluginNotApplied_whenApplyingMonkey_thenItDoesNotThrowException() {
         project.apply plugin: 'com.android.application'
 
         project.apply plugin: MonkeyConfigurationPlugin

--- a/monkey-runner/sample/app/build.gradle
+++ b/monkey-runner/sample/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'android-command'
 
 apply plugin: com.novoda.monkey.MonkeyConfigurationPlugin
 


### PR DESCRIPTION
We can avoid having the users' of this plugin having to apply the android command plugin on their own, thus making it simpler to integrate this plugin in their projects.

Tests updated.