### PR TITLE
[piano-hero] Add data classes to represent notes and chords

### DIFF
--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Chord.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Chord.java
@@ -1,0 +1,44 @@
+package com.novoda.pianohero;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Chord {
+
+    private final Set<Note> notes;
+
+    public Chord(Note... notes) {
+        this(new HashSet<>(Arrays.asList(notes)));
+    }
+
+    public Chord(Set<Note> notes) {
+        this.notes = checkHasMinimumNotes(notes);
+    }
+
+    private Set<Note> checkHasMinimumNotes(Set<Note> notes) {
+        if (notes.size() < 2) {
+            throw new IllegalArgumentException("Chords must contain at least two Notes");
+        }
+        return notes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Chord chord = (Chord) o;
+        return notes.equals(chord.notes);
+    }
+
+    @Override
+    public int hashCode() {
+        return notes.hashCode();
+    }
+}

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Chord.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Chord.java
@@ -25,6 +25,10 @@ public class Chord {
         return notes;
     }
 
+    public Set<Note> notes() {
+        return notes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Chord.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Chord.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 public class Chord {
 
+    private static final int MINIMUM_NUMBER_OF_NOTES_IN_CHORD = 2;
+
     private final Set<Note> notes;
 
     public Chord(Note... notes) {
@@ -17,7 +19,7 @@ public class Chord {
     }
 
     private Set<Note> checkHasMinimumNotes(Set<Note> notes) {
-        if (notes.size() < 2) {
+        if (notes.size() < MINIMUM_NUMBER_OF_NOTES_IN_CHORD) {
             throw new IllegalArgumentException("Chords must contain at least two Notes");
         }
         return notes;

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Chords.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Chords.java
@@ -1,0 +1,12 @@
+package com.novoda.pianohero;
+
+class Chords {
+
+    static final Chord C = new Chord(Notes.C4, Notes.E4, Notes.G4);
+    static final Chord F_2ND_INV = new Chord(Notes.C4, Notes.F4, Notes.A4);
+    static final Chord G_2ND_INV = new Chord(Notes.D4, Notes.G4, Notes.B4);
+    static final Chord EM = new Chord(Notes.E4, Notes.G4, Notes.B5);
+    static final Chord AM_2ND_INV = new Chord(Notes.E4, Notes.A4, Notes.C5);
+    static final Chord G = new Chord(Notes.G4, Notes.B5, Notes.D5);
+    static final Chord C_2ND_INV = new Chord(Notes.G4, Notes.C5, Notes.E5);
+}

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Note.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Note.java
@@ -2,6 +2,9 @@ package com.novoda.pianohero;
 
 public class Note {
 
+    private static final int LOWEST_MIDI_NOTE = 0;
+    private static final int HIGHEST_MIDI_NOTE = 127;
+
     private final int midiNoteNumber;
 
     public Note(int midiNoteNumber) {
@@ -9,8 +12,8 @@ public class Note {
     }
 
     private int checkNotOutOfRange(int midiNoteNumber) {
-        if (midiNoteNumber < 0 && midiNoteNumber > 127) {
-            throw new IllegalArgumentException("MIDI notes range from 0-127 inclusive");
+        if (midiNoteNumber < LOWEST_MIDI_NOTE && midiNoteNumber > HIGHEST_MIDI_NOTE) {
+            throw new IllegalArgumentException("MIDI notes range from " + LOWEST_MIDI_NOTE + "-" + HIGHEST_MIDI_NOTE + " inclusive");
         }
         return midiNoteNumber;
     }

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Note.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Note.java
@@ -1,0 +1,36 @@
+package com.novoda.pianohero;
+
+public class Note {
+
+    private final int midiNoteNumber;
+
+    public Note(int midiNoteNumber) {
+        this.midiNoteNumber = checkNotOutOfRange(midiNoteNumber);
+    }
+
+    private int checkNotOutOfRange(int midiNoteNumber) {
+        if (midiNoteNumber < 0 && midiNoteNumber > 127) {
+            throw new IllegalArgumentException("MIDI notes range from 0-127 inclusive");
+        }
+        return midiNoteNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Note note = (Note) o;
+        return midiNoteNumber == note.midiNoteNumber;
+    }
+
+    @Override
+    public int hashCode() {
+        return midiNoteNumber;
+    }
+}

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Notes.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Notes.java
@@ -1,0 +1,29 @@
+package com.novoda.pianohero;
+
+class Notes {
+
+    static final Note C4 = new Note(60);
+    static final Note C4_S = new Note(61);
+    static final Note D4 = new Note(62);
+    static final Note D4_S = new Note(63);
+    static final Note E4 = new Note(64);
+    static final Note F4 = new Note(65);
+    static final Note F4_S = new Note(66);
+    static final Note G4 = new Note(67);
+    static final Note G4_S = new Note(68);
+    static final Note A4 = new Note(69);
+    static final Note A4_S = new Note(70);
+    static final Note B4 = new Note(71);
+    static final Note C5 = new Note(72);
+    static final Note C5_S = new Note(73);
+    static final Note D5 = new Note(74);
+    static final Note D5_S = new Note(75);
+    static final Note E5 = new Note(76);
+    static final Note F5 = new Note(77);
+    static final Note F5_S = new Note(78);
+    static final Note G5 = new Note(79);
+    static final Note G5_S = new Note(80);
+    static final Note A5 = new Note(81);
+    static final Note A5_S = new Note(82);
+    static final Note B5 = new Note(83);
+}

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/Sequence.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/Sequence.java
@@ -1,0 +1,42 @@
+package com.novoda.pianohero;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public final class Sequence {
+
+    private final List<Set<Note>> notes;
+
+    private Sequence(List<Set<Note>> notes) {
+        this.notes = notes;
+    }
+
+    public Set<Note> get(int position) {
+        return notes.get(position);
+    }
+
+    public int size() {
+        return notes.size();
+    }
+
+    public static class Builder {
+
+        private final List<Set<Note>> notes = new ArrayList<>();
+
+        public Builder add(Chord chord) {
+            notes.add(chord.notes());
+            return this;
+        }
+
+        public Builder add(Note note) {
+            notes.add(Collections.singleton(note));
+            return this;
+        }
+
+        public Sequence build() {
+            return new Sequence(notes);
+        }
+    }
+}

--- a/piano-hero/core/src/main/java/com/novoda/pianohero/SongSequenceFactory.java
+++ b/piano-hero/core/src/main/java/com/novoda/pianohero/SongSequenceFactory.java
@@ -1,0 +1,24 @@
+package com.novoda.pianohero;
+
+public class SongSequenceFactory {
+
+    public Sequence maryHadALittleLamb() {
+        return new Sequence.Builder()
+                .add(Notes.E4).add(Notes.D4).add(Notes.C4).add(Notes.D4).add(Notes.E4).add(Notes.E4).add(Notes.E4)
+                .add(Notes.D4).add(Notes.D4).add(Notes.D4).add(Notes.E4).add(Notes.E4).add(Notes.E4)
+                .add(Notes.E4).add(Notes.D4).add(Notes.C4).add(Notes.D4).add(Notes.E4).add(Notes.E4).add(Notes.E4)
+                .add(Notes.E4).add(Notes.D4).add(Notes.D4).add(Notes.E4).add(Notes.D4).add(Notes.C4)
+                .build();
+    }
+
+    public Sequence pachelbelsCanon() {
+        return new Sequence.Builder()
+                .add(Chords.C_2ND_INV).add(Chords.G).add(Chords.AM_2ND_INV).add(Chords.EM)
+                .add(Chords.F_2ND_INV).add(Chords.C).add(Chords.F_2ND_INV).add(Chords.G_2ND_INV)
+                .add(Chords.C_2ND_INV).add(Chords.G).add(Chords.AM_2ND_INV).add(Chords.EM)
+                .add(Chords.F_2ND_INV).add(Chords.C).add(Chords.F_2ND_INV).add(Chords.G_2ND_INV)
+                .add(Chords.C_2ND_INV).add(Chords.G).add(Chords.AM_2ND_INV).add(Chords.EM)
+                .add(Chords.F_2ND_INV).add(Chords.C).add(Chords.F_2ND_INV).add(Chords.G_2ND_INV).add(Chords.C)
+                .build();
+    }
+}


### PR DESCRIPTION
We need terminology that can be shared between the sensors (e.g. piano) and actuators (e.g. display).

Since we're not concerned with note timings (yet?), I've only added pitch information. Not sure if we technically _need_ `Chord` since it's just a `Set<Note>` (with an additional constraint of minimum notes == 2) but it's been useful in representing chords that are used to create songs in the `SongSequenceFactory`.

The `SongSequenceFactory` contains examples of songs with single notes and chords too.