### PR TITLE
TpBot/ Bot Automatically open a Hangout

### DIFF
--- a/TelepresenceBot/core/src/main/java/com/novoda/tpbot/bot/BotView.java
+++ b/TelepresenceBot/core/src/main/java/com/novoda/tpbot/bot/BotView.java
@@ -4,7 +4,7 @@ import com.novoda.tpbot.Direction;
 
 interface BotView {
 
-    void onConnect(String message);
+    void onConnect(String room);
 
     void onDisconnect();
 

--- a/TelepresenceBot/mobile/build.gradle
+++ b/TelepresenceBot/mobile/build.gradle
@@ -30,14 +30,16 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support.test:testing-support-lib:0.1'
+    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.novoda:notils-java:3.0.2'
     compile 'com.novoda:notils-android:3.0.2'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
-    compile 'com.android.support:support-annotations:25.0.1'
+    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile 'com.android.support:support-annotations:25.3.1'
     compile 'com.github.felHR85:UsbSerial:4.3'
     compile('io.socket:socket.io-client:0.8.2') {
         exclude group: 'org.json', module: 'json'
     }
+    compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
     compile project(path: ':core')
 }

--- a/TelepresenceBot/mobile/build.gradle
+++ b/TelepresenceBot/mobile/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.novoda.tpbot"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -30,7 +30,6 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support.test:testing-support-lib:0.1'
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.novoda:notils-java:3.0.2'
     compile 'com.novoda:notils-android:3.0.2'
@@ -40,6 +39,5 @@ dependencies {
     compile('io.socket:socket.io-client:0.8.2') {
         exclude group: 'org.json', module: 'json'
     }
-    compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
     compile project(path: ':core')
 }

--- a/TelepresenceBot/mobile/src/main/AndroidManifest.xml
+++ b/TelepresenceBot/mobile/src/main/AndroidManifest.xml
@@ -3,9 +3,6 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="com.novoda.tpbot">
 
-  <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18" />
-
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.INTERNET" />
 
   <uses-feature android:name="android.hardware.usb.host" />

--- a/TelepresenceBot/mobile/src/main/AndroidManifest.xml
+++ b/TelepresenceBot/mobile/src/main/AndroidManifest.xml
@@ -3,8 +3,10 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="com.novoda.tpbot">
 
-  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18" />
 
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.INTERNET" />
   <uses-feature android:name="android.hardware.usb.host" />
 
   <application

--- a/TelepresenceBot/mobile/src/main/AndroidManifest.xml
+++ b/TelepresenceBot/mobile/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.INTERNET" />
+
   <uses-feature android:name="android.hardware.usb.host" />
 
   <application
@@ -17,6 +18,16 @@
     android:supportsRtl="true"
     android:theme="@style/AppTheme"
     tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+
+    <service android:name="com.novoda.tpbot.automation.TelepresenceBotAccessibilityService"
+      android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+      <intent-filter>
+        <action android:name="android.accessibilityservice.AccessibilityService" />
+      </intent-filter>
+      <meta-data
+        android:name="android.accessibilityservice"
+        android:resource="@xml/accessibility_service_config" />
+    </service>
 
     <activity
       android:name="com.novoda.tpbot.landing.LandingActivity"

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
@@ -1,0 +1,19 @@
+package com.novoda.tpbot.automation;
+
+import android.accessibilityservice.AccessibilityService;
+import android.util.Log;
+import android.view.accessibility.AccessibilityEvent;
+
+public class TelepresenceBotAccessibilityService extends AccessibilityService {
+
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {
+        Log.e(TelepresenceBotAccessibilityService.class.getSimpleName(), event.toString());
+    }
+
+    @Override
+    public void onInterrupt() {
+        Log.e(TelepresenceBotAccessibilityService.class.getSimpleName(), "onInterrupt");
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
@@ -34,16 +34,16 @@ public class TelepresenceBotAccessibilityService extends AccessibilityService {
         }
     }
 
-    private boolean containsJoinButton(List<AccessibilityNodeInfo> accessibilityNodes) {
-        return accessibilityNodes.size() > 0;
-    }
-
     private boolean isHangouts(String packageName) {
         return packageName.equals(HANGOUTS_PACKAGE_NAME);
     }
 
     private boolean isWindowStateChangeEvent(int eventType) {
         return eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED;
+    }
+
+    private boolean containsJoinButton(List<AccessibilityNodeInfo> accessibilityNodes) {
+        return accessibilityNodes.size() > 0;
     }
 
     @Override

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
@@ -3,12 +3,39 @@ package com.novoda.tpbot.automation;
 import android.accessibilityservice.AccessibilityService;
 import android.util.Log;
 import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import java.util.List;
 
 public class TelepresenceBotAccessibilityService extends AccessibilityService {
 
+    private static final String HANGOUTS_PACKAGE_NAME = "com.google.android.talk";
+    private static final String JOIN_VIDEO_CALL = "JOIN VIDEO CALL";
+
     @Override
     public void onAccessibilityEvent(AccessibilityEvent event) {
-        Log.e(TelepresenceBotAccessibilityService.class.getSimpleName(), event.toString());
+        AccessibilityNodeInfo source = event.getSource();
+
+        if (source == null) {
+            return;
+        }
+
+        String packageName = String.valueOf(source.getPackageName());
+        int eventType = event.getEventType();
+
+        if (isHangouts(packageName) && isWindowStateChangeEvent(eventType)) {
+            List<AccessibilityNodeInfo> accessibilityNodes = source.findAccessibilityNodeInfosByText(JOIN_VIDEO_CALL);
+            AccessibilityNodeInfo joinCallNode = accessibilityNodes.get(0);
+            joinCallNode.performAction(AccessibilityNodeInfo.ACTION_CLICK);
+        }
+    }
+
+    private boolean isHangouts(String packageName) {
+        return packageName.equals(HANGOUTS_PACKAGE_NAME);
+    }
+
+    private boolean isWindowStateChangeEvent(int eventType) {
+        return eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED;
     }
 
     @Override

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
@@ -25,9 +25,17 @@ public class TelepresenceBotAccessibilityService extends AccessibilityService {
 
         if (isHangouts(packageName) && isWindowStateChangeEvent(eventType)) {
             List<AccessibilityNodeInfo> accessibilityNodes = source.findAccessibilityNodeInfosByText(JOIN_VIDEO_CALL);
-            AccessibilityNodeInfo joinCallNode = accessibilityNodes.get(0);
-            joinCallNode.performAction(AccessibilityNodeInfo.ACTION_CLICK);
+            if (containsJoinButton(accessibilityNodes)) {
+                AccessibilityNodeInfo joinCallNode = accessibilityNodes.get(0);
+                joinCallNode.performAction(AccessibilityNodeInfo.ACTION_CLICK);
+            } else {
+                Log.e(TelepresenceBotAccessibilityService.class.getSimpleName(), "Could not locate join video call button");
+            }
         }
+    }
+
+    private boolean containsJoinButton(List<AccessibilityNodeInfo> accessibilityNodes) {
+        return accessibilityNodes.size() > 0;
     }
 
     private boolean isHangouts(String packageName) {

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/automation/TelepresenceBotAccessibilityService.java
@@ -10,7 +10,8 @@ import java.util.List;
 public class TelepresenceBotAccessibilityService extends AccessibilityService {
 
     private static final String HANGOUTS_PACKAGE_NAME = "com.google.android.talk";
-    private static final String JOIN_VIDEO_CALL = "JOIN VIDEO CALL";
+    private static final String JOIN_CALL_VIEW_ID = "com.google.android.apps.hangouts:id/join_hangout";
+    private static final int FIRST_ELEMENT_INDEX = 0;
 
     @Override
     public void onAccessibilityEvent(AccessibilityEvent event) {
@@ -24,9 +25,10 @@ public class TelepresenceBotAccessibilityService extends AccessibilityService {
         int eventType = event.getEventType();
 
         if (isHangouts(packageName) && isWindowStateChangeEvent(eventType)) {
-            List<AccessibilityNodeInfo> accessibilityNodes = source.findAccessibilityNodeInfosByText(JOIN_VIDEO_CALL);
+            List<AccessibilityNodeInfo> accessibilityNodes = source.findAccessibilityNodeInfosByViewId(JOIN_CALL_VIEW_ID);
+
             if (containsJoinButton(accessibilityNodes)) {
-                AccessibilityNodeInfo joinCallNode = accessibilityNodes.get(0);
+                AccessibilityNodeInfo joinCallNode = accessibilityNodes.get(FIRST_ELEMENT_INDEX);
                 joinCallNode.performAction(AccessibilityNodeInfo.ACTION_CLICK);
             } else {
                 Log.e(TelepresenceBotAccessibilityService.class.getSimpleName(), "Could not locate join video call button");

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 
 public class BotActivity extends AppCompatActivity implements BotView {
 
+    private static final String HANGOUTS_BASE_URL = "https://hangouts.google.com/hangouts/_/novoda.com/";
     private SelfDestructingMessageView debugView;
     private SwitchableView switchableView;
 
@@ -85,13 +86,8 @@ public class BotActivity extends AppCompatActivity implements BotView {
     private final ServerDeclarationListener serverDeclarationListener = new ServerDeclarationListener() {
         @Override
         public void onConnect(String serverAddress) {
-            String url = "https://hangouts.google.com/hangouts/_/novoda.com/bot";
-            Intent i = new Intent(Intent.ACTION_VIEW);
-            i.setData(Uri.parse(url));
-            startActivity(i);
-            // TODO: revert.
-//            debugView.showPermanently(getString(R.string.connecting_ellipsis));
-//            presenter.startPresenting(serverAddress);
+            debugView.showPermanently(getString(R.string.connecting_ellipsis));
+            presenter.startPresenting(serverAddress);
         }
     };
 
@@ -182,9 +178,18 @@ public class BotActivity extends AppCompatActivity implements BotView {
     };
 
     @Override
-    public void onConnect(String message) {
+    public void onConnect(String room) {
         debugView.showPermanently(getString(R.string.connected));
         switchableView.setDisplayedChild(1);
+
+        joinHangoutRoom(room);
+    }
+
+    private void joinHangoutRoom(String room) {
+        String url = HANGOUTS_BASE_URL + room;
+        Intent i = new Intent(Intent.ACTION_VIEW);
+        i.setData(Uri.parse(url));
+        startActivity(i);
     }
 
     @Override

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -179,6 +180,11 @@ public class BotActivity extends AppCompatActivity implements BotView {
     public void onConnect(String message) {
         debugView.showPermanently(getString(R.string.connected));
         switchableView.setDisplayedChild(1);
+
+        String url = "https://hangouts.google.com/hangouts/_/novoda.com/bot";
+        Intent i = new Intent(Intent.ACTION_VIEW);
+        i.setData(Uri.parse(url));
+        startActivity(i);
     }
 
     @Override

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
@@ -85,8 +85,13 @@ public class BotActivity extends AppCompatActivity implements BotView {
     private final ServerDeclarationListener serverDeclarationListener = new ServerDeclarationListener() {
         @Override
         public void onConnect(String serverAddress) {
-            debugView.showPermanently(getString(R.string.connecting_ellipsis));
-            presenter.startPresenting(serverAddress);
+            String url = "https://hangouts.google.com/hangouts/_/novoda.com/bot";
+            Intent i = new Intent(Intent.ACTION_VIEW);
+            i.setData(Uri.parse(url));
+            startActivity(i);
+            // TODO: revert.
+//            debugView.showPermanently(getString(R.string.connecting_ellipsis));
+//            presenter.startPresenting(serverAddress);
         }
     };
 
@@ -180,11 +185,6 @@ public class BotActivity extends AppCompatActivity implements BotView {
     public void onConnect(String message) {
         debugView.showPermanently(getString(R.string.connected));
         switchableView.setDisplayedChild(1);
-
-        String url = "https://hangouts.google.com/hangouts/_/novoda.com/bot";
-        Intent i = new Intent(Intent.ACTION_VIEW);
-        i.setData(Uri.parse(url));
-        startActivity(i);
     }
 
     @Override

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/SocketConnectionObservable.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/support/SocketConnectionObservable.java
@@ -63,7 +63,7 @@ public class SocketConnectionObservable extends Observable<Result> {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    notifyOf(Result.from("Successful connection"));
+                    notifyOf(Result.from(Room.LONDON.name().toLowerCase()));
                 }
             });
         }

--- a/TelepresenceBot/mobile/src/main/res/xml/accessibility_service_config.xml
+++ b/TelepresenceBot/mobile/src/main/res/xml/accessibility_service_config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-  android:accessibilityEventTypes="typeViewClicked|typeViewFocused"
-  android:accessibilityFeedbackType="feedbackGeneric"
+  android:packageNames="com.google.android.talk, com.novoda.tpbot"
+  android:accessibilityEventTypes="typeAllMask"
+  android:accessibilityFeedbackType="feedbackAllMask"
   android:notificationTimeout="100"
-  android:settingsActivity="com.example.android.apis.accessibility.TestBackActivity"
   android:canRetrieveWindowContent="true" />
 

--- a/TelepresenceBot/mobile/src/main/res/xml/accessibility_service_config.xml
+++ b/TelepresenceBot/mobile/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+  android:accessibilityEventTypes="typeViewClicked|typeViewFocused"
+  android:accessibilityFeedbackType="feedbackGeneric"
+  android:notificationTimeout="100"
+  android:settingsActivity="com.example.android.apis.accessibility.TestBackActivity"
+  android:canRetrieveWindowContent="true" />
+


### PR DESCRIPTION
#### Problem
As a `user`, I need the bot to be able to automatically connect to a hangout room when I connect to it. The problem is `hangouts` does not have a direct `intent` to open a hangout, it always requires the joiner to confirm their intent to join a video call with the `join video call` button.

#### Solution
Use the `AccessibilityService` to monitor `AccessibilityEvents` coming from the `com.novoda.tpbot` and `com.google.android.talk` packages. When an event originates from `com.google.android.talk` search the `AccessibilityNodes` for the `join call button` and perform an `action.CLICK` on it to confirm a video call. 

#### Screen Capture
In order to use the accessibility service on your device, you need to navigate to `settings -> accessibility` to enable the service. For now, I am hard-coding the room to join in the app as part of the return value of the observable given to the `BotActivity` in a later PR this would be created by using the `human's` username and given to the bot when establishing a connection.
![and_again mov](https://cloud.githubusercontent.com/assets/3380092/24427281/5475d034-1402-11e7-90a1-374825986b6b.gif)



