### PR TITLE
Tpbot/ NPE on service

### DIFF
--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
@@ -40,10 +40,14 @@ public class MovementService extends Service {
     private Toaster toaster;
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
+    public void onCreate() {
+        super.onCreate();
         toaster = Toaster.newInstance(MovementService.this);
         toaster.popToast(MovementService.class.getSimpleName() + " started");
+    }
 
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
         pendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);


### PR DESCRIPTION
#### Problem
Seeing a `NullPointerException` when a command is sent to the `MovementService`. Seems to be some confusion as to when `onServiceConnected(ComponentName name, IBinder service);` is called by the `Service`, it is called before `onStartCommand(Intent intent, int flags, int startId)` where the `Toaster` etc are created, resulting in an NPE.

#### Solution
Move creation of `Toaster` to onCreate to prevent NPE, which occurs before any of the other callbacks.