### PR TITLE
Tpbot/Bot presentation in service

### DIFF
--- a/TelepresenceBot/core/src/main/java/com/novoda/tpbot/bot/BotPresenter.java
+++ b/TelepresenceBot/core/src/main/java/com/novoda/tpbot/bot/BotPresenter.java
@@ -11,16 +11,18 @@ class BotPresenter {
 
     private final BotTelepresenceService tpService;
     private final BotView botView;
+    private final String serverAddress;
 
     private Observable<Result> connectionObservable;
     private Observable<Direction> directionObservable;
 
-    BotPresenter(BotTelepresenceService tpService, BotView botView) {
+    BotPresenter(BotTelepresenceService tpService, BotView botView, String serverAddress) {
         this.tpService = tpService;
         this.botView = botView;
+        this.serverAddress = serverAddress;
     }
 
-    void startPresenting(String serverAddress) {
+    void startPresenting() {
         connectionObservable = tpService.connectTo(serverAddress)
                 .attach(new ConnectionObserver())
                 .start();

--- a/TelepresenceBot/core/src/test/java/com/novoda/tpbot/bot/BotPresenterTest.java
+++ b/TelepresenceBot/core/src/test/java/com/novoda/tpbot/bot/BotPresenterTest.java
@@ -34,7 +34,7 @@ public class BotPresenterTest {
 
     @Before
     public void setUp() throws Exception {
-        presenter = new BotPresenter(tpService, botView);
+        presenter = new BotPresenter(tpService, botView, );
 
         when(tpService.listen()).thenReturn(Observable.just(DIRECTION));
     }

--- a/TelepresenceBot/core/src/test/java/com/novoda/tpbot/bot/BotPresenterTest.java
+++ b/TelepresenceBot/core/src/test/java/com/novoda/tpbot/bot/BotPresenterTest.java
@@ -1,8 +1,8 @@
 package com.novoda.tpbot.bot;
 
+import com.novoda.support.Observable;
 import com.novoda.tpbot.Direction;
 import com.novoda.tpbot.Result;
-import com.novoda.support.Observable;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,7 +34,7 @@ public class BotPresenterTest {
 
     @Before
     public void setUp() throws Exception {
-        presenter = new BotPresenter(tpService, botView, );
+        presenter = new BotPresenter(tpService, botView, SERVER_ADDRESS);
 
         when(tpService.listen()).thenReturn(Observable.just(DIRECTION));
     }
@@ -43,7 +43,7 @@ public class BotPresenterTest {
     public void givenSuccessfulConnection_whenStartPresenting_thenBotViewOnConnectIsCalled() {
         when(tpService.connectTo(SERVER_ADDRESS)).thenReturn(Observable.just(SUCCESS_RESULT));
 
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
 
         verify(botView).onConnect(SUCCESS_RESULT.message().get());
     }
@@ -52,7 +52,7 @@ public class BotPresenterTest {
     public void givenUnsuccessfulConnection_whenStartPresenting_thenBotViewOnErrorIsCalled() {
         when(tpService.connectTo(SERVER_ADDRESS)).thenReturn(Observable.just(FAILURE_RESULT));
 
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
 
         verify(botView).onError(FAILURE_RESULT.exception().get().getMessage());
     }
@@ -60,7 +60,7 @@ public class BotPresenterTest {
     @Test
     public void givenAlreadyPresenting_whenStopPresentingIsCalled_thenTpServiceDisconnectIsCalled() {
         when(tpService.connectTo(SERVER_ADDRESS)).thenReturn(Observable.just(SUCCESS_RESULT));
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
 
         presenter.stopPresenting();
 
@@ -72,7 +72,7 @@ public class BotPresenterTest {
         Observable<Result> observable = Observable.just(SUCCESS_RESULT);
         Observable<Result> spyObservable = Mockito.spy(observable);
         when(tpService.connectTo(SERVER_ADDRESS)).thenReturn(spyObservable);
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
 
         presenter.stopPresenting();
 
@@ -83,7 +83,7 @@ public class BotPresenterTest {
     public void givenSuccessfulConnection_whenStartPresenting_thenStartsListeningForDirections() {
         when(tpService.connectTo(SERVER_ADDRESS)).thenReturn(Observable.just(SUCCESS_RESULT));
 
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
 
         verify(tpService).listen();
     }
@@ -92,7 +92,7 @@ public class BotPresenterTest {
     public void givenUnsuccessfulConnection_whenStartPresenting_thenDoesNotStartListeningForDirections() {
         when(tpService.connectTo(SERVER_ADDRESS)).thenReturn(Observable.just(FAILURE_RESULT));
 
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
 
         verify(tpService, never()).listen();
     }
@@ -101,7 +101,7 @@ public class BotPresenterTest {
     public void givenStartedListeningForDirections_whenDirectionIsEmitted_thenBotViewMoveInDirectionIsCalled() {
         givenStartedListeningForDirections();
 
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
 
         verify(botView).moveIn(DIRECTION);
     }
@@ -110,7 +110,7 @@ public class BotPresenterTest {
     public void givenStartedListeningForDirections_whenStopPresentingIsCalled_thenDirectionObservableObserversAreDetached() {
         Observable<Direction> spyObservable = givenStartedListeningForDirections();
 
-        presenter.startPresenting(SERVER_ADDRESS);
+        presenter.startPresenting();
         presenter.stopPresenting();
 
         verify(spyObservable).detachObservers();

--- a/TelepresenceBot/mobile/src/main/AndroidManifest.xml
+++ b/TelepresenceBot/mobile/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
     android:theme="@style/AppTheme"
     tools:ignore="AllowBackup,GoogleAppIndexingWarning">
 
-    <service android:name="com.novoda.tpbot.automation.HangoutJoinerAutomationService"
+    <service
+      android:name="com.novoda.tpbot.automation.HangoutJoinerAutomationService"
       android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
       <intent-filter>
         <action android:name="android.accessibilityservice.AccessibilityService" />
@@ -58,6 +59,10 @@
 
     <service
       android:name="com.novoda.tpbot.bot.MovementService"
+      android:exported="false" />
+
+    <service
+      android:name="com.novoda.tpbot.bot.BotService"
       android:exported="false" />
 
   </application>

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
@@ -12,7 +12,6 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.provider.Settings;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -105,7 +104,6 @@ public class BotActivity extends AppCompatActivity implements BotView {
             debugView.showPermanently(getString(R.string.connecting_ellipsis));
             botServiceCreator = new BotServiceCreator(getApplicationContext(), BotActivity.this, serverAddress);
             botServiceCreator.create();
-            Log.e(getClass().getSimpleName(), "onConnect()");
         }
     };
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotService.java
@@ -6,59 +6,36 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.util.Log;
 
-import com.novoda.support.Observer;
-import com.novoda.tpbot.Result;
-
 public class BotService extends Service {
 
     private final IBinder binder = new BotServiceBinder();
 
-    private BotTelepresenceService botTelepresenceService;
-    private BotView botView;
+    private BotPresenter botPresenter;
 
     @Override
     public IBinder onBind(Intent intent) {
         return binder;
     }
 
-    private void connectTo(String serverAddress) {
-        botTelepresenceService.connectTo(serverAddress)
-                .attach(new ConnectionObserver())
-                .start();
-    }
-
-    private class ConnectionObserver implements Observer<Result> {
-
-        @Override
-        public void update(Result result) {
-            if (result.isError()) {
-                botView.onError(result.exception().get().getMessage());
-            } else {
-                botView.onConnect(result.message().get());
-            }
-        }
-
+    private void start() {
+        botPresenter.startPresenting();
     }
 
     @Override
-    public void onDestroy() {
-        botTelepresenceService.disconnect();
-        Log.e(getClass().getSimpleName(), "onDestroy()");
-        super.onDestroy();
+    public boolean onUnbind(Intent intent) {
+        Log.e(getClass().getSimpleName(), "onUnbind");
+        botPresenter.stopPresenting();
+        return super.onUnbind(intent);
     }
 
     class BotServiceBinder extends Binder {
 
-        void setBotTelepresenceService(BotTelepresenceService botTelepresenceService) {
-            BotService.this.botTelepresenceService = botTelepresenceService;
+        void setBotPresenter(BotPresenter botPresenter) {
+            BotService.this.botPresenter = botPresenter;
         }
 
-        void setBotView(BotView botView) {
-            BotService.this.botView = botView;
-        }
-
-        void startConnection(String serverAddress) {
-            BotService.this.connectTo(serverAddress);
+        void onDependenciesBound() {
+            BotService.this.start();
         }
 
     }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotService.java
@@ -4,7 +4,6 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.IBinder;
-import android.util.Log;
 
 public class BotService extends Service {
 
@@ -23,7 +22,6 @@ public class BotService extends Service {
 
     @Override
     public boolean onUnbind(Intent intent) {
-        Log.e(getClass().getSimpleName(), "onUnbind");
         botPresenter.stopPresenting();
         return super.onUnbind(intent);
     }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotService.java
@@ -1,0 +1,63 @@
+package com.novoda.tpbot.bot;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.novoda.support.Observable;
+import com.novoda.support.Observer;
+import com.novoda.tpbot.Result;
+
+import static com.novoda.support.Observable.unsubscribe;
+
+public class BotService extends IntentService {
+
+    private static final String EXTRA_SERVER_ADDRESS = "EXTRA_SERVER_ADDRESS";
+
+    private BotTelepresenceService botTelepresenceService;
+    private Observable<Result> connectionObservable;
+
+    /**
+     * Creates an IntentService.  Invoked by your subclass's constructor.
+     *
+     * @param name Used to name the worker thread, important only for debugging.
+     */
+    public BotService(String name) {
+        super(name);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        botTelepresenceService = SocketIOTelepresenceService.getInstance();
+    }
+
+    @Override
+    public void onDestroy() {
+        unsubscribe(connectionObservable);
+        botTelepresenceService.disconnect();
+        super.onDestroy();
+    }
+
+    @Override
+    protected void onHandleIntent(@Nullable Intent intent) {
+        if (intent != null && intent.hasExtra(EXTRA_SERVER_ADDRESS)) {
+            String serverAddress = intent.getStringExtra(EXTRA_SERVER_ADDRESS);
+
+            connectionObservable = botTelepresenceService.connectTo(serverAddress)
+                    .attach(new ConnectionObserver())
+                    .start();
+        }
+    }
+
+    private class ConnectionObserver implements Observer<Result> {
+
+        @Override
+        public void update(Result result) {
+            Log.e(getClass().getSimpleName(), "Pass to movement service: " + result);
+        }
+
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotServiceCreator.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotServiceCreator.java
@@ -1,0 +1,49 @@
+package com.novoda.tpbot.bot;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.util.Log;
+
+public class BotServiceCreator {
+
+    private final Context context;
+    private final BotView botView;
+    private final String serverAddress;
+
+    public BotServiceCreator(Context context, BotView botView, String serverAddress) {
+        this.context = context;
+        this.botView = botView;
+        this.serverAddress = serverAddress;
+    }
+
+    private final ServiceConnection botServiceConnection = new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName componentName, IBinder iBinder) {
+            BotService.BotServiceBinder binder = (BotService.BotServiceBinder) iBinder;
+            BotPresenter botPresenter = new BotPresenter(SocketIOTelepresenceService.getInstance(), botView, serverAddress);
+            binder.setBotPresenter(botPresenter);
+            binder.onDependenciesBound();
+            Log.e(getClass().getSimpleName(), "onServiceConnected");
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName componentName) {
+
+        }
+    };
+
+    public void create() {
+        Intent botServiceIntent = new Intent(context, BotService.class);
+        context.bindService(botServiceIntent, botServiceConnection, Context.BIND_AUTO_CREATE);
+    }
+
+    public void destroy() {
+        context.unbindService(botServiceConnection);
+        context.stopService(new Intent(context, BotService.class));
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotServiceCreator.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotServiceCreator.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
-import android.util.Log;
 
 public class BotServiceCreator {
 
@@ -27,7 +26,6 @@ public class BotServiceCreator {
             BotPresenter botPresenter = new BotPresenter(SocketIOTelepresenceService.getInstance(), botView, serverAddress);
             binder.setBotPresenter(botPresenter);
             binder.onDependenciesBound();
-            Log.e(getClass().getSimpleName(), "onServiceConnected");
         }
 
         @Override

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotServiceCreator.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotServiceCreator.java
@@ -6,16 +6,21 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 
-public class BotServiceCreator {
+class BotServiceCreator {
 
     private final Context context;
     private final BotView botView;
     private final String serverAddress;
 
-    public BotServiceCreator(Context context, BotView botView, String serverAddress) {
+    BotServiceCreator(Context context, BotView botView, String serverAddress) {
         this.context = context;
         this.botView = botView;
         this.serverAddress = serverAddress;
+    }
+
+    void create() {
+        Intent botServiceIntent = new Intent(context, BotService.class);
+        context.bindService(botServiceIntent, botServiceConnection, Context.BIND_AUTO_CREATE);
     }
 
     private final ServiceConnection botServiceConnection = new ServiceConnection() {
@@ -34,12 +39,7 @@ public class BotServiceCreator {
         }
     };
 
-    public void create() {
-        Intent botServiceIntent = new Intent(context, BotService.class);
-        context.bindService(botServiceIntent, botServiceConnection, Context.BIND_AUTO_CREATE);
-    }
-
-    public void destroy() {
+    void destroy() {
         context.unbindService(botServiceConnection);
         context.stopService(new Intent(context, BotService.class));
     }


### PR DESCRIPTION
#### Problem
The `Bot` is able to automatically open a `hangout` when connected to the middleman server. When opening the `hangout` the `BotActivity` is torn down including any necessary presenters. Tearing down the presentation layer of the `Bot` automatically disconnects said `Bot` from the middleman server. 

#### Solution
Create a `BoundService` and perform all `Bot` actions in this service. For now, only the logic related to connecting and listening for moves has been moved. In the next PR the movement service will be added to the `BoundService` rather than having two independent services (if possible).
The unbinding of the `BotService` is performed in `onDestroy` ensuring that the service lives even when the app is moved to the background (similar how multi-window is handled). 

#### Screen Capture
No updates.