### PR TITLE
DropCap/ Allow multiple DropCaps

### DIFF
--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -88,7 +88,7 @@ public class DropCapView extends View {
             setCopyTextColor(copyTextColor);
 
             String text = typedArray.getString(R.styleable.DropCapView_android_text);
-            setText(text);
+            setText(text, numberOfDropCaps);
 
         } finally {
             typedArray.recycle();
@@ -96,8 +96,8 @@ public class DropCapView extends View {
     }
 
     public void setNumberOfDropCaps(int numberOfDropCaps) {
-        this.numberOfDropCaps = numberOfDropCaps;
-        remeasureAndRedraw();
+        String text = dropCapText + copyText;
+        setText(text, numberOfDropCaps);
     }
 
     public void setDropCapFontType(String fontPath) {
@@ -212,7 +212,11 @@ public class DropCapView extends View {
     }
 
     public void setText(String text) {
-        if (isSameText(text)) {
+        setText(text, numberOfDropCaps);
+    }
+
+    private void setText(String text, int numberOfDropCaps) {
+        if (sameNumberOfDropCaps(numberOfDropCaps) && sameText(text)) {
             return;
         }
 
@@ -224,14 +228,19 @@ public class DropCapView extends View {
             copyText = (text == null) ? "" : text;
         }
 
+        this.numberOfDropCaps = numberOfDropCaps;
         remeasureAndRedraw();
     }
 
-    private boolean isSameText(String text) {
+    private boolean sameNumberOfDropCaps(int numberOfDropCaps) {
+        return this.numberOfDropCaps == numberOfDropCaps;
+    }
+
+    private boolean sameText(String text) {
         return text != null && text.equals(dropCapText + copyText);
     }
 
-    private boolean enoughTextForDropCap(CharSequence text) {
+    private boolean enoughTextForDropCap(String text) {
         return text != null && text.length() > numberOfDropCaps;
     }
 
@@ -257,7 +266,7 @@ public class DropCapView extends View {
 
     private void measureDropCapFor(int width) {
         dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, dropCapText.length()) + spacer);
-        dropCapPaint.getTextBounds(dropCapText, 0, numberOfDropCaps, dropCapBounds);
+        dropCapPaint.getTextBounds(dropCapText, 0, dropCapText.length(), dropCapBounds);
         int copyWidthForDropCap = width - dropCapWidth;
 
         if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != copyWidthForDropCap) {
@@ -383,7 +392,7 @@ public class DropCapView extends View {
             int baseline = dropCapStaticLayout.getLineBaseline(i) + getPaddingTop();
 
             if (i == 0) {
-                lineStart = lineStart + 1;
+                lineStart = lineStart + dropCapText.length();
             }
 
             canvas.drawText(

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -32,7 +32,6 @@ public class DropCapView extends View {
     private String dropCapText;
     private String copyText;
 
-    private int numberOfDropCaps;
     private int lineSpacingExtra;
     private int numberOfLinesToSpan;
     private int dropCapWidth;
@@ -59,9 +58,6 @@ public class DropCapView extends View {
         }
 
         try {
-            int defaultNumberOfDropCaps = 0;
-            numberOfDropCaps = typedArray.getInt(R.styleable.DropCapView_numberOfDropCaps, defaultNumberOfDropCaps);
-
             String dropCapFontPath = typedArray.getString(R.styleable.DropCapView_dropCapFontPath);
             setDropCapFontType(dropCapFontPath);
 
@@ -88,16 +84,11 @@ public class DropCapView extends View {
             setCopyTextColor(copyTextColor);
 
             String text = typedArray.getString(R.styleable.DropCapView_android_text);
-            setText(text, numberOfDropCaps);
+            setText(text);
 
         } finally {
             typedArray.recycle();
         }
-    }
-
-    public void setNumberOfDropCaps(int numberOfDropCaps) {
-        String text = dropCapText + copyText;
-        setText(text, numberOfDropCaps);
     }
 
     public void setDropCapFontType(String fontPath) {
@@ -212,36 +203,27 @@ public class DropCapView extends View {
     }
 
     public void setText(String text) {
-        setText(text, numberOfDropCaps);
-    }
-
-    private void setText(String text, int numberOfDropCaps) {
-        if (sameNumberOfDropCaps(numberOfDropCaps) && sameText(text)) {
+        if (isSameText(text)) {
             return;
         }
 
         if (enoughTextForDropCap(text)) {
-            dropCapText = String.valueOf(text.substring(0, numberOfDropCaps)).toUpperCase();
-            copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
+            dropCapText = String.valueOf(text.charAt(0));
+            copyText = String.valueOf(text.subSequence(1, text.length()));
         } else {
             dropCapText = String.valueOf('\0');
             copyText = (text == null) ? "" : text;
         }
 
-        this.numberOfDropCaps = numberOfDropCaps;
         remeasureAndRedraw();
     }
 
-    private boolean sameNumberOfDropCaps(int numberOfDropCaps) {
-        return this.numberOfDropCaps == numberOfDropCaps;
-    }
-
-    private boolean sameText(String text) {
+    private boolean isSameText(String text) {
         return text != null && text.equals(dropCapText + copyText);
     }
 
-    private boolean enoughTextForDropCap(String text) {
-        return text != null && text.length() > numberOfDropCaps;
+    private boolean enoughTextForDropCap(CharSequence text) {
+        return text != null && text.length() > 1;
     }
 
     @Override
@@ -265,8 +247,8 @@ public class DropCapView extends View {
     }
 
     private void measureDropCapFor(int width) {
-        dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, dropCapText.length()) + spacer);
-        dropCapPaint.getTextBounds(dropCapText, 0, dropCapText.length(), dropCapBounds);
+        dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, 1) + spacer);
+        dropCapPaint.getTextBounds(dropCapText, 0, 1, dropCapBounds);
         int copyWidthForDropCap = width - dropCapWidth;
 
         if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != copyWidthForDropCap) {
@@ -381,7 +363,7 @@ public class DropCapView extends View {
 
     private void drawDropCap(Canvas canvas) {
         float dropCapBaselineFromCopyTop = dropCapBaseline + distanceFromViewPortTop;
-        canvas.drawText(dropCapStaticLayout.getText(), 0, dropCapText.length(), getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
+        canvas.drawText(dropCapStaticLayout.getText(), 0, 1, getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
     }
 
     private void drawCopyForDropCap(Canvas canvas) {
@@ -392,7 +374,7 @@ public class DropCapView extends View {
             int baseline = dropCapStaticLayout.getLineBaseline(i) + getPaddingTop();
 
             if (i == 0) {
-                lineStart = lineStart + dropCapText.length();
+                lineStart = lineStart + 1;
             }
 
             canvas.drawText(

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -268,9 +268,7 @@ public class DropCapView extends View {
             );
 
             calculateLinesToSpan();
-
-            float baseline = dropCapBounds.height() + getPaddingTop();
-            dropCapBaseline = baseline - dropCapBounds.bottom;
+            calculateDropCapBaseline();
         }
     }
 
@@ -286,6 +284,11 @@ public class DropCapView extends View {
             }
         }
         dropCapLineHeight = currentLineTop;
+    }
+
+    private void calculateDropCapBaseline() {
+        float baseline = dropCapBounds.height() + getPaddingTop();
+        dropCapBaseline = baseline - dropCapBounds.bottom;
     }
 
     private void measureRemainingCopyFor(int totalWidth) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -351,7 +351,7 @@ public class DropCapView extends View {
     protected void onDraw(Canvas canvas) {
         if (canDrawDropCap) {
             drawDropCap(canvas);
-            drawCopyForDropCap(canvas);
+            drawCopyWrappingDropCap(canvas);
             drawRemainingCopy(canvas);
         } else {
             drawCopyWithoutDropCap(canvas);
@@ -363,7 +363,7 @@ public class DropCapView extends View {
         canvas.drawText(dropCapText, 0, dropCapText.length(), getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
     }
 
-    private void drawCopyForDropCap(Canvas canvas) {
+    private void drawCopyWrappingDropCap(Canvas canvas) {
         for (int i = 0; i < numberOfLinesToSpan; i++) {
             int lineStart = dropCapCopyStaticLayout.getLineStart(i);
             int lineEnd = dropCapCopyStaticLayout.getLineEnd(i);

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -254,13 +254,13 @@ public class DropCapView extends View {
     private void measureDropCapFor(int width) {
         dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, dropCapText.length()) + spacer);
         dropCapPaint.getTextBounds(dropCapText, 0, dropCapText.length(), dropCapBounds);
-        int copyWidthForDropCap = width - dropCapWidth;
+        int remainingWidthAfterDropCap = width - dropCapWidth;
 
-        if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != copyWidthForDropCap) {
+        if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != remainingWidthAfterDropCap) {
             dropCapStaticLayout = new StaticLayout(
-                    dropCapText + copyText,
+                    copyText,
                     copyTextPaint,
-                    copyWidthForDropCap,
+                    remainingWidthAfterDropCap,
                     Layout.Alignment.ALIGN_NORMAL,
                     SPACING_MULTIPLIER,
                     lineSpacingExtra,
@@ -372,7 +372,7 @@ public class DropCapView extends View {
 
     private void drawDropCap(Canvas canvas) {
         float dropCapBaselineFromCopyTop = dropCapBaseline + distanceFromViewPortTop;
-        canvas.drawText(dropCapStaticLayout.getText(), 0, dropCapText.length(), getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
+        canvas.drawText(dropCapText, 0, dropCapText.length(), getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
     }
 
     private void drawCopyForDropCap(Canvas canvas) {
@@ -381,10 +381,6 @@ public class DropCapView extends View {
             int lineEnd = dropCapStaticLayout.getLineEnd(i);
 
             int baseline = dropCapStaticLayout.getLineBaseline(i) + getPaddingTop();
-
-            if (i == 0) {
-                lineStart = lineStart + dropCapText.length();
-            }
 
             canvas.drawText(
                     dropCapStaticLayout.getText(),

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -59,14 +59,14 @@ public class DropCapView extends View {
         }
 
         try {
+            int defaultNumberOfDropCaps = 0;
+            numberOfDropCaps = typedArray.getInt(R.styleable.DropCapView_numberOfDropCaps, defaultNumberOfDropCaps);
+
             String dropCapFontPath = typedArray.getString(R.styleable.DropCapView_dropCapFontPath);
             setDropCapFontType(dropCapFontPath);
 
             String copyFontPath = typedArray.getString(R.styleable.DropCapView_copyFontPath);
             setCopyFontType(copyFontPath);
-
-            int defaultNumberOfDropCaps = 0;
-            numberOfDropCaps = typedArray.getInt(R.styleable.DropCapView_numberOfDropCaps, defaultNumberOfDropCaps);
 
             int defaultLineSpacingExtra = 0;
             lineSpacingExtra = typedArray.getDimensionPixelSize(R.styleable.DropCapView_lineSpacingExtra, defaultLineSpacingExtra);
@@ -93,6 +93,11 @@ public class DropCapView extends View {
         } finally {
             typedArray.recycle();
         }
+    }
+
+    public void setNumberOfDropCaps(int numberOfDropCaps) {
+        this.numberOfDropCaps = numberOfDropCaps;
+        remeasureAndRedraw();
     }
 
     public void setDropCapFontType(String fontPath) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -6,6 +6,7 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.support.annotation.ColorInt;
+import android.support.annotation.Nullable;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
@@ -104,7 +105,7 @@ public class DropCapView extends View {
         setText(text);
     }
 
-    public void setText(String text) {
+    public void setText(@Nullable String text) {
         if (enoughTextForDropCap(text)) {
             dropCapText = String.valueOf(text.substring(0, numberOfDropCaps));
             copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
@@ -120,7 +121,7 @@ public class DropCapView extends View {
         return text != null && text.length() > numberOfDropCaps;
     }
 
-    public void setDropCapFontType(String fontPath) {
+    public void setDropCapFontType(@Nullable String fontPath) {
         Typeface typeface = typefaceFactory.createFrom(getContext(), fontPath);
         if (dropCapPaint.getTypeface() == typeface) {
             return;
@@ -142,7 +143,7 @@ public class DropCapView extends View {
         }
     }
 
-    public void setCopyFontType(String fontPath) {
+    public void setCopyFontType(@Nullable String fontPath) {
         Typeface typeface = typefaceFactory.createFrom(getContext(), fontPath);
         if (copyTextPaint.getTypeface() == typeface) {
             return;

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -239,7 +239,7 @@ public class DropCapView extends View {
 
         measureDropCapFor(widthWithoutPadding);
 
-        if (enoughLinesForDropCap()) {
+        if (enoughLinesToWrapDropCap()) {
             measureRemainingCopyFor(totalWidth);
         } else {
             measureWholeTextFor(totalWidth);
@@ -329,7 +329,7 @@ public class DropCapView extends View {
         }
     }
 
-    private boolean enoughLinesForDropCap() {
+    private boolean enoughLinesToWrapDropCap() {
         return dropCapCopyStaticLayout.getLineCount() > numberOfLinesToSpan && numberOfLinesToSpan > 0;
     }
 
@@ -342,7 +342,7 @@ public class DropCapView extends View {
 
     @Override
     protected void onDraw(Canvas canvas) {
-        if (enoughLinesForDropCap()) {
+        if (enoughLinesToWrapDropCap()) {
             drawDropCap(canvas);
             drawCopyForDropCap(canvas);
             drawRemainingCopy(canvas);

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -212,7 +212,7 @@ public class DropCapView extends View {
         }
 
         if (enoughTextForDropCap(text)) {
-            dropCapText = String.valueOf(text.substring(0, numberOfDropCaps));
+            dropCapText = String.valueOf(text.substring(0, numberOfDropCaps)).toUpperCase();
             copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
         } else {
             dropCapText = String.valueOf('\0');

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -10,7 +10,6 @@ import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 
@@ -106,7 +105,6 @@ public class DropCapView extends View {
     }
 
     public void setText(String text) {
-        Log.e(getClass().getSimpleName(), "setText");
         if (enoughTextForDropCap(text)) {
             dropCapText = String.valueOf(text.substring(0, numberOfDropCaps));
             copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -269,10 +269,8 @@ public class DropCapView extends View {
 
             calculateLinesToSpan();
 
-            if (enoughLinesForDropCap()) {
-                float baseline = dropCapBounds.height() + getPaddingTop();
-                dropCapBaseline = baseline - dropCapBounds.bottom;
-            }
+            float baseline = dropCapBounds.height() + getPaddingTop();
+            dropCapBaseline = baseline - dropCapBounds.bottom;
         }
     }
 

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -382,7 +382,7 @@ public class DropCapView extends View {
             int baseline = dropCapStaticLayout.getLineBaseline(i) + getPaddingTop();
 
             if (i == 0) {
-                lineStart = lineStart + 1;
+                lineStart = lineStart + dropCapText.length();
             }
 
             canvas.drawText(

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -28,7 +28,7 @@ public class DropCapView extends View {
     private final float spacer;
 
     private Layout copyStaticLayout;
-    private Layout dropCapStaticLayout;
+    private Layout dropCapCopyStaticLayout;
 
     private String dropCapText;
     private String copyText;
@@ -134,9 +134,9 @@ public class DropCapView extends View {
     }
 
     private void remeasureAndRedraw() {
-        if (dropCapStaticLayout != null || copyStaticLayout != null) {
+        if (dropCapCopyStaticLayout != null || copyStaticLayout != null) {
             copyStaticLayout = null;
-            dropCapStaticLayout = null;
+            dropCapCopyStaticLayout = null;
             requestLayout();
             invalidate();
         }
@@ -256,8 +256,8 @@ public class DropCapView extends View {
         dropCapPaint.getTextBounds(dropCapText, 0, dropCapText.length(), dropCapBounds);
         int remainingWidthAfterDropCap = width - dropCapWidth;
 
-        if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != remainingWidthAfterDropCap) {
-            dropCapStaticLayout = new StaticLayout(
+        if (dropCapCopyStaticLayout == null || dropCapCopyStaticLayout.getWidth() != remainingWidthAfterDropCap) {
+            dropCapCopyStaticLayout = new StaticLayout(
                     copyText,
                     copyTextPaint,
                     remainingWidthAfterDropCap,
@@ -280,20 +280,20 @@ public class DropCapView extends View {
         int currentLineTop = 0;
         numberOfLinesToSpan = 0;
 
-        for (int i = 0; i < dropCapStaticLayout.getLineCount(); i++) {
-            currentLineTop = dropCapStaticLayout.getLineTop(i);
+        for (int i = 0; i < dropCapCopyStaticLayout.getLineCount(); i++) {
+            currentLineTop = dropCapCopyStaticLayout.getLineTop(i);
             if (currentLineTop >= dropCapBounds.height()) {
                 numberOfLinesToSpan = i;
-                i = dropCapStaticLayout.getLineCount();
+                i = dropCapCopyStaticLayout.getLineCount();
             }
         }
         dropCapLineHeight = currentLineTop;
     }
 
     private void measureRemainingCopyFor(int totalWidth) {
-        int lineStart = dropCapStaticLayout.getLineEnd(numberOfLinesToSpanAsZeroIndex());
-        int lineEnd = dropCapStaticLayout.getText().length();
-        String remainingText = String.valueOf(dropCapStaticLayout.getText().subSequence(lineStart, lineEnd));
+        int lineStart = dropCapCopyStaticLayout.getLineEnd(numberOfLinesToSpanAsZeroIndex());
+        int lineEnd = dropCapCopyStaticLayout.getText().length();
+        String remainingText = String.valueOf(dropCapCopyStaticLayout.getText().subSequence(lineStart, lineEnd));
 
         if (copyStaticLayout == null || copyStaticLayout.getWidth() != totalWidth || !remainingText.equals(copyStaticLayout.getText())) {
             copyStaticLayout = new StaticLayout(
@@ -329,7 +329,7 @@ public class DropCapView extends View {
     }
 
     private boolean enoughLinesForDropCap() {
-        return dropCapStaticLayout.getLineCount() > numberOfLinesToSpan && numberOfLinesToSpan > 0;
+        return dropCapCopyStaticLayout.getLineCount() > numberOfLinesToSpan && numberOfLinesToSpan > 0;
     }
 
     private float calculateCopyDistanceFromViewPortTop() {
@@ -377,25 +377,25 @@ public class DropCapView extends View {
 
     private void drawCopyForDropCap(Canvas canvas) {
         for (int i = 0; i < numberOfLinesToSpan; i++) {
-            int lineStart = dropCapStaticLayout.getLineStart(i);
-            int lineEnd = dropCapStaticLayout.getLineEnd(i);
+            int lineStart = dropCapCopyStaticLayout.getLineStart(i);
+            int lineEnd = dropCapCopyStaticLayout.getLineEnd(i);
 
-            int baseline = dropCapStaticLayout.getLineBaseline(i) + getPaddingTop();
+            int baseline = dropCapCopyStaticLayout.getLineBaseline(i) + getPaddingTop();
 
             canvas.drawText(
-                    dropCapStaticLayout.getText(),
+                    dropCapCopyStaticLayout.getText(),
                     lineStart,
                     lineEnd,
                     getPaddingLeft() + dropCapWidth,
                     baseline,
-                    dropCapStaticLayout.getPaint()
+                    dropCapCopyStaticLayout.getPaint()
             );
         }
     }
 
     private void drawRemainingCopy(Canvas canvas) {
-        int ascentPadding = Math.abs(dropCapStaticLayout.getTopPadding());
-        int baseline = dropCapStaticLayout.getLineBottom(numberOfLinesToSpanAsZeroIndex()) - ascentPadding + getPaddingTop();
+        int ascentPadding = Math.abs(dropCapCopyStaticLayout.getTopPadding());
+        int baseline = dropCapCopyStaticLayout.getLineBottom(numberOfLinesToSpanAsZeroIndex()) - ascentPadding + getPaddingTop();
         canvas.translate(getPaddingLeft(), baseline);
         copyStaticLayout.draw(canvas);
     }

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -32,6 +32,7 @@ public class DropCapView extends View {
     private String dropCapText;
     private String copyText;
 
+    private int numberOfDropCaps;
     private int lineSpacingExtra;
     private int numberOfLinesToSpan;
     private int dropCapWidth;
@@ -63,6 +64,9 @@ public class DropCapView extends View {
 
             String copyFontPath = typedArray.getString(R.styleable.DropCapView_copyFontPath);
             setCopyFontType(copyFontPath);
+
+            int defaultNumberOfDropCaps = 0;
+            numberOfDropCaps = typedArray.getInt(R.styleable.DropCapView_numberOfDropCaps, defaultNumberOfDropCaps);
 
             int defaultLineSpacingExtra = 0;
             lineSpacingExtra = typedArray.getDimensionPixelSize(R.styleable.DropCapView_lineSpacingExtra, defaultLineSpacingExtra);
@@ -208,8 +212,8 @@ public class DropCapView extends View {
         }
 
         if (enoughTextForDropCap(text)) {
-            dropCapText = String.valueOf(text.charAt(0));
-            copyText = String.valueOf(text.subSequence(1, text.length()));
+            dropCapText = String.valueOf(text.substring(0, numberOfDropCaps));
+            copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
         } else {
             dropCapText = String.valueOf('\0');
             copyText = (text == null) ? "" : text;
@@ -223,7 +227,7 @@ public class DropCapView extends View {
     }
 
     private boolean enoughTextForDropCap(CharSequence text) {
-        return text != null && text.length() > 1;
+        return text != null && text.length() > numberOfDropCaps;
     }
 
     @Override
@@ -247,8 +251,8 @@ public class DropCapView extends View {
     }
 
     private void measureDropCapFor(int width) {
-        dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, 1) + spacer);
-        dropCapPaint.getTextBounds(dropCapText, 0, 1, dropCapBounds);
+        dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, dropCapText.length()) + spacer);
+        dropCapPaint.getTextBounds(dropCapText, 0, numberOfDropCaps, dropCapBounds);
         int copyWidthForDropCap = width - dropCapWidth;
 
         if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != copyWidthForDropCap) {
@@ -363,7 +367,7 @@ public class DropCapView extends View {
 
     private void drawDropCap(Canvas canvas) {
         float dropCapBaselineFromCopyTop = dropCapBaseline + distanceFromViewPortTop;
-        canvas.drawText(dropCapStaticLayout.getText(), 0, 1, getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
+        canvas.drawText(dropCapStaticLayout.getText(), 0, dropCapText.length(), getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
     }
 
     private void drawCopyForDropCap(Canvas canvas) {

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -32,6 +32,7 @@ public class DropCapView extends View {
     private String dropCapText;
     private String copyText;
 
+    private int numberOfDropCaps;
     private int lineSpacingExtra;
     private int numberOfLinesToSpan;
     private int dropCapWidth;
@@ -63,6 +64,9 @@ public class DropCapView extends View {
 
             String copyFontPath = typedArray.getString(R.styleable.DropCapView_copyFontPath);
             setCopyFontType(copyFontPath);
+
+            int defaultNumberOfDropCaps = 1;
+            numberOfDropCaps = typedArray.getInt(R.styleable.DropCapView_numberOfDropCaps, defaultNumberOfDropCaps);
 
             int defaultLineSpacingExtra = 0;
             lineSpacingExtra = typedArray.getDimensionPixelSize(R.styleable.DropCapView_lineSpacingExtra, defaultLineSpacingExtra);
@@ -208,7 +212,7 @@ public class DropCapView extends View {
         }
 
         if (enoughTextForDropCap(text)) {
-            dropCapText = String.valueOf(text.charAt(0));
+            dropCapText = String.valueOf(text.substring(0, numberOfDropCaps));
             copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
         } else {
             dropCapText = String.valueOf('\0');
@@ -222,8 +226,8 @@ public class DropCapView extends View {
         return text != null && text.equals(dropCapText + copyText);
     }
 
-    private boolean enoughTextForDropCap(CharSequence text) {
-        return text != null && text.length() > 1;
+    private boolean enoughTextForDropCap(String text) {
+        return text != null && text.length() > numberOfDropCaps;
     }
 
     @Override

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -209,7 +209,7 @@ public class DropCapView extends View {
 
         if (enoughTextForDropCap(text)) {
             dropCapText = String.valueOf(text.charAt(0));
-            copyText = String.valueOf(text.subSequence(1, text.length()));
+            copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
         } else {
             dropCapText = String.valueOf('\0');
             copyText = (text == null) ? "" : text;
@@ -247,8 +247,8 @@ public class DropCapView extends View {
     }
 
     private void measureDropCapFor(int width) {
-        dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, 1) + spacer);
-        dropCapPaint.getTextBounds(dropCapText, 0, 1, dropCapBounds);
+        dropCapWidth = (int) (dropCapPaint.measureText(dropCapText, 0, dropCapText.length()) + spacer);
+        dropCapPaint.getTextBounds(dropCapText, 0, dropCapText.length(), dropCapBounds);
         int copyWidthForDropCap = width - dropCapWidth;
 
         if (dropCapStaticLayout == null || dropCapStaticLayout.getWidth() != copyWidthForDropCap) {
@@ -286,7 +286,7 @@ public class DropCapView extends View {
     }
 
     private void measureRemainingCopyFor(int totalWidth) {
-        int lineStart = dropCapStaticLayout.getLineEnd(numberOfLinesToSpan - 1);
+        int lineStart = dropCapStaticLayout.getLineEnd(numberOfLinesToSpanAsZeroIndex());
         int lineEnd = dropCapStaticLayout.getText().length();
         String remainingText = String.valueOf(dropCapStaticLayout.getText().subSequence(lineStart, lineEnd));
 
@@ -303,6 +303,10 @@ public class DropCapView extends View {
 
             distanceFromViewPortTop = calculateCopyDistanceFromViewPortTop();
         }
+    }
+
+    private int numberOfLinesToSpanAsZeroIndex() {
+        return numberOfLinesToSpan - 1;
     }
 
     private void measureWholeTextFor(int totalWidth) {
@@ -363,7 +367,7 @@ public class DropCapView extends View {
 
     private void drawDropCap(Canvas canvas) {
         float dropCapBaselineFromCopyTop = dropCapBaseline + distanceFromViewPortTop;
-        canvas.drawText(dropCapStaticLayout.getText(), 0, 1, getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
+        canvas.drawText(dropCapStaticLayout.getText(), 0, dropCapText.length(), getPaddingLeft(), dropCapBaselineFromCopyTop, dropCapPaint);
     }
 
     private void drawCopyForDropCap(Canvas canvas) {
@@ -390,7 +394,7 @@ public class DropCapView extends View {
 
     private void drawRemainingCopy(Canvas canvas) {
         int ascentPadding = Math.abs(dropCapStaticLayout.getTopPadding());
-        int baseline = dropCapStaticLayout.getLineBottom(numberOfLinesToSpan - 1) - ascentPadding + getPaddingTop();
+        int baseline = dropCapStaticLayout.getLineBottom(numberOfLinesToSpanAsZeroIndex()) - ascentPadding + getPaddingTop();
         canvas.translate(getPaddingLeft(), baseline);
         copyStaticLayout.draw(canvas);
     }

--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -10,6 +10,7 @@ import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 
@@ -93,6 +94,30 @@ public class DropCapView extends View {
         } finally {
             typedArray.recycle();
         }
+    }
+
+    public void setNumberOfDropCaps(int numberOfDropCaps) {
+        this.numberOfDropCaps = numberOfDropCaps;
+
+        String text = dropCapText + copyText;
+        setText(text);
+    }
+
+    public void setText(String text) {
+        Log.e(getClass().getSimpleName(), "setText");
+        if (enoughTextForDropCap(text)) {
+            dropCapText = String.valueOf(text.substring(0, numberOfDropCaps));
+            copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
+        } else {
+            dropCapText = String.valueOf('\0');
+            copyText = (text == null) ? "" : text;
+        }
+
+        remeasureAndRedraw();
+    }
+
+    private boolean enoughTextForDropCap(String text) {
+        return text != null && text.length() > numberOfDropCaps;
     }
 
     public void setDropCapFontType(String fontPath) {
@@ -204,30 +229,6 @@ public class DropCapView extends View {
     @ColorInt
     public int getCopyTextColor() {
         return copyTextPaint.getColor();
-    }
-
-    public void setText(String text) {
-        if (isSameText(text)) {
-            return;
-        }
-
-        if (enoughTextForDropCap(text)) {
-            dropCapText = String.valueOf(text.substring(0, numberOfDropCaps));
-            copyText = String.valueOf(text.subSequence(dropCapText.length(), text.length()));
-        } else {
-            dropCapText = String.valueOf('\0');
-            copyText = (text == null) ? "" : text;
-        }
-
-        remeasureAndRedraw();
-    }
-
-    private boolean isSameText(String text) {
-        return text != null && text.equals(dropCapText + copyText);
-    }
-
-    private boolean enoughTextForDropCap(String text) {
-        return text != null && text.length() > numberOfDropCaps;
     }
 
     @Override

--- a/drop-cap/library/src/main/res/values/attrs.xml
+++ b/drop-cap/library/src/main/res/values/attrs.xml
@@ -7,6 +7,7 @@
     <attr name="dropCapTextSize" format="dimension" />
     <attr name="dropCapTextColor" format="color" />
     <attr name="dropCapFontPath" format="string" />
+    <attr name="numberOfDropCaps" format="integer" />
 
     <attr name="copyTextSize" format="dimension" />
     <attr name="copyTextColor" format="color" />

--- a/drop-cap/library/src/main/res/values/attrs.xml
+++ b/drop-cap/library/src/main/res/values/attrs.xml
@@ -2,7 +2,6 @@
 <resources>
 
   <declare-styleable name="DropCapView">
-    <attr name="numberOfDropCaps" format="integer" />
     <attr name="lineSpacingExtra" format="dimension" />
     <attr name="dropCapTextSize" format="dimension" />
     <attr name="dropCapTextColor" format="color" />

--- a/drop-cap/library/src/main/res/values/attrs.xml
+++ b/drop-cap/library/src/main/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources>
 
   <declare-styleable name="DropCapView">
+    <attr name="numberOfDropCaps" format="integer" />
     <attr name="lineSpacingExtra" format="dimension" />
     <attr name="dropCapTextSize" format="dimension" />
     <attr name="dropCapTextColor" format="color" />

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
@@ -202,7 +202,7 @@ public class DropCapActivity extends Activity {
     private final OnDropCapNumberChangeListener onDropCapNumberChangeListener = new OnDropCapNumberChangeListener() {
         @Override
         public void onDropCapNumberChanged(int newNumberOfDropCaps) {
-            dropCapView.setNumberOfDropCaps(newNumberOfDropCaps);
+            // TODO: Programmatically set on DropCapView.
             numberOfDropCaps = newNumberOfDropCaps;
         }
     };

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
@@ -20,7 +20,9 @@ public class DropCapActivity extends Activity {
     private TextColorDialogDisplayer copyTextColorDialogDisplayer;
     private TypefaceDialogDisplayer dropCapTypefaceDialogDisplayer;
     private TypefaceDialogDisplayer copyTypefaceDialogDisplayer;
+    private DropCapNumberDialogDisplayer dropCapNumberDialogDisplayer;
 
+    private int numberOfDropCaps = 1;
     private FontType dropCapFontType;
     private FontType copyFontType;
 
@@ -34,6 +36,7 @@ public class DropCapActivity extends Activity {
         createTextColorDialogDisplayers();
         createTypefaceDialogDisplayers();
         createTextUpdater();
+        createDropCapNumberUpdater();
     }
 
     private void createTextSizeDialogDisplayers() {
@@ -54,7 +57,6 @@ public class DropCapActivity extends Activity {
 
         Button copyTextSizeButton = (Button) findViewById(R.id.copy_size);
         copyTextSizeButton.setOnClickListener(onClickDisplayCopyTextSizeDialog);
-
     }
 
     private final OnTextSizeChangeListener onDropCapTextSizeChanged = new OnTextSizeChangeListener() {
@@ -183,6 +185,32 @@ public class DropCapActivity extends Activity {
         @Override
         public void onClick(View v) {
             copyTypefaceDialogDisplayer.showTypefaceDialog(copyFontType);
+        }
+    };
+
+    private void createDropCapNumberUpdater() {
+        dropCapNumberDialogDisplayer = new DropCapNumberDialogDisplayer(
+                getFragmentManager(),
+                getResources(),
+                onDropCapNumberChangeListener
+        );
+
+        Button numberOfDropCapsButton = (Button) findViewById(R.id.drop_cap_number);
+        numberOfDropCapsButton.setOnClickListener(onClickDisplayNumberOfDropCapsDialog);
+    }
+
+    private final OnDropCapNumberChangeListener onDropCapNumberChangeListener = new OnDropCapNumberChangeListener() {
+        @Override
+        public void onDropCapNumberChanged(int newNumberOfDropCaps) {
+            dropCapView.setNumberOfDropCaps(newNumberOfDropCaps);
+            numberOfDropCaps = newNumberOfDropCaps;
+        }
+    };
+
+    private final View.OnClickListener onClickDisplayNumberOfDropCapsDialog = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            dropCapNumberDialogDisplayer.showDropCapNumberDialog(numberOfDropCaps);
         }
     };
 

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
@@ -203,6 +203,7 @@ public class DropCapActivity extends Activity {
         @Override
         public void onDropCapNumberChanged(int newNumberOfDropCaps) {
             // TODO: Programmatically set on DropCapView.
+            dropCapView.setNumberOfDropCaps(newNumberOfDropCaps);
             numberOfDropCaps = newNumberOfDropCaps;
         }
     };

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapActivity.java
@@ -202,7 +202,6 @@ public class DropCapActivity extends Activity {
     private final OnDropCapNumberChangeListener onDropCapNumberChangeListener = new OnDropCapNumberChangeListener() {
         @Override
         public void onDropCapNumberChanged(int newNumberOfDropCaps) {
-            // TODO: Programmatically set on DropCapView.
             dropCapView.setNumberOfDropCaps(newNumberOfDropCaps);
             numberOfDropCaps = newNumberOfDropCaps;
         }

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapNumberDialogDisplayer.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapNumberDialogDisplayer.java
@@ -1,0 +1,39 @@
+package com.novoda.dropcap.demo;
+
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.content.res.Resources;
+
+import com.novoda.drop_cap.R;
+
+public class DropCapNumberDialogDisplayer {
+
+    private final FragmentManager fragmentManager;
+    private final Resources resources;
+
+    private final OnDropCapNumberChangeListener numberChangeListener;
+
+    public DropCapNumberDialogDisplayer(FragmentManager fragmentManager, Resources resources, OnDropCapNumberChangeListener numberChangeListener) {
+        this.fragmentManager = fragmentManager;
+        this.resources = resources;
+        this.numberChangeListener = numberChangeListener;
+    }
+
+    public void showDropCapNumberDialog(int previousDropCapNumber) {
+        String dropCapNumberFragmentTag = resources.getString(R.string.fragment_tag_drop_cap_number);
+        DropCapNumberDialogFragment dropCapNumberFragment = (DropCapNumberDialogFragment) fragmentManager.findFragmentByTag(dropCapNumberFragmentTag);
+
+        FragmentTransaction transaction = fragmentManager.beginTransaction();
+
+        if (dropCapNumberFragment == null) {
+            dropCapNumberFragment = new DropCapNumberDialogFragment();
+            dropCapNumberFragment.setDropCapNumberChangeListener(numberChangeListener);
+            dropCapNumberFragment.setPreviousNumberOfDropCaps(previousDropCapNumber);
+        } else {
+            transaction.remove(dropCapNumberFragment);
+        }
+
+        dropCapNumberFragment.show(transaction, dropCapNumberFragmentTag);
+    }
+
+}

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapNumberDialogFragment.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/DropCapNumberDialogFragment.java
@@ -1,0 +1,74 @@
+package com.novoda.dropcap.demo;
+
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.NumberPicker;
+
+import com.novoda.drop_cap.R;
+
+public class DropCapNumberDialogFragment extends DialogFragment {
+
+    private OnDropCapNumberChangeListener onDropCapNumberChangeListener;
+    private Button positiveButton;
+    private Button negativeButton;
+    private NumberPicker numberPicker;
+    private int previousNumberOfDropCaps;
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        dialog.setTitle(getResources().getString(R.string.text_size_title));
+        return dialog;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_drop_cap_number_dialog, container);
+        positiveButton = (Button) view.findViewById(R.id.drop_cap_number_button_positive);
+        negativeButton = (Button) view.findViewById(R.id.drop_cap_number_button_negative);
+        numberPicker = (NumberPicker) view.findViewById(R.id.drop_cap_number_picker);
+        return view;
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        numberPicker.setMinValue(getResources().getInteger(R.integer.drop_cap_number_picker_min));
+        numberPicker.setMaxValue(getResources().getInteger(R.integer.drop_cap_number_picker_max));
+        numberPicker.setValue(previousNumberOfDropCaps);
+
+        positiveButton.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        int newNumberOfDropCaps = numberPicker.getValue();
+                        onDropCapNumberChangeListener.onDropCapNumberChanged(newNumberOfDropCaps);
+                        dismiss();
+                    }
+                }
+        );
+
+        negativeButton.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        dismiss();
+                    }
+                }
+        );
+    }
+
+    public void setDropCapNumberChangeListener(OnDropCapNumberChangeListener onDropCapNumberChangeListener) {
+        this.onDropCapNumberChangeListener = onDropCapNumberChangeListener;
+    }
+
+    public void setPreviousNumberOfDropCaps(int previousNumberOfDropCaps) {
+        this.previousNumberOfDropCaps = previousNumberOfDropCaps;
+    }
+
+}

--- a/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/OnDropCapNumberChangeListener.java
+++ b/drop-cap/sample/src/main/java/com/novoda/dropcap/demo/OnDropCapNumberChangeListener.java
@@ -1,0 +1,7 @@
+package com.novoda.dropcap.demo;
+
+interface OnDropCapNumberChangeListener {
+
+    void onDropCapNumberChanged(int newNumberOfDropCaps);
+
+}

--- a/drop-cap/sample/src/main/res/layout/activity_drop_cap.xml
+++ b/drop-cap/sample/src/main/res/layout/activity_drop_cap.xml
@@ -85,6 +85,13 @@
 
   </LinearLayout>
 
+  <Button
+    android:id="@+id/drop_cap_number"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:text="@string/drop_cap_edit_drop_cap_number" />
+
   <EditText
     android:id="@+id/drop_cap_edit_text"
     android:layout_width="match_parent"

--- a/drop-cap/sample/src/main/res/layout/fragment_drop_cap_number_dialog.xml
+++ b/drop-cap/sample/src/main/res/layout/fragment_drop_cap_number_dialog.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <NumberPicker
+    android:id="@+id/drop_cap_number_picker"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_centerHorizontal="true" />
+
+  <LinearLayout
+    style="?android:attr/buttonBarStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_below="@+id/drop_cap_number_picker"
+    android:orientation="horizontal">
+
+    <Button
+      android:id="@+id/drop_cap_number_button_negative"
+      style="?android:attr/buttonBarButtonStyle"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="100"
+      android:text="@string/fragment_cancel" />
+
+    <Button
+      android:id="@+id/drop_cap_number_button_positive"
+      style="?android:attr/buttonBarButtonStyle"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="100"
+      android:text="@string/fragment_set" />
+
+  </LinearLayout>
+
+</RelativeLayout>

--- a/drop-cap/sample/src/main/res/values/drop-cap-integers.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-integers.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <integer name="drop_cap_number">1</integer>
+
+</resources>

--- a/drop-cap/sample/src/main/res/values/drop-cap-strings.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-strings.xml
@@ -68,6 +68,7 @@
   <string name="drop_cap_edit_copy_color">Edit Copy Color</string>
   <string name="drop_cap_edit_drop_cap_typeface">Edit DropCap Typeface</string>
   <string name="drop_cap_edit_copy_typeface">Edit Copy Typeface</string>
+  <string name="drop_cap_edit_drop_cap_number">Edit number of DropCaps</string>
   <string name="drop_cap_update_text">Update text</string>
 
 </resources>

--- a/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
@@ -10,7 +10,7 @@
     <item name="android:paddingRight">@dimen/drop_cap_padding_right</item>
     <item name="android:paddingBottom">@dimen/drop_cap_padding_bottom</item>
     <item name="dropCapTextSize">@dimen/drop_cap_text</item>
-    <item name="dropCapFontPath">fonts/funkrocker.otf</item>
+    <item name="dropCapFontPath">fonts/SANS-SERIF_Cabin-Regular.otf</item>
     <item name="copyTextSize">@dimen/copy_text</item>
     <item name="copyFontPath">fonts/neuropolitical_rg.ttf</item>
     <item name="lineSpacingExtra">@dimen/drop_cap_linespacing_extra</item>

--- a/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
@@ -4,6 +4,7 @@
     parent="Theme.AppCompat.Light.DarkActionBar" />
 
   <style name="DropCap">
+    <item name="numberOfDropCaps">2</item>
     <item name="android:paddingLeft">@dimen/drop_cap_padding_left</item>
     <item name="android:paddingTop">@dimen/drop_cap_padding_top</item>
     <item name="android:paddingRight">@dimen/drop_cap_padding_right</item>

--- a/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
@@ -4,7 +4,6 @@
     parent="Theme.AppCompat.Light.DarkActionBar" />
 
   <style name="DropCap">
-    <item name="numberOfDropCaps">1</item>
     <item name="android:paddingLeft">@dimen/drop_cap_padding_left</item>
     <item name="android:paddingTop">@dimen/drop_cap_padding_top</item>
     <item name="android:paddingRight">@dimen/drop_cap_padding_right</item>

--- a/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
@@ -4,7 +4,7 @@
     parent="Theme.AppCompat.Light.DarkActionBar" />
 
   <style name="DropCap">
-    <item name="numberOfDropCaps">2</item>
+    <item name="numberOfDropCaps">1</item>
     <item name="android:paddingLeft">@dimen/drop_cap_padding_left</item>
     <item name="android:paddingTop">@dimen/drop_cap_padding_top</item>
     <item name="android:paddingRight">@dimen/drop_cap_padding_right</item>

--- a/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-styles.xml
@@ -10,6 +10,7 @@
     <item name="android:paddingRight">@dimen/drop_cap_padding_right</item>
     <item name="android:paddingBottom">@dimen/drop_cap_padding_bottom</item>
     <item name="dropCapTextSize">@dimen/drop_cap_text</item>
+    <item name="numberOfDropCaps">@integer/drop_cap_number</item>
     <item name="dropCapFontPath">fonts/SANS-SERIF_Cabin-Regular.otf</item>
     <item name="copyTextSize">@dimen/copy_text</item>
     <item name="copyFontPath">fonts/neuropolitical_rg.ttf</item>

--- a/drop-cap/sample/src/main/res/values/fragment-dialog-strings.xml
+++ b/drop-cap/sample/src/main/res/values/fragment-dialog-strings.xml
@@ -3,6 +3,7 @@
   <string name="fragment_tag_text_size">text_size_fragment</string>
   <string name="fragment_tag_text_color">text_color_fragment</string>
   <string name="fragment_tag_typeface">typeface_fragment</string>
+  <string name="fragment_tag_drop_cap_number">drop_cap_number_fragment</string>
 
   <string name="fragment_cancel">Cancel</string>
   <string name="fragment_set">Set</string>

--- a/drop-cap/sample/src/main/res/values/fragment-drop-cap-number-dialog-integers.xml
+++ b/drop-cap/sample/src/main/res/values/fragment-drop-cap-number-dialog-integers.xml
@@ -1,0 +1,6 @@
+<resources>
+
+  <integer name="drop_cap_number_picker_min">1</integer>
+  <integer name="drop_cap_number_picker_max">10</integer>
+
+</resources>


### PR DESCRIPTION
#### Problem
As per issue #282 a `DropCap` cannot be applied to more than a single character. The most pressing example where this would be an issue is in the following (pulled from issue), where a normally `DropCapped` character is preceded by a quotation mark.

![image](https://cloud.githubusercontent.com/assets/3380092/24715257/b1974bdc-1a22-11e7-8338-9ab9d4108667.png)

#### Solution
Allow the client to specify the number of characters to `DropCap`. 

In the event that the copy wrapping the `DropCap` cannot fit on the remaining width of the `viewPort` the `DropCap` is not drawn. Typically this will only occur if the client specifies too many `DropCaps` such that the remaining width (to the right of the DropCap) is less than the size of one character of copy text.

#### Screen Captures

Single DropCap | Two DropCaps
---|---
![drop_cap_one](https://cloud.githubusercontent.com/assets/3380092/24722504/d2e4ddea-1a3b-11e7-8749-0158ad3ab5e9.png) | ![drop_cap_two](https://cloud.githubusercontent.com/assets/3380092/24722503/d2dff1e0-1a3b-11e7-9990-e5a071f02b9b.png)

Lots of DropCaps | Not enough room for copy
---|---
![drop_cap_all](https://cloud.githubusercontent.com/assets/3380092/24722529/edcd641a-1a3b-11e7-82df-0e535a8c60b2.png) | ![drop_cap_too_many](https://cloud.githubusercontent.com/assets/3380092/24722530/edcf912c-1a3b-11e7-8757-d336c8bd3c95.png)

