### PR TITLE
Adds basic scripts for code coupling in iOS

### DIFF
--- a/code-review-tools/README.md
+++ b/code-review-tools/README.md
@@ -1,0 +1,3 @@
+# Code review tools
+
+This aims to serve as a repository for any tools and artifacts that are useful for reviewing code and analysing its effectiveness. Many are simple bash scripts to be run against a repository

--- a/code-review-tools/README.md
+++ b/code-review-tools/README.md
@@ -1,3 +1,19 @@
 # Code review tools
 
-This aims to serve as a repository for any tools and artifacts that are useful for reviewing code and analysing its effectiveness. Many are simple bash scripts to be run against a repository
+This aims to serve as a repository for any tools and artifacts that are useful for reviewing code and analysing its effectiveness.
+
+## Android
+
+No tools currently available.
+
+## iOS
+
+- `uikit` (bash script) measures the number of files which import UIKit. This can be used as a (rough) indication that code is improperly coupled to UI libraries.
+- `lines` (bash script) simply gives the number of lines per file. This can then be used to plot a histogram. The point of this is to quickly visualise large files and begin discussions around making them smaller. See an example histogram [here](https://docs.google.com/spreadsheets/d/1m-wIygVxOLJ2KciEokNgpOHeVgIcrM5FwXkoSB-rAyI/pubchart?oid=1766467159&format=interactive)
+- `imports` (bash script) records the number of import statements per file. This can also be used to plot a histogram, and indicates code which is too tightly coupled to other code. See an example histogram [here](https://docs.google.com/spreadsheets/d/1m-wIygVxOLJ2KciEokNgpOHeVgIcrM5FwXkoSB-rAyI/pubchart?oid=472356679&format=interactive)
+
+There are limitations to these scripts will would be addressed if we feel these are viable and useful:
+- `uikit` and `imports` do not walk the tree of their dependencies. Therefore, if class A imports header B, and header B has an import of header C, it won't record that class A also implicitly imports C. This would also solve implicit imports in `.m` file from their `.h`
+- there is no mechanism to include and exclude directories. Currently, `Pods/` is ignored but it would be nice to enable more customisations
+- currently these are simple bash scripts. Perhaps it would be nice to make them more interactive or use a better scripting environment e.g. Gradle, with unified configuration options and entry points.
+

--- a/code-review-tools/README.md
+++ b/code-review-tools/README.md
@@ -12,8 +12,11 @@ No tools currently available.
 - `lines` (bash script) simply gives the number of lines per file. This can then be used to plot a histogram. The point of this is to quickly visualise large files and begin discussions around making them smaller. See an example histogram [here](https://docs.google.com/spreadsheets/d/1m-wIygVxOLJ2KciEokNgpOHeVgIcrM5FwXkoSB-rAyI/pubchart?oid=1766467159&format=interactive)
 - `imports` (bash script) records the number of import statements per file. This can also be used to plot a histogram, and indicates code which is too tightly coupled to other code. See an example histogram [here](https://docs.google.com/spreadsheets/d/1m-wIygVxOLJ2KciEokNgpOHeVgIcrM5FwXkoSB-rAyI/pubchart?oid=472356679&format=interactive)
 
+## Current limitations
+
 There are limitations to these scripts will would be addressed if we feel these are viable and useful:
 - `uikit` and `imports` do not walk the tree of their dependencies. Therefore, if class A imports header B, and header B has an import of header C, it won't record that class A also implicitly imports C. This would also solve implicit imports in `.m` file from their `.h`
+- `lines` and `imports` could easily be modified to handle Java, JS, or Kotlin as appropriate.
 - there is no mechanism to include and exclude directories. Currently, `Pods/` is ignored but it would be nice to enable more customisations
 - currently these are simple bash scripts. Perhaps it would be nice to make them more interactive or use a better scripting environment e.g. Gradle, with unified configuration options and entry points.
 

--- a/code-review-tools/ios/imports
+++ b/code-review-tools/ios/imports
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+printf "Imports in header files: \n"
+fgrep -e "#import" --include '*.h' --exclude './Pods/*' -rc . | grep -v ':0$'
+
+printf "Imports in implementation files: \n"
+fgrep -e "#import" --include '*.m' --exclude './Pods/*' -rc . | grep -v ':0$'
+
+printf "Module imports in Swift files: \n"
+fgrep -e "import " --include '*.swift' --exclude './Pods/*' -rc . | grep -v ':0$'

--- a/code-review-tools/ios/lines
+++ b/code-review-tools/ios/lines
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+find . -path ./Pods -prune -o -name "*\.m" -exec wc -l {} +
+
+TOTAL=$(find . -path ./Pods -prune -o -name "*\.m" | wc -l)
+printf "Total number of *.m files: %s \n" $TOTAL
+
+find . -path ./Pods -prune -o -name "*\.swift" -exec wc -l {} +
+
+SWIFT_TOTAL=$(find . -path ./Pods -prune -o -name "*\.swift" | wc -l)
+printf "Total number of Swift files: %s \n" $SWIFT_TOTAL

--- a/code-review-tools/ios/uikit
+++ b/code-review-tools/ios/uikit
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+printf "Swift files importing UIKit:           "
+SWIFT=$(fgrep -e "import UIKit" --include '*.swift' --exclude './Pods/*' -rl . | wc -l)
+SWIFT_TOTAL=$(find . -path ./Pods -prune -o -name "*\.swift" -print | wc -l)
+printf "%d / %d" $SWIFT $SWIFT_TOTAL
+printf "\n"
+
+printf "Header files importing UIKit:          "
+HEADER=$(fgrep -e "#import <UIKit/UIKit.h>" --include '*.h' --exclude './Pods/*' -rl . | wc -l)
+HEADER_TOTAL=$(find . -path ./Pods -prune -o -name "*\.h" -print | wc -l)
+printf "%s / %s" $HEADER $HEADER_TOTAL
+printf "\n"
+
+printf "Implementation files importing UIKit:  "
+IMPL=$(fgrep -e "#import <UIKit/UIKit.h>" --include '*.m' --exclude './Pods/*' -rl . | wc -l)
+IMPL_TOTAL=$(find . -path ./Pods -prune -o -name "*\.m" -print | wc -l)
+printf "%s / %s" $IMPL $IMPL_TOTAL
+printf "\n"


### PR DESCRIPTION
## This PR adds

A few scripts I used whilst evaluating clients' iOS codebases centering around code coupling.

## Considerations and implementation

Three scripts are added:
- `uikit` measures the number of files which import UIKit. This can be used as a (rough) indication that code is improperly coupled to UI libraries.
- `lines` simply gives the number of lines per file. This can then be used to plot a histogram. The point of this is to quickly visualise large files and begin discussions around making them smaller. See an example histogram [here](https://docs.google.com/spreadsheets/d/1m-wIygVxOLJ2KciEokNgpOHeVgIcrM5FwXkoSB-rAyI/pubchart?oid=1766467159&format=interactive)
- `imports` records the number of import statements per file. This can also be used to plot a histogram, and indicates code which is too tightly coupled to other code. See an example histogram [here](https://docs.google.com/spreadsheets/d/1m-wIygVxOLJ2KciEokNgpOHeVgIcrM5FwXkoSB-rAyI/pubchart?oid=472356679&format=interactive)

There are limitations to these files will would be addressed if we feel these are viable:
- `uikit` and `imports` do not walk the tree of their dependencies. Therefore, if class A imports header B, and header B has an import of UIKit, it won't record that class A also implicitly imports UIKit. 
- there is no mechanism to include and exclude directories. Currently, `Pods/` is ignored but it would be nice to enable more customisations

### Test(s) added 

No, this is bash. Should this go further I would consider migrating it to another platform and adding tests there

### Screenshots

![image 1](https://cloud.githubusercontent.com/assets/666285/24241121/191b51aa-0fb4-11e7-8380-91036ee3420d.png)
![image 2](https://cloud.githubusercontent.com/assets/666285/24241120/191ade46-0fb4-11e7-9690-1cd5bb8859df.png)

If you are a novoda employee, you can see the raw data [here](https://docs.google.com/a/novoda.com/spreadsheets/d/1m-wIygVxOLJ2KciEokNgpOHeVgIcrM5FwXkoSB-rAyI/edit?usp=sharing)

### Paired with 

@ no-one
