### PR TITLE
Tpbot/ Pass room in Query

### DIFF
--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SocketIOTpService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SocketIOTpService.java
@@ -9,6 +9,7 @@ import com.novoda.tpbot.support.ClientType;
 import com.novoda.tpbot.support.Event;
 import com.novoda.tpbot.support.MalformedServerAddressException;
 import com.novoda.tpbot.support.Observable;
+import com.novoda.tpbot.support.Room;
 import com.novoda.tpbot.support.SocketConnectionObservable;
 
 import java.net.MalformedURLException;
@@ -37,7 +38,7 @@ class SocketIOTpService implements BotTpService {
         try {
             URL url = new URL(serverAddress);
             IO.Options options = new IO.Options();
-            options.query = ClientType.BOT.rawQuery();
+            options.query = ClientType.BOT.rawQuery() + "&" + Room.LONDON.rawQuery();
             socket = IO.socket(url.toExternalForm(), options);
         } catch (MalformedURLException | URISyntaxException exception) {
             MalformedServerAddressException exceptionWithUserFacingMessage = new MalformedServerAddressException(exception);

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/SocketIOTpService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/human/SocketIOTpService.java
@@ -9,6 +9,7 @@ import com.novoda.tpbot.support.ClientType;
 import com.novoda.tpbot.support.Event;
 import com.novoda.tpbot.support.MalformedServerAddressException;
 import com.novoda.tpbot.support.Observable;
+import com.novoda.tpbot.support.Room;
 import com.novoda.tpbot.support.SocketConnectionObservable;
 
 import java.net.MalformedURLException;
@@ -36,7 +37,7 @@ class SocketIOTpService implements HumanTpService {
         try {
             URL url = new URL(serverAddress);
             IO.Options options = new IO.Options();
-            options.query = ClientType.HUMAN.rawQuery();
+            options.query = ClientType.HUMAN.rawQuery() + "&" + Room.LONDON.rawQuery();
             socket = IO.socket(url.toExternalForm(), options);
         } catch (MalformedURLException | URISyntaxException exception) {
             MalformedServerAddressException exceptionWithUserFacingMessage = new MalformedServerAddressException(exception);

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Room.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/Room.java
@@ -1,0 +1,17 @@
+package com.novoda.tpbot.support;
+
+public enum Room {
+
+    LONDON("room=London");
+
+    private final String rawQuery;
+
+    Room(String rawQuery) {
+        this.rawQuery = rawQuery;
+    }
+
+    public String rawQuery() {
+        return rawQuery;
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/SocketConnectionObservable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/SocketConnectionObservable.java
@@ -8,9 +8,7 @@ import io.socket.client.Socket;
 import io.socket.client.SocketIOException;
 import io.socket.emitter.Emitter;
 
-import static io.socket.client.Socket.EVENT_CONNECT;
-import static io.socket.client.Socket.EVENT_CONNECT_ERROR;
-import static io.socket.client.Socket.EVENT_ERROR;
+import static io.socket.client.Socket.*;
 
 public class SocketConnectionObservable extends Observable<Result> {
 

--- a/TelepresenceBot/server-unit/core/botLocator.js
+++ b/TelepresenceBot/server-unit/core/botLocator.js
@@ -5,16 +5,17 @@ function BotLocator(rooms) {
 BotLocator.prototype.locateFirstAvailableBotIn = function(room) {
     var botsInRoom = this.rooms[room];
 
-    if(botsInRoom != undefined) {
-        for (socketId in botsInRoom.sockets) {
-            var socketsInBotRoom = this.rooms[socketId];
+    if(!botsInRoom) {
+        return;
+    }
 
-            if(botNotConnectedToHuman(socketsInBotRoom)) {
-                return socketId;
-            }
+    for (socketId in botsInRoom.sockets) {
+        var socketsInBotRoom = this.rooms[socketId];
+
+        if(botNotConnectedToHuman(socketsInBotRoom)) {
+            return socketId;
         }
     }
-    return undefined;
 }
 
 function botNotConnectedToHuman(socketsInBotRoom) {

--- a/TelepresenceBot/server-unit/core/botLocator.js
+++ b/TelepresenceBot/server-unit/core/botLocator.js
@@ -1,0 +1,27 @@
+function BotLocator(rooms) {
+    this.rooms = rooms;
+}
+
+BotLocator.prototype.locateFirstAvailableBotIn = function(room) {
+    var botsInRoom = this.rooms[room];
+
+    if(botsInRoom != undefined) {
+        for (socketId in botsInRoom.sockets) {
+
+            var socketsInBotRoom = this.rooms[socketId];
+
+            if(botNotConnectedToHuman(socketsInBotRoom)) {
+                return socketId;
+            }
+        }
+    }
+    return undefined;
+}
+
+function botNotConnectedToHuman(socketsInBotRoom) {
+    return  socketsInBotRoom.length != undefined && socketsInBotRoom.length == 1;
+}
+
+module.exports = BotLocator;
+
+

--- a/TelepresenceBot/server-unit/core/botLocator.js
+++ b/TelepresenceBot/server-unit/core/botLocator.js
@@ -7,7 +7,6 @@ BotLocator.prototype.locateFirstAvailableBotIn = function(room) {
 
     if(botsInRoom != undefined) {
         for (socketId in botsInRoom.sockets) {
-
             var socketsInBotRoom = this.rooms[socketId];
 
             if(botNotConnectedToHuman(socketsInBotRoom)) {

--- a/TelepresenceBot/server-unit/core/botLocator.js
+++ b/TelepresenceBot/server-unit/core/botLocator.js
@@ -19,9 +19,7 @@ BotLocator.prototype.locateFirstAvailableBotIn = function(room) {
 }
 
 function botNotConnectedToHuman(socketsInBotRoom) {
-    return  socketsInBotRoom.length != undefined && socketsInBotRoom.length == 1;
+    return  socketsInBotRoom.length === 1;
 }
 
 module.exports = BotLocator;
-
-

--- a/TelepresenceBot/server-unit/core/loggingClient.js
+++ b/TelepresenceBot/server-unit/core/loggingClient.js
@@ -6,7 +6,7 @@ LoggingClient.prototype.emit = function(event, dataToEmit) {
     if(this.client != undefined) {
         this.client.emit(event, dataToEmit);
     }
-    console.log("\nEvent Emitted: " + event + "\nData Emitted: " + dataToEmit + "\n");
+    console.log("\nEvent Emitted: ", event, "\nData Emitted: ", dataToEmit, "\n");
 }
 
 module.exports = LoggingClient;

--- a/TelepresenceBot/server-unit/core/loggingClient.js
+++ b/TelepresenceBot/server-unit/core/loggingClient.js
@@ -6,7 +6,11 @@ LoggingClient.prototype.emit = function(event, dataToEmit) {
     if(this.client != undefined) {
         this.client.emit(event, dataToEmit);
     }
-    console.log("\nEvent Emitted: ", event, "\nData Emitted: ", dataToEmit, "\n");
+    console.log("\nEvent Emitted: ", event);
+
+    if(dataToEmit != undefined && dataToEmit.length > 0) {
+        console.log("Data Emitted: ", dataToEmit);
+    }
 }
 
 module.exports = LoggingClient;

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -18,19 +18,15 @@ io.use(function(client, next){
         case ClientType.BOT:
             return next();
         case ClientType.HUMAN:
-            console.log(rawRoom);
             var roomRoster = io.sockets.adapter.rooms[rawRoom];
-            console.log(io.sockets.adapter.rooms);
 
             if(roomRoster != undefined) {
                 for (socketId in roomRoster.sockets) {
-                    console.log("botRooms: ", io.sockets.connected[socketId].rooms);
-                    console.log("botRoom: ", io.sockets.adapter.rooms[socketId]);
 
-                    var botsRoom = io.sockets.adapter.rooms[socketId];
-                    if(botsRoom.length != undefined && botsRoom.length == 1) { // Doesn't contain a human.
-                        client.handshake.query.room = socketId; // Replace the room with the bot socket id.
-                        console.log("query: ", client.handshake.query);
+                    var socketsInBotRoom = io.sockets.adapter.rooms[socketId];
+
+                    if(botNotConnectedToHuman(socketsInBotRoom)) {
+                        client.handshake.query.room = socketId;
                         return next();
                     }
                 }
@@ -43,6 +39,10 @@ io.use(function(client, next){
     }
 
 });
+
+function botNotConnectedToHuman(socketsInBotRoom) {
+    return  socketsInBotRoom.length != undefined && socketsInBotRoom.length == 1;
+}
 
 io.sockets.on('connection', function (client) {
 

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -41,6 +41,7 @@ io.sockets.on('connection', function (client) {
 
     switch(clientType) {
         case ClientType.HUMAN:
+            leaveAllRooms(client);
             client.join(roomName);
             testClient.emit('connected_human', asRoomsWithSocketIds());
             break;
@@ -59,6 +60,8 @@ io.sockets.on('connection', function (client) {
 
 
     client.on('disconnect', function() {
+        disconnectAllClientsNotInARoom();
+
         testClient.emit('disconnected_human', asRoomsWithSocketIds());
         testClient.emit('disconnected_bot', asRoomsWithSocketIds());
     });
@@ -71,6 +74,24 @@ io.sockets.on('connection', function (client) {
         }
     });
 });
+
+function leaveAllRooms(client) {
+    var rooms = Object.keys(io.sockets.adapter.sids[client.id]);
+    for(var i = 0; i < rooms.length; i++) {
+        client.leave(rooms[i]);
+    }
+}
+
+function disconnectAllClientsNotInARoom() {
+    var connectedClientIds = Object.keys(io.sockets.connected);
+
+    for(var i = 0; i < connectedClientIds.length; i++) {
+        var client = io.sockets.connected[connectedClientIds[i]];
+        if(client.rooms.length == 0) {
+            client.disconnect();
+        }
+    }
+}
 
 function asRoomsWithSocketIds() {
     var roomNames = Object.keys(io.sockets.adapter.rooms);

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -65,8 +65,8 @@ io.sockets.on('connection', function (client) {
     client.on('disconnect', function() {
         humans.splice(humans.indexOf(client.id), 1);
         bots.splice(bots.indexOf(client.id), 1);
-        testClient.emit('disconnected_human', humans);
-        testClient.emit('disconnected_bot', bots);
+        testClient.emit('disconnected_human', asRoomsWithSocketIds());
+        testClient.emit('disconnected_bot', asRoomsWithSocketIds());
     });
 
 });

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -8,6 +8,8 @@ var bots = [];
 var testClient = new LoggingClient();
 
 io.use(function(client, next){
+
+    var rawRoom = client.handshake.query.room;
     var rawClientType = client.handshake.query.clientType;
     var clientType = ClientType.from(rawClientType);
 
@@ -16,7 +18,7 @@ io.use(function(client, next){
         case ClientType.BOT:
             return next();
         case ClientType.HUMAN:
-            var roomRoster = io.sockets.adapter.rooms[room];
+            var roomRoster = io.sockets.adapter.rooms[rawRoom];
             if(roomRoster != undefined && roomRoster.length == 1) {
                 return next();
             } else {
@@ -26,22 +28,24 @@ io.use(function(client, next){
             return next(new Error('Unrecognised clientType: ' + rawClientType));
 
     }
+
 });
 
 io.sockets.on('connection', function (client) {
 
+    var rawRoom = client.handshake.query.room;
     var rawClientType = client.handshake.query.clientType;
     var clientType = ClientType.from(rawClientType);
 
     switch(clientType) {
         case ClientType.HUMAN:
             humans.push(client.id);
-            client.join(room);
+            client.join(rawRoom);
             testClient.emit('connected_human', humans);
             break;
         case ClientType.BOT:
             bots.push(client.id);
-            client.join(room);
+            client.join(rawRoom);
             testClient.emit('connected_bot', bots);
             break;
         case ClientType.TEST:

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -50,7 +50,7 @@ io.sockets.on('connection', function (client) {
         case ClientType.BOT:
             bots.push(client.id);
             client.join(roomName);
-            testClient.emit('connected_bot', asRoomsWithSockets());
+            testClient.emit('connected_bot', asRoomsWithSocketIds());
             break;
         case ClientType.TEST:
             console.log('switching test client');
@@ -71,13 +71,13 @@ io.sockets.on('connection', function (client) {
 
 });
 
-function asRoomsWithSockets() {
+function asRoomsWithSocketIds() {
     var roomNames = Object.keys(io.sockets.adapter.rooms);
     var roomsWithSockets = {};
 
     for(var i = 0; i < roomNames.length; i++) {
         var room = io.sockets.adapter.rooms[roomNames[i]];
-        roomsWithSockets[roomNames[i]] = room.sockets;
+        roomsWithSockets[roomNames[i]] = Object.keys(room.sockets);
     }
 
     return roomsWithSockets;

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -18,12 +18,25 @@ io.use(function(client, next){
         case ClientType.BOT:
             return next();
         case ClientType.HUMAN:
+            console.log(rawRoom);
             var roomRoster = io.sockets.adapter.rooms[rawRoom];
-            if(roomRoster != undefined && roomRoster.length == 1) {
-                return next();
-            } else {
-                return next(new Error('No bots available'));
+            console.log(io.sockets.adapter.rooms);
+
+            if(roomRoster != undefined) {
+                for (socketId in roomRoster.sockets) {
+                    console.log("botRooms: ", io.sockets.connected[socketId].rooms);
+                    console.log("botRoom: ", io.sockets.adapter.rooms[socketId]);
+
+                    var botsRoom = io.sockets.adapter.rooms[socketId];
+                    if(botsRoom.length != undefined && botsRoom.length == 1) { // Doesn't contain a human.
+                        client.handshake.query.room = socketId; // Replace the room with the bot socket id.
+                        console.log("query: ", client.handshake.query);
+                        return next();
+                    }
+                }
             }
+
+            return next(new Error('No bots available'));
         default:
             return next(new Error('Unrecognised clientType: ' + rawClientType));
 

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -4,8 +4,6 @@ var LoggingClient = require("./loggingClient.js");
 var BotLocator = require("./botLocator.js");
 
 var room = "London";
-var humans = [];
-var bots = [];
 var testClient = new LoggingClient();
 var botLocator = new BotLocator(io.sockets.adapter.rooms);
 
@@ -43,12 +41,10 @@ io.sockets.on('connection', function (client) {
 
     switch(clientType) {
         case ClientType.HUMAN:
-            humans.push(client.id);
             client.join(roomName);
             testClient.emit('connected_human', humans);
             break;
         case ClientType.BOT:
-            bots.push(client.id);
             client.join(roomName);
             testClient.emit('connected_bot', asRoomsWithSocketIds());
             break;
@@ -63,8 +59,6 @@ io.sockets.on('connection', function (client) {
 
 
     client.on('disconnect', function() {
-        humans.splice(humans.indexOf(client.id), 1);
-        bots.splice(bots.indexOf(client.id), 1);
         testClient.emit('disconnected_human', asRoomsWithSocketIds());
         testClient.emit('disconnected_bot', asRoomsWithSocketIds());
     });

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -50,9 +50,7 @@ io.sockets.on('connection', function (client) {
         case ClientType.BOT:
             bots.push(client.id);
             client.join(roomName);
-
-            console.log("socketListInLondon: ", asSocketListFrom(roomName));
-            testClient.emit('connected_bot', asSocketListFrom(roomName));
+            testClient.emit('connected_bot', asRoomsWithSockets());
             break;
         case ClientType.TEST:
             console.log('switching test client');
@@ -73,12 +71,14 @@ io.sockets.on('connection', function (client) {
 
 });
 
-function asSocketListFrom(roomName) {
-    var room = io.sockets.adapter.rooms[roomName];
+function asRoomsWithSockets() {
+    var roomNames = Object.keys(io.sockets.adapter.rooms);
+    var roomsWithSockets = {};
 
-    if(room == undefined) {
-        return [];
+    for(var i = 0; i < roomNames.length; i++) {
+        var room = io.sockets.adapter.rooms[roomNames[i]];
+        roomsWithSockets[roomNames[i]] = room.sockets;
     }
 
-    return Object.keys(room.sockets);
+    return roomsWithSockets;
 }

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -3,7 +3,6 @@ var ClientType = require("./clientType.js");
 var LoggingClient = require("./loggingClient.js");
 var BotLocator = require("./botLocator.js");
 
-var room = "London";
 var testClient = new LoggingClient();
 var botLocator = new BotLocator(io.sockets.adapter.rooms);
 

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -61,19 +61,9 @@ io.sockets.on('connection', function (client) {
 
     // TODO: check this disconnect method, it is not removing the human.
     client.on('disconnect', function() {
-        switch(clientType) {
-            case ClientType.HUMAN:
-                testClient.emit('disconnected_human', asRoomsWithSocketIds());
-                break;
-            case ClientType.BOT:
-                disconnectRoom(client.id);
-                testClient.emit('disconnected_bot', asRoomsWithSocketIds());
-                break;
-            case ClientType.TEST:
-                break;
-            default:
-                throw 'Unexpected rawClientType: ' + clientType;
-        }
+        disconnectRoom(client.id);
+        testClient.emit('disconnected_human', asRoomsWithSocketIds());
+        testClient.emit('disconnected_bot', asRoomsWithSocketIds());
     });
 
     client.on('move_in', function(direction) {

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -42,7 +42,7 @@ io.sockets.on('connection', function (client) {
     switch(clientType) {
         case ClientType.HUMAN:
             client.join(roomName);
-            testClient.emit('connected_human', humans);
+            testClient.emit('connected_human', asRoomsWithSocketIds());
             break;
         case ClientType.BOT:
             client.join(roomName);

--- a/TelepresenceBot/server-unit/core/server.js
+++ b/TelepresenceBot/server-unit/core/server.js
@@ -59,7 +59,6 @@ io.sockets.on('connection', function (client) {
             throw 'Unexpected rawClientType: ' + clientType;
     }
 
-    // TODO: check this disconnect method, it is not removing the human.
     client.on('disconnect', function() {
         disconnectRoom(client.id);
         testClient.emit('disconnected_human', asRoomsWithSocketIds());
@@ -85,13 +84,6 @@ function disconnectRoom(name) {
             var connectedClient = io.sockets.connected[client];
             connectedClient.disconnect();
         }
-    }
-}
-
-function leaveAllRooms(client) {
-    var rooms = Object.keys(io.sockets.adapter.rooms[client.id]);
-    for(var i = 0; i < rooms.length; i++) {
-        client.leave(rooms[i]);
     }
 }
 

--- a/TelepresenceBot/server-unit/test/botLocatorTest.js
+++ b/TelepresenceBot/server-unit/test/botLocatorTest.js
@@ -1,0 +1,38 @@
+var should = require('should');
+var test = require('unit.js');
+var BotLocator = require("../core/botLocator.js");
+
+var rooms = {
+    'botId': {
+        sockets: {'botId':true},
+        length:1
+    },
+    'London': {
+        sockets: {'botId':true},
+        length:1
+    }
+};
+
+var botLocator = new BotLocator(rooms);
+
+describe("BotLocator ",function() {
+
+    it('Should give undefined when bot is not found in given room.', function(done){
+        var bot = botLocator.locateFirstAvailableBotIn("Unexpected Room");
+
+        test.value(bot)
+            .isUndefined();
+
+        done();
+    });
+
+    it('Should give bot id when bot is found in given room.', function(done){
+        var bot = botLocator.locateFirstAvailableBotIn("London");
+
+        test.string(bot)
+            .is("botId");
+
+        done();
+    });
+
+});

--- a/TelepresenceBot/server-unit/test/botLocatorTest.js
+++ b/TelepresenceBot/server-unit/test/botLocatorTest.js
@@ -2,7 +2,7 @@ var should = require('should');
 var test = require('unit.js');
 var BotLocator = require("../core/botLocator.js");
 
-var botWithNoOtherSocketsInRoom = {
+var roomWithASingleBot = {
     'botId': {
         sockets: {'botId':true},
         length:1
@@ -13,10 +13,36 @@ var botWithNoOtherSocketsInRoom = {
     }
 };
 
+var roomWhereBotIsConnectedToHuman = {
+    'botId': {
+        sockets: {'botId':true, 'humanId':true},
+        length:2
+    },
+    'London': {
+        sockets: {'botId':true},
+        length:1
+    }
+};
+
+var roomContainingMultipleBotsWhereOneIsConnectedToHuman = {
+    'botId01': {
+        sockets: {'botId01':true, 'human01':true},
+        length:2
+    },
+    'botId02': {
+        sockets: {'botId02':true},
+        length:1
+    },
+    'London': {
+        sockets: {'botId01':true, 'botId02':true},
+        length:2
+    }
+};
+
 describe("BotLocator ",function() {
 
     it('Should give undefined when bot is not found in given room.', function(done){
-        var botLocator = new BotLocator(botWithNoOtherSocketsInRoom);
+        var botLocator = new BotLocator(roomWithASingleBot);
 
         var bot = botLocator.locateFirstAvailableBotIn("Unexpected Room");
 
@@ -26,13 +52,35 @@ describe("BotLocator ",function() {
         done();
     });
 
-    it('Should give bot id when bot is found in given room.', function(done){
-        var botLocator = new BotLocator(botWithNoOtherSocketsInRoom);
+    it('Should give bot id when bot room does not contain other sockets.', function(done){
+        var botLocator = new BotLocator(roomWithASingleBot);
 
         var bot = botLocator.locateFirstAvailableBotIn("London");
 
         test.string(bot)
             .is("botId");
+
+        done();
+    });
+
+    it('Should give undefined when bot room contains other sockets.', function(done){
+        var botLocator = new BotLocator(roomWhereBotIsConnectedToHuman);
+
+        var bot = botLocator.locateFirstAvailableBotIn("London");
+
+        test.value(bot)
+            .isUndefined();
+
+        done();
+    });
+
+    it('Should give first bot in room that contains multiple bots.', function(done){
+        var botLocator = new BotLocator(roomContainingMultipleBotsWhereOneIsConnectedToHuman);
+
+        var bot = botLocator.locateFirstAvailableBotIn("London");
+
+        test.string(bot)
+            .is('botId02');
 
         done();
     });

--- a/TelepresenceBot/server-unit/test/botLocatorTest.js
+++ b/TelepresenceBot/server-unit/test/botLocatorTest.js
@@ -2,7 +2,7 @@ var should = require('should');
 var test = require('unit.js');
 var BotLocator = require("../core/botLocator.js");
 
-var rooms = {
+var botWithNoOtherSocketsInRoom = {
     'botId': {
         sockets: {'botId':true},
         length:1
@@ -13,11 +13,11 @@ var rooms = {
     }
 };
 
-var botLocator = new BotLocator(rooms);
-
 describe("BotLocator ",function() {
 
     it('Should give undefined when bot is not found in given room.', function(done){
+        var botLocator = new BotLocator(botWithNoOtherSocketsInRoom);
+
         var bot = botLocator.locateFirstAvailableBotIn("Unexpected Room");
 
         test.value(bot)
@@ -27,6 +27,8 @@ describe("BotLocator ",function() {
     });
 
     it('Should give bot id when bot is found in given room.', function(done){
+        var botLocator = new BotLocator(botWithNoOtherSocketsInRoom);
+
         var bot = botLocator.locateFirstAvailableBotIn("London");
 
         test.string(bot)

--- a/TelepresenceBot/server-unit/test/botTest.js
+++ b/TelepresenceBot/server-unit/test/botTest.js
@@ -18,6 +18,24 @@ var testOptions ={
 
 describe("TelepresenceBot Server: BotTest ",function() {
 
+    it('Should add bot to Room:London on connection.', function(done) {
+        var testObserver = io.connect(socketURL, testOptions);
+
+        testObserver.on('connected', function(){
+            var bot = io.connect(socketURL, options);
+
+            testObserver.on('connected_bot', function(actualConnectedBots){
+                var expectedConnectedBots = [bot.id];
+                test.array(actualConnectedBots)
+                    .is(expectedConnectedBots);
+
+                bot.disconnect();
+                testObserver.disconnect();
+                done();
+            });
+        });
+    });
+
     it('Should add bot to list of bots on connection.', function(done) {
         var testObserver = io.connect(socketURL, testOptions);
 

--- a/TelepresenceBot/server-unit/test/botTest.js
+++ b/TelepresenceBot/server-unit/test/botTest.js
@@ -66,6 +66,32 @@ describe("TelepresenceBot Server: BotTest ",function() {
         });
     });
 
+    it('Should disconnect human on bot disconnection.', function(done) {
+        var testObserver = io.connect(socketURL, testOptions);
+
+        testObserver.on('connected', function(){
+            var bot = io.connect(socketURL, options);
+
+            testObserver.on('connected_bot', function(){
+                var human = io.connect(socketURL, humanOptions);
+
+                testObserver.on('connected_human', function(){
+                    bot.disconnect();
+
+                    testObserver.on('disconnected_human', function(roomsWithSockets){
+                        var actualSockets = roomsWithSockets[bot.id];
+
+                        test.value(actualSockets)
+                            .isUndefined();
+
+                        testObserver.disconnect();
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
     it('Should forward movement directions from human to bot.', function(done) {
         var testObserver = io.connect(socketURL, testOptions);
 

--- a/TelepresenceBot/server-unit/test/botTest.js
+++ b/TelepresenceBot/server-unit/test/botTest.js
@@ -7,7 +7,7 @@ var socketURL = 'http://0.0.0.0:5000'
 var options ={
     transports: ['websocket'],
     'force new connection': true,
-    query: 'clientType=bot'
+    query: 'clientType=bot&room=London'
 };
 
 var testOptions ={

--- a/TelepresenceBot/server-unit/test/botTest.js
+++ b/TelepresenceBot/server-unit/test/botTest.js
@@ -13,7 +13,7 @@ var options ={
 var humanOptions ={
     transports: ['websocket'],
     'force new connection': true,
-    query: 'clientType=human'
+    query: 'clientType=human&room=London'
 };
 
 var testOptions ={
@@ -44,7 +44,7 @@ describe("TelepresenceBot Server: BotTest ",function() {
         });
     });
 
-    it('Should remove bot from list of bots on disconnection.', function(done) {
+    it('Should remove bot from Room:London on disconnection.', function(done) {
         var testObserver = io.connect(socketURL, testOptions);
 
         testObserver.on('connected', function(){

--- a/TelepresenceBot/server-unit/test/botTest.js
+++ b/TelepresenceBot/server-unit/test/botTest.js
@@ -24,28 +24,12 @@ describe("TelepresenceBot Server: BotTest ",function() {
         testObserver.on('connected', function(){
             var bot = io.connect(socketURL, options);
 
-            testObserver.on('connected_bot', function(actualConnectedBots){
-                var expectedConnectedBots = [bot.id];
-                test.array(actualConnectedBots)
-                    .is(expectedConnectedBots);
+            testObserver.on('connected_bot', function(roomsWithSockets){
+                var expectedSockets = [bot.id];
+                var actualSockets = roomsWithSockets["London"];
 
-                bot.disconnect();
-                testObserver.disconnect();
-                done();
-            });
-        });
-    });
-
-    it('Should add bot to list of bots on connection.', function(done) {
-        var testObserver = io.connect(socketURL, testOptions);
-
-        testObserver.on('connected', function(){
-            var bot = io.connect(socketURL, options);
-
-            testObserver.on('connected_bot', function(actualConnectedBots){
-                var expectedConnectedBots = [bot.id];
-                test.array(actualConnectedBots)
-                    .is(expectedConnectedBots);
+                test.array(actualSockets)
+                    .is(expectedSockets);
 
                 bot.disconnect();
                 testObserver.disconnect();
@@ -63,9 +47,11 @@ describe("TelepresenceBot Server: BotTest ",function() {
             testObserver.on('connected_bot', function(){
                 bot.disconnect();
 
-                testObserver.on('disconnected_bot', function(actualConnectedBots) {
-                    test.array(actualConnectedBots)
-                    .isEmpty();
+                testObserver.on('disconnected_bot', function(roomsWithSockets) {
+                    var actualSockets = roomsWithSockets["London"];
+
+                    test.value(actualSockets)
+                        .isUndefined();
 
                     testObserver.disconnect();
                     done();

--- a/TelepresenceBot/server-unit/test/humanTest.js
+++ b/TelepresenceBot/server-unit/test/humanTest.js
@@ -7,13 +7,13 @@ var socketURL = 'http://0.0.0.0:5000'
 var options ={
     transports: ['websocket'],
     'force new connection': true,
-    query: 'clientType=human'
+    query: 'clientType=human&room=London'
 };
 
 var botOptions ={
     transports: ['websocket'],
     'force new connection': true,
-    query: 'clientType=bot'
+    query: 'clientType=bot&room=London'
 };
 
 var testOptions ={

--- a/TelepresenceBot/server-unit/test/humanTest.js
+++ b/TelepresenceBot/server-unit/test/humanTest.js
@@ -54,7 +54,7 @@ describe("TelepresenceBot Server: HumanTest ",function() {
         });
     });
 
-    it('Should add human to list of humans on connection.', function(done) {
+    it('Should add human to first available bots room.', function(done) {
         var testObserver = io.connect(socketURL, testOptions);
 
         testObserver.on('connect', function(){
@@ -63,10 +63,12 @@ describe("TelepresenceBot Server: HumanTest ",function() {
             testObserver.on('connected_bot', function(){
                 var human = io.connect(socketURL, options);
 
-                testObserver.on('connected_human', function(actualConnectedHumans){
-                    var expectedConnectedHumans = [human.id];
-                    test.array(actualConnectedHumans)
-                        .is(expectedConnectedHumans);
+                testObserver.on('connected_human', function(roomsWithSockets){
+                    var expectedSockets = [bot.id, human.id];
+                    var actualSockets = roomsWithSockets[bot.id];
+
+                    test.array(actualSockets)
+                        .is(expectedSockets);
 
                     human.disconnect();
                     bot.disconnect();
@@ -77,7 +79,7 @@ describe("TelepresenceBot Server: HumanTest ",function() {
         });
     });
 
-    it('Should remove human from list of humans on disconnection.', function(done) {
+    it('Should remove human from bots room.', function(done) {
         var testObserver = io.connect(socketURL, testOptions);
 
         testObserver.on('connect', function(){
@@ -89,9 +91,12 @@ describe("TelepresenceBot Server: HumanTest ",function() {
                 testObserver.on('connected_human', function(){
                     human.disconnect();
 
-                    testObserver.on('disconnected_human', function(actualConnectedHumans){
-                        test.array(actualConnectedHumans)
-                            .isEmpty();
+                    testObserver.on('disconnected_human', function(roomsWithSockets){
+                        var expectedSockets = [bot.id];
+                        var actualSockets = roomsWithSockets[bot.id];
+
+                        test.array(actualSockets)
+                            .is(expectedSockets);
 
                         bot.disconnect();
                         testObserver.disconnect();


### PR DESCRIPTION
#### Problem
Currently, the `server` only allows a single `bot` and `human` to connect to the sole `London` room. Ideally, we should pass the room in via the request query and have that `human` / `bot` join that room.

#### Solution
Move the decision of rooms to the `android app` and pass which room to join via the request query.

##### When connecting 
For Bots, they immediately join whichever room is passed in through the `query`, at the moment this will be `London`.

For Humans, pull all `sockets` located in the room passed through in `query`. Take all of the rooms that each socket belongs to, should be `London` and `socket.id` rooms. If the `socket.id` room for a socket is empty then that `socket` is not connected to another client and is our available bot. Before allowing the `human` to connect we modify the `query` sent to change the room from `London` to the `availableBotSocket.id`. On connection, the `human` is connected directly to the `bot` via the `bots` own room.

##### When disconnecting
For Bots, we disconnect all other sockets that are in the `botSocket.id` room, disconnecting all humans.

For Humans, we disconnect only the `human` socket and leave all bots in limbo, awaiting a new `human` connection.

#### Screen Capture
UI has not changed but you can now add multiple bots to a given room.

#### Future Plans
I would like to remove the `Room` from the app entirely and instead serve it to the app through a call when first opening the app. 
