### PR TITLE
Tpbot/ Web Client

### DIFF
--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -12,10 +12,10 @@
 
 <ul id="messages"></ul>
 <div id="controller">
-    <input id="w" type="button" class="button" value="w" onclick="sendMessage('w')">
-    <input id="a" type="button" class="button" value="a" onclick="sendMessage('a')">
-    <input id="s" type="button" class="button" value="s" onclick="sendMessage('s')">
-    <input id="d" type="button" class="button" value="d" onclick="sendMessage('d')">
+    <input id="w" type="button" class="button" value="w" onmousedown="onMouseDown()">
+    <input id="a" type="button" class="button" value="a" onmousedown="onMouseDown()" onmouseup="onMouseUp()">
+    <input id="s" type="button" class="button" value="s" onmousedown="onMouseDown()" onmouseup="onMouseUp()">
+    <input id="d" type="button" class="button" value="d" onmousedown="onMouseDown()" onmouseup="onMouseUp()">
 </div>
 </body>
 </html>

--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -12,18 +12,8 @@
     <input id="s" type="button" class="button" value="s">
     <input id="d" type="button" class="button" value="d">
 </div>
-<script src="/socket.io/socket.io.js"></script>
-<script src="https://code.jquery.com/jquery-1.11.1.js"></script>
-<script>
-  $(function () {
-    var socket = io();
-    $('form').submit(function(){
-      socket.emit('chat message', $('#m').val());
-      $('#m').val('');
-      return false;
-    });
-  });
-</script>
-</script
+<script type="text/javascript" src="/socket.io/socket.io.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.1.js"></script>
+<script type="text/javascript" src="js\connect.js"></script>
 </body>
 </html>

--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -12,10 +12,10 @@
 
 <ul id="messages"></ul>
 <div id="controller">
-    <input id="w" type="button" class="button" value="w" onmousedown="onMouseDown()">
-    <input id="a" type="button" class="button" value="a" onmousedown="onMouseDown()" onmouseup="onMouseUp()">
-    <input id="s" type="button" class="button" value="s" onmousedown="onMouseDown()" onmouseup="onMouseUp()">
-    <input id="d" type="button" class="button" value="d" onmousedown="onMouseDown()" onmouseup="onMouseUp()">
+    <input id="w" type="button" class="button" value="w">
+    <input id="a" type="button" class="button" value="a">
+    <input id="s" type="button" class="button" value="s">
+    <input id="d" type="button" class="button" value="d">
 </div>
 </body>
 </html>

--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -6,10 +6,12 @@
 </head>
 <body>
 <ul id="messages"></ul>
-<form action="">
-    <input id="m" autocomplete="off"/>
-    <button>Send</button>
-</form>
+<div id="controller">
+    <input id="w" type="button" class="button" value="w">
+    <input id="a" type="button" class="button" value="a">
+    <input id="s" type="button" class="button" value="s">
+    <input id="d" type="button" class="button" value="d">
+</div>
 <script src="/socket.io/socket.io.js"></script>
 <script src="https://code.jquery.com/jquery-1.11.1.js"></script>
 <script>

--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -1,25 +1,37 @@
 <!doctype html>
-<html lang="en">
+<html>
 <head>
+    <title>Socket.IO chat</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { font: 13px Helvetica, Arial; }
+      form { background: #000; padding: 3px; position: fixed; bottom: 0; width: 100%; }
+      form input { border: 0; padding: 10px; width: 90%; margin-right: .5%; }
+      form button { width: 9%; background: rgb(130, 224, 255); border: none; padding: 10px; }
+      #messages { list-style-type: none; margin: 0; padding: 0; }
+      #messages li { padding: 5px 10px; }
+      #messages li:nth-child(odd) { background: #eee; }
 
+    </style>
 </head>
 <body>
-<h1>Hello World!</h1>
-<div id="future"></div>
-<form id="form" id="chat_form">
-    <input id="chat_input" type="text">
-    <input type="submit" value="Send">
+<ul id="messages"></ul>
+<form action="">
+    <input id="m" autocomplete="off"/>
+    <button>Send</button>
 </form>
-<script src="https://code.jquery.com/jquery-1.10.2.js"></script>
 <script src="/socket.io/socket.io.js"></script>
+<script src="https://code.jquery.com/jquery-1.11.1.js"></script>
 <script>
-    var socket = io.connect('http://localhost:4200');
-    socket.on('connect', function(data) {
-        socket.emit('join', 'Hello World from client');
+  $(function () {
+    var socket = io();
+    $('form').submit(function(){
+      socket.emit('chat message', $('#m').val());
+      $('#m').val('');
+      return false;
     });
-    socket.on('messages', function(data) {
-                alert(data);
-    });
+  });
 </script>
+</script
 </body>
 </html>

--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -1,19 +1,21 @@
 <!doctype html>
-<html>
+<html xmlns="http://www.w3.org/1999/html">
 <head>
     <title>Socket.IO chat</title>
-    <link rel="stylesheet" type="text/css" href="css/index.css">
+    <link rel="stylesheet" type="text/css" href="/css/index.css">
 </head>
 <body>
-<ul id="messages"></ul>
-<div id="controller">
-    <input id="w" type="button" class="button" value="w">
-    <input id="a" type="button" class="button" value="a">
-    <input id="s" type="button" class="button" value="s">
-    <input id="d" type="button" class="button" value="d">
-</div>
+
 <script type="text/javascript" src="/socket.io/socket.io.js"></script>
 <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.1.js"></script>
-<script type="text/javascript" src="js\connect.js"></script>
+<script type="text/javascript" src="/js/connect.js"></script>
+
+<ul id="messages"></ul>
+<div id="controller">
+    <input id="w" type="button" class="button" value="w" onclick="sendMessage('w')">
+    <input id="a" type="button" class="button" value="a" onclick="sendMessage('a')">
+    <input id="s" type="button" class="button" value="s" onclick="sendMessage('s')">
+    <input id="d" type="button" class="button" value="d" onclick="sendMessage('d')">
+</div>
 </body>
 </html>

--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+
+</head>
+<body>
+<h1>Hello World!</h1>
+<div id="future"></div>
+<form id="form" id="chat_form">
+    <input id="chat_input" type="text">
+    <input type="submit" value="Send">
+</form>
+<script src="https://code.jquery.com/jquery-1.10.2.js"></script>
+<script src="/socket.io/socket.io.js"></script>
+<script>
+    var socket = io.connect('http://localhost:4200');
+    socket.on('connect', function(data) {
+        socket.emit('join', 'Hello World from client');
+    });
+    socket.on('messages', function(data) {
+                alert(data);
+    });
+</script>
+</body>
+</html>

--- a/TelepresenceBot/server-unit/core/html/index.html
+++ b/TelepresenceBot/server-unit/core/html/index.html
@@ -2,17 +2,7 @@
 <html>
 <head>
     <title>Socket.IO chat</title>
-    <style>
-      * { margin: 0; padding: 0; box-sizing: border-box; }
-      body { font: 13px Helvetica, Arial; }
-      form { background: #000; padding: 3px; position: fixed; bottom: 0; width: 100%; }
-      form input { border: 0; padding: 10px; width: 90%; margin-right: .5%; }
-      form button { width: 9%; background: rgb(130, 224, 255); border: none; padding: 10px; }
-      #messages { list-style-type: none; margin: 0; padding: 0; }
-      #messages li { padding: 5px 10px; }
-      #messages li:nth-child(odd) { background: #eee; }
-
-    </style>
+    <link rel="stylesheet" type="text/css" href="css/index.css">
 </head>
 <body>
 <ul id="messages"></ul>

--- a/TelepresenceBot/server-unit/core/json/rooms.json
+++ b/TelepresenceBot/server-unit/core/json/rooms.json
@@ -1,0 +1,6 @@
+{
+  "rooms": [
+    "London",
+    "Berlin"
+  ]
+}

--- a/TelepresenceBot/server-unit/core/public/css/index.css
+++ b/TelepresenceBot/server-unit/core/public/css/index.css
@@ -56,6 +56,9 @@ body {
     margin: 0;
     padding: 0;
     height:50vh;
+    overflow:hidden;
+    overflow-y:scroll;
+    border-bottom: solid;
 }
 
 #messages li {

--- a/TelepresenceBot/server-unit/core/public/css/index.css
+++ b/TelepresenceBot/server-unit/core/public/css/index.css
@@ -1,0 +1,46 @@
+@charset "utf-8";
+
+* {
+    margin: 0; padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font: 13px Helvetica, Arial;
+}
+
+form {
+    background: #000;
+    padding: 3px;
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+}
+
+form input {
+    border: 0;
+    padding: 10px;
+    width: 90%;
+    margin-right: .5%;
+}
+
+form button {
+    width: 9%;
+    background: rgb(130, 224, 255);
+    border: none;
+    padding: 10px;
+}
+
+#messages {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
+#messages li {
+    padding: 5px 10px;
+}
+
+#messages li:nth-child(odd) {
+    background: #eee;
+}

--- a/TelepresenceBot/server-unit/core/public/css/index.css
+++ b/TelepresenceBot/server-unit/core/public/css/index.css
@@ -9,32 +9,53 @@ body {
     font: 13px Helvetica, Arial;
 }
 
-form {
-    background: #000;
-    padding: 3px;
-    position: fixed;
-    bottom: 0;
-    width: 100%;
+#controller {
+    height:50vh;
 }
 
-form input {
-    border: 0;
-    padding: 10px;
-    width: 90%;
-    margin-right: .5%;
-}
-
-form button {
-    width: 9%;
-    background: rgb(130, 224, 255);
+.button {
+    height:50px;
+    width:100px;
+    margin: -20px -50px;
+    background-color: #4CAF50;
     border: none;
-    padding: 10px;
+    color: white;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+}
+
+#w {
+    position:relative;
+    top:25%;
+    left:50%;
+}
+
+#s {
+    position:relative;
+    top:75%;
+    left:50%;
+}
+
+#a {
+    position:relative;
+    top:50%;
+    left:40%;
+}
+
+#d {
+    position:relative;
+    top:50%;
+    left:60%;
 }
 
 #messages {
     list-style-type: none;
     margin: 0;
     padding: 0;
+    height:50vh;
 }
 
 #messages li {

--- a/TelepresenceBot/server-unit/core/public/js/connect.js
+++ b/TelepresenceBot/server-unit/core/public/js/connect.js
@@ -1,4 +1,19 @@
+var intervalId;
+
+$('body').mousedown(function(event) {
+    console.log("mouseDown");
+    var message = $("input[type=button]").val();
+    intervalId = setInterval(function(){
+        sendMessage(message);
+    }, 500);
+});
+
 function sendMessage(message) {
     var socket = io();
     socket.emit('chat message', message);
 }
+
+$('body').mouseup(function(event) {
+    console.log("mouseUp");
+    clearInterval(intervalId);
+});

--- a/TelepresenceBot/server-unit/core/public/js/connect.js
+++ b/TelepresenceBot/server-unit/core/public/js/connect.js
@@ -7,7 +7,7 @@ $(document).ready(function(){
         var message = $(this).val();
         intervalId = setInterval(function() {
             sendMessage(message);
-        }, 500);
+        }, 100);
     });
 
     function sendMessage(message) {

--- a/TelepresenceBot/server-unit/core/public/js/connect.js
+++ b/TelepresenceBot/server-unit/core/public/js/connect.js
@@ -1,10 +1,5 @@
 var intervalId;
 
-function sendMessage(message) {
-    var socket = io();
-    socket.emit('chat message', message);
-}
-
 $(document).ready(function(){
 
     $("input").mousedown(function(){
@@ -14,6 +9,12 @@ $(document).ready(function(){
             sendMessage(message);
         }, 500);
     });
+
+    function sendMessage(message) {
+        var socket = io();
+        socket.emit('chat message', message);
+        $('#messages').append($('<li>').text(message));
+    }
 
     $("input").mouseup(function(){
         console.log("mouseUp");

--- a/TelepresenceBot/server-unit/core/public/js/connect.js
+++ b/TelepresenceBot/server-unit/core/public/js/connect.js
@@ -1,0 +1,8 @@
+$(function () {
+    var socket = io();
+    $('form').submit(function(){
+        socket.emit('chat message', $('#m').val());
+        $('#m').val('');
+        return false;
+    });
+});

--- a/TelepresenceBot/server-unit/core/public/js/connect.js
+++ b/TelepresenceBot/server-unit/core/public/js/connect.js
@@ -1,8 +1,4 @@
-$(function () {
+function sendMessage(message) {
     var socket = io();
-    $('form').submit(function(){
-        socket.emit('chat message', $('#m').val());
-        $('#m').val('');
-        return false;
-    });
-});
+    socket.emit('chat message', message);
+}

--- a/TelepresenceBot/server-unit/core/public/js/connect.js
+++ b/TelepresenceBot/server-unit/core/public/js/connect.js
@@ -1,19 +1,23 @@
 var intervalId;
 
-$('body').mousedown(function(event) {
-    console.log("mouseDown");
-    var message = $("input[type=button]").val();
-    intervalId = setInterval(function(){
-        sendMessage(message);
-    }, 500);
-});
-
 function sendMessage(message) {
     var socket = io();
     socket.emit('chat message', message);
 }
 
-$('body').mouseup(function(event) {
-    console.log("mouseUp");
-    clearInterval(intervalId);
+$(document).ready(function(){
+
+    $("input").mousedown(function(){
+        console.log("mouseDown");
+        var message = $(this).val();
+        intervalId = setInterval(function() {
+            sendMessage(message);
+        }, 500);
+    });
+
+    $("input").mouseup(function(){
+        console.log("mouseUp");
+        clearInterval(intervalId);
+    });
+
 });

--- a/TelepresenceBot/server-unit/core/testServer.js
+++ b/TelepresenceBot/server-unit/core/testServer.js
@@ -1,5 +1,7 @@
 var express = require('express');
 var app = express();
+var http = require('http').Server(app);
+var io = require('socket.io')(http);
 
 var port = process.env.PORT || 8080;
 
@@ -9,10 +11,18 @@ router.get('/', function(req, res) {
     res.json({ message: 'Welcome to the TelepresenceBot api' });
 });
 
-router.route('/rooms')
-    .get(function(req, res) {
-        res.sendFile(__dirname + '/json/rooms.json');
-    });
+router.route('/rooms').get(function(req, res) {
+    res.sendFile(__dirname + '/json/rooms.json');
+});
+
+router.route('/connect').get(function(req, res) {
+    var socket = io.listen(http);
+    res.send("listening");
+});
+
+io.on('connection', function(socket){
+  console.log('a user connected');
+});
 
 app.use('/api', router);
 

--- a/TelepresenceBot/server-unit/core/testServer.js
+++ b/TelepresenceBot/server-unit/core/testServer.js
@@ -1,6 +1,5 @@
 var express = require('express');
 var app = express();
-var jsonFile = require('jsonfile')
 
 var port = process.env.PORT || 8080;
 
@@ -12,8 +11,7 @@ router.get('/', function(req, res) {
 
 router.route('/rooms')
     .get(function(req, res) {
-        var file = './json/rooms.json'
-        res.json(jsonFile.readFileSync(file));
+        res.sendFile(__dirname + '/json/rooms.json');
     });
 
 app.use('/api', router);

--- a/TelepresenceBot/server-unit/core/testServer.js
+++ b/TelepresenceBot/server-unit/core/testServer.js
@@ -27,8 +27,8 @@ io.sockets.on("connection", function (socket) {
         console.log('user disconnected');
     });
 
-    socket.on('chat message', function(msg){
-        console.log('message: ' + msg);
+    socket.on('chat message', function(message){
+        console.log('message: ', message);
     });
 
     socket.on("echo", function (msg, callback) {

--- a/TelepresenceBot/server-unit/core/testServer.js
+++ b/TelepresenceBot/server-unit/core/testServer.js
@@ -3,21 +3,33 @@ var app = express();
 var server = require('http').createServer(app);
 var io = require('socket.io')(server);
 
-app.get('/', function(req, res) {
-    res.json({ message: 'Welcome to the TelepresenceBot api' });
-});
-
 var server = server.listen(4200, function() {
     console.log("Express server listening on port " + 4200);
+});
+
+app.get('/', function(req, res) {
+    res.sendFile(__dirname + '/html/index.html');
 });
 
 io.set("log level", 0);
 
 io.sockets.on("connection", function (socket) {
+    console.log('a user connected');
+
+    socket.on('disconnect', function(){
+        console.log('user disconnected');
+    });
+
+    socket.on('chat message', function(msg){
+        console.log('message: ' + msg);
+    });
+
     socket.on("echo", function (msg, callback) {
         callback = callback || function () {};
 
         socket.emit("echo", msg);
+
+        console.log("on Connection");
 
         callback(null, "Done.");
     });

--- a/TelepresenceBot/server-unit/core/testServer.js
+++ b/TelepresenceBot/server-unit/core/testServer.js
@@ -1,30 +1,26 @@
 var express = require('express');
 var app = express();
-var http = require('http').Server(app);
-var io = require('socket.io')(http);
+var server = require('http').createServer(app);
+var io = require('socket.io')(server);
 
-var port = process.env.PORT || 8080;
-
-var router = express.Router();
-
-router.get('/', function(req, res) {
+app.get('/', function(req, res) {
     res.json({ message: 'Welcome to the TelepresenceBot api' });
 });
 
-router.route('/rooms').get(function(req, res) {
-    res.sendFile(__dirname + '/json/rooms.json');
+var server = server.listen(4200, function() {
+    console.log("Express server listening on port " + 4200);
 });
 
-router.route('/connect').get(function(req, res) {
-    var socket = io.listen(http);
-    res.send("listening");
+io.set("log level", 0);
+
+io.sockets.on("connection", function (socket) {
+    socket.on("echo", function (msg, callback) {
+        callback = callback || function () {};
+
+        socket.emit("echo", msg);
+
+        callback(null, "Done.");
+    });
 });
 
-io.on('connection', function(socket){
-  console.log('a user connected');
-});
-
-app.use('/api', router);
-
-app.listen(port);
-console.log('Starting server on ' + port);
+exports.server = server;

--- a/TelepresenceBot/server-unit/core/testServer.js
+++ b/TelepresenceBot/server-unit/core/testServer.js
@@ -2,13 +2,20 @@ var express = require('express');
 var app = express();
 var server = require('http').createServer(app);
 var io = require('socket.io')(server);
+var path = require('path')
 
 var server = server.listen(4200, function() {
     console.log("Express server listening on port " + 4200);
 });
 
+app.use(express.static(path.join(__dirname, 'public')));
+
 app.get('/', function(req, res) {
     res.sendFile(__dirname + '/html/index.html');
+});
+
+app.get('/rooms', function(req, res) {
+    res.sendFile(__dirname + '/json/rooms.json');
 });
 
 io.set("log level", 0);

--- a/TelepresenceBot/server-unit/core/testServer.js
+++ b/TelepresenceBot/server-unit/core/testServer.js
@@ -1,0 +1,22 @@
+var express = require('express');
+var app = express();
+var jsonFile = require('jsonfile')
+
+var port = process.env.PORT || 8080;
+
+var router = express.Router();
+
+router.get('/', function(req, res) {
+    res.json({ message: 'Welcome to the TelepresenceBot api' });
+});
+
+router.route('/rooms')
+    .get(function(req, res) {
+        var file = './json/rooms.json'
+        res.json(jsonFile.readFileSync(file));
+    });
+
+app.use('/api', router);
+
+app.listen(port);
+console.log('Starting server on ' + port);

--- a/TelepresenceBot/server-unit/package.json
+++ b/TelepresenceBot/server-unit/package.json
@@ -16,6 +16,7 @@
   "author": "Novoda",
   "license": "MIT",
   "dependencies": {
+    "chai": "^3.5.0",
     "express": "^4.15.2",
     "socket.io": "^1.7.3"
   },

--- a/TelepresenceBot/server-unit/package.json
+++ b/TelepresenceBot/server-unit/package.json
@@ -16,6 +16,8 @@
   "author": "Novoda",
   "license": "MIT",
   "dependencies": {
+    "express": "^4.15.2",
+    "jsonfile": "^2.4.0",
     "socket.io": "^1.7.3"
   },
   "devDependencies": {

--- a/TelepresenceBot/server-unit/package.json
+++ b/TelepresenceBot/server-unit/package.json
@@ -17,7 +17,6 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.15.2",
-    "jsonfile": "^2.4.0",
     "socket.io": "^1.7.3"
   },
   "devDependencies": {

--- a/TelepresenceBot/server-unit/package.json
+++ b/TelepresenceBot/server-unit/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "chai": "^3.5.0",
     "express": "^4.15.2",
+    "path": "^0.12.7",
     "socket.io": "^1.7.3"
   },
   "devDependencies": {

--- a/TelepresenceBot/server-unit/test/test.js
+++ b/TelepresenceBot/server-unit/test/test.js
@@ -1,0 +1,34 @@
+var chai = require('chai'),
+    mocha = require('mocha'),
+    should = chai.should();
+
+var io = require('socket.io-client');
+
+var server, options = {
+    transports: ['websocket'],
+    'force new connection': true
+};
+
+describe("echo", function () {
+
+    beforeEach(function (done) {
+        server = require('../core/testServer').server;
+        done();
+    });
+
+    it("echos message", function (done) {
+        var client = io.connect("http://localhost:4200", options);
+
+        client.once("connect", function () {
+            client.once("echo", function (message) {
+                message.should.equal("Hello World");
+
+                client.disconnect();
+                done();
+            });
+
+            client.emit("echo", "Hello World");
+        });
+    });
+
+});


### PR DESCRIPTION
#### Problem
The plan for the `MVP` is to open a hangout to connect to the `bot` and chat with people from another office. Well if we are opening a hangout perhaps we should also create a `webClient` so that the user does not need to have both a mobile device for moving the `bot` and another device for chatting?

#### Solution
Create a `webpage` from which the user can navigate the `bot`. This is just the beginning of the `webClient` creating a dummy controller that hands back to our `server` but does not pass any comments through `socketIO` yet. In a follow-up PR I will add hook up `socketIO` and fully test the `webClient` part. 

#### Screen Capture
![tpbot_html mov](https://cloud.githubusercontent.com/assets/3380092/24347762/5ace4a06-12d1-11e7-9417-881a8189ab5c.gif)

