### PR TITLE
[espresso-support] Add view matchers to assert custom usage hints

### DIFF
--- a/espresso-support/core/build.gradle
+++ b/espresso-support/core/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     provided project(':extras')
     compile libraries.androidTestRunner
     compile libraries.androidEspressoCore
+    compile libraries.supportAnnotations
 }
 
 publish {

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -28,7 +28,7 @@ public class AccessibilityViewMatchers {
                     return false;
                 }
 
-                if (null == this.expectedText) {
+                if (expectedText == null) {
                     try {
                         expectedText = view.getResources().getString(resourceId);
                         resourceName = view.getResources().getResourceEntryName(resourceId);
@@ -36,7 +36,7 @@ public class AccessibilityViewMatchers {
                         // view could be from a context unaware of the resource id.
                     }
                 }
-                if (null != expectedText) {
+                if (expectedText != null) {
                     AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
                     AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_CLICK);
 
@@ -50,12 +50,12 @@ public class AccessibilityViewMatchers {
             public void describeTo(Description description) {
                 description.appendText("is clickable and has custom usage hint for ACTION_CLICK from resource id: ");
                 description.appendValue(resourceId);
-                if (null != this.resourceName) {
+                if (resourceName != null) {
                     description.appendText("[");
                     description.appendText(resourceName);
                     description.appendText("]");
                 }
-                if (null != this.expectedText) {
+                if (expectedText != null) {
                     description.appendText(" value: ");
                     description.appendText(expectedText);
                 }
@@ -104,7 +104,7 @@ public class AccessibilityViewMatchers {
                     return false;
                 }
 
-                if (null == this.expectedText) {
+                if (expectedText == null) {
                     try {
                         expectedText = view.getResources().getString(resourceId);
                         resourceName = view.getResources().getResourceEntryName(resourceId);
@@ -112,7 +112,7 @@ public class AccessibilityViewMatchers {
                         // view could be from a context unaware of the resource id.
                     }
                 }
-                if (null != expectedText) {
+                if (expectedText != null) {
                     AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
                     AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_LONG_CLICK);
 
@@ -126,12 +126,12 @@ public class AccessibilityViewMatchers {
             public void describeTo(Description description) {
                 description.appendText("is long clickable and has custom usage hint for ACTION_LONG_CLICK from resource id: ");
                 description.appendValue(resourceId);
-                if (null != this.resourceName) {
+                if (resourceName != null) {
                     description.appendText("[");
                     description.appendText(resourceName);
                     description.appendText("]");
                 }
-                if (null != this.expectedText) {
+                if (expectedText != null) {
                     description.appendText(" value: ");
                     description.appendText(expectedText);
                 }

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -37,9 +37,7 @@ public class AccessibilityViewMatchers {
                     }
                 }
                 if (expectedText != null) {
-                    AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
-                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_CLICK);
-
+                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_CLICK);
                     return expectedText.equals(clickAction.getLabel());
                 } else {
                     return false;
@@ -76,10 +74,7 @@ public class AccessibilityViewMatchers {
                 if (!view.isClickable()) {
                     return false;
                 }
-
-                AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
-                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_CLICK);
-
+                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_CLICK);
                 return charSequenceMatcher.matches(clickAction.getLabel());
             }
 
@@ -113,9 +108,7 @@ public class AccessibilityViewMatchers {
                     }
                 }
                 if (expectedText != null) {
-                    AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
-                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_LONG_CLICK);
-
+                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_LONG_CLICK);
                     return expectedText.equals(clickAction.getLabel());
                 } else {
                     return false;
@@ -152,10 +145,7 @@ public class AccessibilityViewMatchers {
                 if (!view.isLongClickable()) {
                     return false;
                 }
-
-                AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
-                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_LONG_CLICK);
-
+                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_LONG_CLICK);
                 return charSequenceMatcher.matches(clickAction.getLabel());
             }
 
@@ -168,7 +158,8 @@ public class AccessibilityViewMatchers {
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    public static AccessibilityNodeInfo.AccessibilityAction findAction(AccessibilityNodeInfo accessibilityNodeInfo, int actionId) {
+    public static AccessibilityNodeInfo.AccessibilityAction findAction(View view, int actionId) {
+        AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
         for (AccessibilityNodeInfo.AccessibilityAction accessibilityAction : accessibilityNodeInfo.getActionList()) {
             if (actionId == accessibilityAction.getId()) {
                 return accessibilityAction;

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -1,6 +1,5 @@
 package com.novoda.espresso;
 
-import android.content.res.Resources;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 import android.support.annotation.StringRes;
@@ -28,20 +27,15 @@ public class AccessibilityViewMatchers {
                     return false;
                 }
 
+                expectedText = view.getResources().getString(resourceId);
+                resourceName = view.getResources().getResourceEntryName(resourceId);
+
                 if (expectedText == null) {
-                    try {
-                        expectedText = view.getResources().getString(resourceId);
-                        resourceName = view.getResources().getResourceEntryName(resourceId);
-                    } catch (Resources.NotFoundException ignored) {
-                        // view could be from a context unaware of the resource id.
-                    }
-                }
-                if (expectedText != null) {
-                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_CLICK);
-                    return expectedText.equals(clickAction.getLabel());
-                } else {
                     return false;
                 }
+
+                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_CLICK);
+                return expectedText.equals(clickAction.getLabel());
             }
 
             @Override
@@ -99,20 +93,15 @@ public class AccessibilityViewMatchers {
                     return false;
                 }
 
+                expectedText = view.getResources().getString(resourceId);
+                resourceName = view.getResources().getResourceEntryName(resourceId);
+
                 if (expectedText == null) {
-                    try {
-                        expectedText = view.getResources().getString(resourceId);
-                        resourceName = view.getResources().getResourceEntryName(resourceId);
-                    } catch (Resources.NotFoundException ignored) {
-                        // view could be from a context unaware of the resource id.
-                    }
-                }
-                if (expectedText != null) {
-                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_LONG_CLICK);
-                    return expectedText.equals(clickAction.getLabel());
-                } else {
                     return false;
                 }
+
+                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(view, AccessibilityNodeInfo.ACTION_LONG_CLICK);
+                return expectedText.equals(clickAction.getLabel());
             }
 
             @Override

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -1,6 +1,8 @@
 package com.novoda.espresso;
 
 import android.content.res.Resources;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.support.annotation.StringRes;
 import android.view.View;
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -13,6 +15,7 @@ import static org.hamcrest.Matchers.is;
 
 public class AccessibilityViewMatchers {
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     public static Matcher<? super View> withUsageHintOnClick(@StringRes final int resourceId) {
         return new TypeSafeMatcher<View>() {
 
@@ -60,10 +63,12 @@ public class AccessibilityViewMatchers {
         };
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     public static Matcher<? super View> withUsageHintOnClick(CharSequence text) {
         return withUsageHintOnClick(is(text));
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     public static Matcher<? super View> withUsageHintOnClick(final Matcher<? extends CharSequence> charSequenceMatcher) {
         return new TypeSafeMatcher<View>() {
             @Override
@@ -86,6 +91,7 @@ public class AccessibilityViewMatchers {
         };
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     public static Matcher<? super View> withUsageHintOnLongClick(@StringRes final int resourceId) {
         return new TypeSafeMatcher<View>() {
 
@@ -133,10 +139,12 @@ public class AccessibilityViewMatchers {
         };
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     public static Matcher<? super View> withUsageHintOnLongClick(CharSequence text) {
         return withUsageHintOnLongClick(is(text));
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     public static Matcher<? super View> withUsageHintOnLongClick(final Matcher<? extends CharSequence> charSequenceMatcher) {
         return new TypeSafeMatcher<View>() {
             @Override
@@ -159,6 +167,7 @@ public class AccessibilityViewMatchers {
         };
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     public static AccessibilityNodeInfo.AccessibilityAction findAction(AccessibilityNodeInfo accessibilityNodeInfo, int actionId) {
         for (AccessibilityNodeInfo.AccessibilityAction accessibilityAction : accessibilityNodeInfo.getActionList()) {
             if (actionId == accessibilityAction.getId()) {

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -1,0 +1,178 @@
+package com.novoda.espresso;
+
+import android.content.res.Resources;
+import android.support.annotation.StringRes;
+import android.view.View;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import static org.hamcrest.Matchers.is;
+
+public class AccessibilityViewMatchers {
+
+    public static Matcher<? super View> withUsageHintOnClick(@StringRes final int resourceId) {
+        return new TypeSafeMatcher<View>() {
+
+            private String resourceName = null;
+            private String expectedText = null;
+
+            @Override
+            protected boolean matchesSafely(View view) {
+                if (!view.isClickable()) {
+                    return false;
+                }
+
+                if (null == this.expectedText) {
+                    try {
+                        expectedText = view.getResources().getString(resourceId);
+                        resourceName = view.getResources().getResourceEntryName(resourceId);
+                    } catch (Resources.NotFoundException ignored) {
+                        // view could be from a context unaware of the resource id.
+                    }
+                }
+                if (null != expectedText) {
+                    AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
+                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_CLICK);
+
+                    return expectedText.equals(clickAction.getLabel());
+                } else {
+                    return false;
+                }
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("is clickable and has custom usage hint for ACTION_CLICK from resource id: ");
+                description.appendValue(resourceId);
+                if (null != this.resourceName) {
+                    description.appendText("[");
+                    description.appendText(resourceName);
+                    description.appendText("]");
+                }
+                if (null != this.expectedText) {
+                    description.appendText(" value: ");
+                    description.appendText(expectedText);
+                }
+            }
+        };
+    }
+
+    public static Matcher<? super View> withUsageHintOnClick(CharSequence text) {
+        return withUsageHintOnClick(is(text));
+    }
+
+    public static Matcher<? super View> withUsageHintOnClick(final Matcher<? extends CharSequence> charSequenceMatcher) {
+        return new TypeSafeMatcher<View>() {
+            @Override
+            protected boolean matchesSafely(View view) {
+                if (!view.isClickable()) {
+                    return false;
+                }
+
+                AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
+                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_CLICK);
+
+                return charSequenceMatcher.matches(clickAction.getLabel());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("is clickable and has custom usage hint for ACTION_CLICK: ");
+                charSequenceMatcher.describeTo(description);
+            }
+        };
+    }
+
+    public static Matcher<? super View> withUsageHintOnLongClick(@StringRes final int resourceId) {
+        return new TypeSafeMatcher<View>() {
+
+            private String resourceName = null;
+            private String expectedText = null;
+
+            @Override
+            protected boolean matchesSafely(View view) {
+                if (!view.isLongClickable()) {
+                    return false;
+                }
+
+                if (null == this.expectedText) {
+                    try {
+                        expectedText = view.getResources().getString(resourceId);
+                        resourceName = view.getResources().getResourceEntryName(resourceId);
+                    } catch (Resources.NotFoundException ignored) {
+                        // view could be from a context unaware of the resource id.
+                    }
+                }
+                if (null != expectedText) {
+                    AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
+                    AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_LONG_CLICK);
+
+                    return expectedText.equals(clickAction.getLabel());
+                } else {
+                    return false;
+                }
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("is long clickable and has custom usage hint for ACTION_LONG_CLICK from resource id: ");
+                description.appendValue(resourceId);
+                if (null != this.resourceName) {
+                    description.appendText("[");
+                    description.appendText(resourceName);
+                    description.appendText("]");
+                }
+                if (null != this.expectedText) {
+                    description.appendText(" value: ");
+                    description.appendText(expectedText);
+                }
+            }
+        };
+    }
+
+    public static Matcher<? super View> withUsageHintOnLongClick(CharSequence text) {
+        return withUsageHintOnLongClick(is(text));
+    }
+
+    public static Matcher<? super View> withUsageHintOnLongClick(final Matcher<? extends CharSequence> charSequenceMatcher) {
+        return new TypeSafeMatcher<View>() {
+            @Override
+            protected boolean matchesSafely(View view) {
+                if (!view.isLongClickable()) {
+                    return false;
+                }
+
+                AccessibilityNodeInfo accessibilityNodeInfo = view.createAccessibilityNodeInfo();
+                AccessibilityNodeInfo.AccessibilityAction clickAction = findAction(accessibilityNodeInfo, AccessibilityNodeInfo.ACTION_LONG_CLICK);
+
+                return charSequenceMatcher.matches(clickAction.getLabel());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("is long clickable and has custom usage hint for ACTION_LONG_CLICK: ");
+                charSequenceMatcher.describeTo(description);
+            }
+        };
+    }
+
+    public static AccessibilityNodeInfo.AccessibilityAction findAction(AccessibilityNodeInfo accessibilityNodeInfo, int actionId) {
+        for (AccessibilityNodeInfo.AccessibilityAction accessibilityAction : accessibilityNodeInfo.getActionList()) {
+            if (actionId == accessibilityAction.getId()) {
+                return accessibilityAction;
+            }
+        }
+        throw new AccessibilityActionNotFoundException(actionId);
+    }
+
+    public static class AccessibilityActionNotFoundException extends RuntimeException {
+
+        public AccessibilityActionNotFoundException(int actionId) {
+            super("Could not find AccessibilityAction with id: " + actionId);
+        }
+    }
+
+}

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -1,6 +1,7 @@
 package com.novoda.espresso;
 
 import android.os.Build;
+import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 import android.support.annotation.StringRes;
 import android.view.View;
@@ -40,17 +41,8 @@ public class AccessibilityViewMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("is clickable and has custom usage hint for ACTION_CLICK from resource id: ");
-                description.appendValue(resourceId);
-                if (resourceName != null) {
-                    description.appendText("[");
-                    description.appendText(resourceName);
-                    description.appendText("]");
-                }
-                if (expectedText != null) {
-                    description.appendText(" value: ");
-                    description.appendText(expectedText);
-                }
+                description.appendText("is clickable and has custom usage hint for ACTION_CLICK from resource id: ").appendValue(resourceId);
+                appendResourceNameAndExpectedTextToDescription(description, resourceName, expectedText);
             }
         };
     }
@@ -106,17 +98,8 @@ public class AccessibilityViewMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("is long clickable and has custom usage hint for ACTION_LONG_CLICK from resource id: ");
-                description.appendValue(resourceId);
-                if (resourceName != null) {
-                    description.appendText("[");
-                    description.appendText(resourceName);
-                    description.appendText("]");
-                }
-                if (expectedText != null) {
-                    description.appendText(" value: ");
-                    description.appendText(expectedText);
-                }
+                description.appendText("is long clickable and has custom usage hint for ACTION_LONG_CLICK from resource id: ").appendValue(resourceId);
+                appendResourceNameAndExpectedTextToDescription(description, resourceName, expectedText);
             }
         };
     }
@@ -155,6 +138,15 @@ public class AccessibilityViewMatchers {
             }
         }
         throw new AccessibilityActionNotFoundException(actionId);
+    }
+
+    public static void appendResourceNameAndExpectedTextToDescription(Description description, @Nullable String resourceName, @Nullable String expectedText) {
+        if (resourceName != null) {
+            description.appendText("[").appendText(resourceName).appendText("]");
+        }
+        if (expectedText != null) {
+            description.appendText(" value: ").appendText(expectedText);
+        }
     }
 
     public static class AccessibilityActionNotFoundException extends RuntimeException {

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -182,6 +182,7 @@ public class AccessibilityViewMatchers {
         public AccessibilityActionNotFoundException(int actionId) {
             super("Could not find AccessibilityAction with id: " + actionId);
         }
+
     }
 
 }

--- a/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/AccessibilityViewMatchers.java
@@ -19,8 +19,8 @@ public class AccessibilityViewMatchers {
     public static Matcher<? super View> withUsageHintOnClick(@StringRes final int resourceId) {
         return new TypeSafeMatcher<View>() {
 
-            private String resourceName = null;
-            private String expectedText = null;
+            private String resourceName;
+            private String expectedText;
 
             @Override
             protected boolean matchesSafely(View view) {
@@ -90,8 +90,8 @@ public class AccessibilityViewMatchers {
     public static Matcher<? super View> withUsageHintOnLongClick(@StringRes final int resourceId) {
         return new TypeSafeMatcher<View>() {
 
-            private String resourceName = null;
-            private String expectedText = null;
+            private String resourceName;
+            private String expectedText;
 
             @Override
             protected boolean matchesSafely(View view) {

--- a/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
+++ b/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
@@ -18,7 +18,11 @@ import org.mockito.junit.MockitoRule;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.*;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.novoda.espresso.AccessibilityViewMatchers.withUsageHintOnClick;
+import static com.novoda.espresso.AccessibilityViewMatchers.withUsageHintOnLongClick;
 import static org.hamcrest.CoreMatchers.is;
 
 @RunWith(AndroidJUnit4.class)
@@ -55,6 +59,18 @@ public class MovieItemViewTalkBackTest {
         onView(withClassName(is(MovieItemView.class.getName()))).perform(click());
 
         checkMenuDisplayed();
+    }
+
+    @Test
+    public void movieItemViewHasCustomUsageHintOnClick() {
+        onView(withClassName(is(MovieItemView.class.getName())))
+                .check(matches(withUsageHintOnClick("see actions")));
+    }
+
+    @Test
+    public void movieItemViewHasCustomUsageHintOnLongClick() {
+        onView(withClassName(is(MovieItemView.class.getName())))
+                .check(matches(withUsageHintOnLongClick("open details")));
     }
 
     private void givenMovieItemViewIsBoundTo(final Movie movie) {

--- a/espresso-support/dependencies.gradle
+++ b/espresso-support/dependencies.gradle
@@ -21,6 +21,7 @@ ext {
             dexmakerMockito    : "com.google.dexmaker:dexmaker-mockito:${versions.dexmaker}",
             jUnit              : 'junit:junit:4.12',
             mockitoCore        : 'org.mockito:mockito-core:1.10.19',
+            supportAnnotations : 'com.android.support:support-annotations:25.2.0',
             supportAppCompatV7 : 'com.android.support:appcompat-v7:25.2.0'
     ]
 }


### PR DESCRIPTION
This PR adds some custom matchers for the `espresso-support` library that allow the user to assert a view has custom usage hints for click and long-click actions.

If a view is clickable, the default usage hint will be "activate" so TalkBack will read aloud, "double tap to activate". This isn't very descriptive - we should set custom usage hints.

The demo shows that we can assert the custom usage hint for both click and long click actions.

:warning: The solution is only suitable for API 21 and above since `AccessibilityAction.getLabel()` is only available on that API. Added "requires api" annotations:

![image](https://cloud.githubusercontent.com/assets/2678555/24124596/5dee3b34-0dbc-11e7-87a4-67deff9daac9.png)


I tried to follow the style for `ViewMatchers.withContentDescription()`.