### PR TITLE
DropCap/ Padding ignored

### DIFF
--- a/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
+++ b/drop-cap/library/src/main/java/com/novoda/dropcap/DropCapView.java
@@ -235,14 +235,14 @@ public class DropCapView extends View {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         int totalWidth = MeasureSpec.getSize(widthMeasureSpec);
         int horizontalPadding = getPaddingLeft() + getPaddingRight();
-        int widthWithoutPadding = totalWidth - horizontalPadding;
+        int allowedWidth = totalWidth - horizontalPadding;
 
-        measureDropCapFor(widthWithoutPadding);
+        measureDropCapFor(allowedWidth);
 
         if (canDrawDropCap) {
-            measureRemainingCopyFor(totalWidth);
+            measureRemainingCopyFor(allowedWidth);
         } else {
-            measureWholeTextFor(totalWidth);
+            measureWholeTextFor(allowedWidth);
         }
 
         int desiredHeight = dropCapLineHeight + copyStaticLayout.getHeight() + getPaddingTop() + getPaddingBottom();

--- a/drop-cap/sample/src/main/res/values/drop-cap-dimens.xml
+++ b/drop-cap/sample/src/main/res/values/drop-cap-dimens.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <dimen name="drop_cap_padding_left">0dp</dimen>
-  <dimen name="drop_cap_padding_top">0dp</dimen>
-  <dimen name="drop_cap_padding_right">0dp</dimen>
-  <dimen name="drop_cap_padding_bottom">0dp</dimen>
+  <dimen name="drop_cap_padding_left">10dp</dimen>
+  <dimen name="drop_cap_padding_top">10dp</dimen>
+  <dimen name="drop_cap_padding_right">10dp</dimen>
+  <dimen name="drop_cap_padding_bottom">10dp</dimen>
 
   <dimen name="drop_cap_text">64sp</dimen>
   <dimen name="copy_text">21sp</dimen>


### PR DESCRIPTION
#### Problem
`DropCapView` ignores padding rules even when a padding is supplied. When creating the `StaticLayouts` the `DropCapView` was using `totalWidth` rather than the `allowedWidth` which is the `totalWidth - horizonalPadding`.

#### Solution
Use `allowedWidth` for creation of all `StaticLayouts`.

#### Screen Capture

Before | After
--- | ---
![default](https://cloud.githubusercontent.com/assets/3380092/24837442/3254db2a-1d2c-11e7-865c-781d578ec1dd.png) | ![padding_left](https://cloud.githubusercontent.com/assets/3380092/24837443/325bd114-1d2c-11e7-9d89-8e814bb53426.png)
