### PR TITLE
Tpbot/ Handler exception

### DIFF
--- a/TelepresenceBot/core/src/main/java/com/novoda/tpbot/human/HumanPresenter.java
+++ b/TelepresenceBot/core/src/main/java/com/novoda/tpbot/human/HumanPresenter.java
@@ -23,8 +23,13 @@ class HumanPresenter {
     }
 
     void stopPresenting() {
-        observable.detachObservers();
-        humanTpService.disconnect();
+        if (observable != null) {
+            observable.detachObservers();
+        }
+
+        if (humanTpService != null) {
+            humanTpService.disconnect();
+        }
     }
 
     private class ConnectionObserver implements Observer<Result> {

--- a/TelepresenceBot/core/src/main/java/com/novoda/tpbot/human/HumanPresenter.java
+++ b/TelepresenceBot/core/src/main/java/com/novoda/tpbot/human/HumanPresenter.java
@@ -27,9 +27,7 @@ class HumanPresenter {
             observable.detachObservers();
         }
 
-        if (humanTpService != null) {
-            humanTpService.disconnect();
-        }
+        humanTpService.disconnect();
     }
 
     private class ConnectionObserver implements Observer<Result> {

--- a/TelepresenceBot/core/src/main/java/com/novoda/tpbot/human/HumanPresenter.java
+++ b/TelepresenceBot/core/src/main/java/com/novoda/tpbot/human/HumanPresenter.java
@@ -4,6 +4,8 @@ import com.novoda.tpbot.Result;
 import com.novoda.tpbot.support.Observable;
 import com.novoda.tpbot.support.Observer;
 
+import static com.novoda.tpbot.support.Observable.unsubscribe;
+
 class HumanPresenter {
 
     private final HumanTpService humanTpService;
@@ -23,10 +25,7 @@ class HumanPresenter {
     }
 
     void stopPresenting() {
-        if (observable != null) {
-            observable.detachObservers();
-        }
-
+        unsubscribe(observable);
         humanTpService.disconnect();
     }
 

--- a/TelepresenceBot/core/src/main/java/com/novoda/tpbot/support/Observable.java
+++ b/TelepresenceBot/core/src/main/java/com/novoda/tpbot/support/Observable.java
@@ -29,7 +29,7 @@ public abstract class Observable<T> {
         return this;
     }
 
-    public synchronized void detach(Observer observer) {
+    synchronized void detach(Observer observer) {
         observers.remove(observer);
     }
 
@@ -41,6 +41,12 @@ public abstract class Observable<T> {
 
     public synchronized void detachObservers() {
         observers.clear();
+    }
+
+    public static void unsubscribe(Observable observable) {
+        if (observable != null) {
+            observable.detachObservers();
+        }
     }
 
     private static class SingleEmissionObservable<T> extends Observable<T> {

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
@@ -28,8 +28,6 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_human);
 
-        presenter = new HumanPresenter(SocketIOTpService.getInstance(), this);
-
         debugView = Views.findById(this, R.id.bot_controller_debug_view);
         switchableView = Views.findById(this, R.id.bot_switchable_view);
 
@@ -83,6 +81,12 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
     };
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        presenter = new HumanPresenter(SocketIOTpService.getInstance(), this);
+    }
+
+    @Override
     public void onConnect(String message) {
         debugView.showPermanently(getResources().getString(R.string.connected));
         switchableView.setDisplayedChild(1);
@@ -108,6 +112,7 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
     @Override
     protected void onStop() {
         presenter.stopPresenting();
+        presenter = null;
         super.onStop();
     }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
@@ -31,6 +31,8 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
         debugView = Views.findById(this, R.id.bot_controller_debug_view);
         switchableView = Views.findById(this, R.id.bot_switchable_view);
 
+        presenter = new HumanPresenter(SocketIOTpService.getInstance(), this);
+
         Handler handler = new Handler();
         commandRepeater = new CommandRepeater(commandRepeatedListener, handler);
 
@@ -81,12 +83,6 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
     };
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        presenter = new HumanPresenter(SocketIOTpService.getInstance(), this);
-    }
-
-    @Override
     public void onConnect(String message) {
         debugView.showPermanently(getResources().getString(R.string.connected));
         switchableView.setDisplayedChild(1);
@@ -112,7 +108,6 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
     @Override
     protected void onStop() {
         presenter.stopPresenting();
-        presenter = null;
         super.onStop();
     }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
@@ -43,6 +43,14 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
         serverDeclarationView.setServerDeclarationListener(serverDeclarationListener);
     }
 
+    private CommandRepeater.Listener commandRepeatedListener = new CommandRepeater.Listener() {
+        @Override
+        public void onCommandRepeated(String command) {
+            debugView.showTimed(command);
+            // TODO: send command to the receiver (bot) part
+        }
+    };
+
     private final ControllerListener controllerListener = new ControllerListener() {
 
         @Override
@@ -65,26 +73,6 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
             commandRepeater.stopRepeatingCommand(LAZERS);
         }
     };
-
-    private CommandRepeater.Listener commandRepeatedListener = new CommandRepeater.Listener() {
-        @Override
-        public void onCommandRepeated(String command) {
-            debugView.showTimed(command);
-            // TODO: send command to the receiver (bot) part
-        }
-    };
-
-    @Override
-    protected void onPause() {
-        commandRepeater.stopCurrentRepeatingCommand();
-        super.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        presenter.stopPresenting();
-        super.onStop();
-    }
 
     private final ServerDeclarationListener serverDeclarationListener = new ServerDeclarationListener() {
         @Override
@@ -109,6 +97,18 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
     public void onError(String message) {
         debugView.showPermanently(message);
         switchableView.setDisplayedChild(0);
+    }
+
+    @Override
+    protected void onPause() {
+        commandRepeater.stopCurrentRepeatingCommand();
+        super.onPause();
+    }
+
+    @Override
+    protected void onStop() {
+        presenter.stopPresenting();
+        super.onStop();
     }
 
 }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/HumanActivity.java
@@ -41,7 +41,7 @@ public class HumanActivity extends AppCompatActivity implements HumanView {
         serverDeclarationView.setServerDeclarationListener(serverDeclarationListener);
     }
 
-    private CommandRepeater.Listener commandRepeatedListener = new CommandRepeater.Listener() {
+    private final CommandRepeater.Listener commandRepeatedListener = new CommandRepeater.Listener() {
         @Override
         public void onCommandRepeated(String command) {
             debugView.showTimed(command);

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/SocketIOTpService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/SocketIOTpService.java
@@ -44,7 +44,7 @@ class SocketIOTpService implements HumanTpService {
             socket = IO.socket(url.toExternalForm());
         } catch (MalformedURLException | URISyntaxException exception) {
             String message = "Address should be in the format `http://[ip_address]:[port_number]`";
-            HumanSocketIOConnectionException exceptionWithUserFacingMessage = new HumanSocketIOConnectionException(message, exception);
+            ConnectionException exceptionWithUserFacingMessage = new ConnectionException(message, exception);
             return Observable.just(Result.from(exceptionWithUserFacingMessage));
         }
         return new SocketConnectionObservable();
@@ -110,9 +110,9 @@ class SocketIOTpService implements HumanTpService {
         private static final SocketIOTpService INSTANCE = new SocketIOTpService();
     }
 
-    private class HumanSocketIOConnectionException extends IOException {
+    private class ConnectionException extends IOException {
 
-        private HumanSocketIOConnectionException(String message, Throwable throwable) {
+        private ConnectionException(String message, Throwable throwable) {
             super(message, throwable);
         }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/landing/LandingActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/landing/LandingActivity.java
@@ -19,21 +19,24 @@ public class LandingActivity extends AppCompatActivity {
         View humanSelection = findViewById(R.id.human_selection);
         View botSelection = findViewById(R.id.bot_selection);
 
-        humanSelection.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(LandingActivity.this, HumanActivity.class);
-                startActivity(intent);
-            }
-        });
-
-        botSelection.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(LandingActivity.this, BotActivity.class);
-                startActivity(intent);
-            }
-        });
+        humanSelection.setOnClickListener(onHumanSelectionListener);
+        botSelection.setOnClickListener(onBotSelectionListener);
     }
+
+    private final View.OnClickListener onHumanSelectionListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            Intent intent = new Intent(getApplicationContext(), HumanActivity.class);
+            startActivity(intent);
+        }
+    };
+
+    private final View.OnClickListener onBotSelectionListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            Intent intent = new Intent(getApplicationContext(), BotActivity.class);
+            startActivity(intent);
+        }
+    };
 
 }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/SelfDestructingMessageView.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/SelfDestructingMessageView.java
@@ -18,19 +18,21 @@ public class SelfDestructingMessageView extends TextView {
     }
 
     public void showPermanently(String arrowCharacter) {
+        clearMessage();
         setText(arrowCharacter);
-        getHandler().removeCallbacks(clearTextRunnable);
     }
 
     public void showTimed(String string) {
+        clearMessage();
         setText(string);
-        getHandler().removeCallbacks(clearTextRunnable);
         getHandler().postDelayed(clearTextRunnable, COMMAND_FADING_DELAY);
     }
 
-    public void clearMessage() {
+    private void clearMessage() {
         setText(null);
-        getHandler().removeCallbacks(clearTextRunnable);
+        if (getHandler() != null) {
+            getHandler().removeCallbacks(clearTextRunnable);
+        }
     }
 
     private final Runnable clearTextRunnable = new Runnable() {


### PR DESCRIPTION
#### Problem
Receiving an NPE when navigating between the `HumanActivity` and the `LandingActivity`. We are trying to remove callbacks on a `Handler` that is null.

#### Solution
Add guard against attempting to clear callbacks on a null `Handler`.

#### Additional
Stop and Start of presenting are matched to the corresponding lifecycle methods, onStop and onStart. Guard against NPEs on Presenter when detaching service and observables.