### PR TITLE
Tpbot/ Testable Movement Service

### DIFF
--- a/TelepresenceBot/mobile/src/main/AndroidManifest.xml
+++ b/TelepresenceBot/mobile/src/main/AndroidManifest.xml
@@ -58,7 +58,7 @@
     </receiver>
 
     <service
-      android:name="com.novoda.tpbot.bot.MovementService"
+      android:name="com.novoda.tpbot.bot.AndroidMovementService"
       android:exported="false" />
 
     <service

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
@@ -47,15 +47,25 @@ public class AndroidMovementService extends Service implements MovementService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        createBroadcastReceiver();
+        startConnection();
+        return START_STICKY;
+    }
+
+    private void createBroadcastReceiver() {
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         registerReceiver(broadcastReceiver, filter);
-
-        startConnection();
-
-        return START_STICKY;
     }
+
+    private final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            MovementServiceIntentHandler.IntentHandler intentHandler = MovementServiceIntentHandler.get(intent.getAction());
+            intentHandler.handle(intent, AndroidMovementService.this);
+        }
+    };
 
     private void startConnection() {
         if (isSerialStarted) {
@@ -90,14 +100,6 @@ public class AndroidMovementService extends Service implements MovementService {
     private boolean isSupportedDeviceID(int deviceVID) {
         return SUPPORTED_VENDOR_IDS.contains(deviceVID);
     }
-
-    private final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            MovementServiceIntentHandler.IntentHandler intentHandler = MovementServiceIntentHandler.get(intent.getAction());
-            intentHandler.handle(intent, AndroidMovementService.this);
-        }
-    };
 
     @Override
     public void onPermissionGranted() {

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MovementService extends Service {
+public class AndroidMovementService extends Service {
 
     private static final String SERIAL_TAG = "SERIAL";
 
@@ -42,8 +42,8 @@ public class MovementService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        toaster = Toaster.newInstance(MovementService.this);
-        toaster.popToast(MovementService.class.getSimpleName() + " started");
+        toaster = Toaster.newInstance(AndroidMovementService.this);
+        toaster.popToast(AndroidMovementService.class.getSimpleName() + " started");
     }
 
     @Override
@@ -95,6 +95,8 @@ public class MovementService extends Service {
     private final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
+            MovementServiceIntentHandler intentHandler = new MovementServiceIntentHandler(this);
+
             if (intent.getAction().equals(ACTION_USB_PERMISSION)) {
                 boolean permissionGranted = intent.getExtras().getBoolean(UsbManager.EXTRA_PERMISSION_GRANTED);
                 if (permissionGranted) {
@@ -113,6 +115,14 @@ public class MovementService extends Service {
             }
         }
     };
+
+    private interface MovementServiceFoo {
+        void setupSerialPort();
+
+        void startConnection();
+
+        void closeConnection();
+    }
 
     private void setupSerialPort() {
         connection = usbManager.openDevice(device);
@@ -193,13 +203,13 @@ public class MovementService extends Service {
     }
 
     public static class Binder extends android.os.Binder {
-        private final MovementService service;
+        private final AndroidMovementService service;
 
-        Binder(MovementService service) {
+        Binder(AndroidMovementService service) {
             this.service = service;
         }
 
-        public MovementService getService() {
+        public AndroidMovementService getService() {
             return service;
         }
     }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
@@ -34,7 +34,8 @@ public class AndroidMovementService extends Service implements MovementService {
 
         usbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
         supportedDeviceRetriever = new SupportedDeviceRetriever(usbManager);
-        serialPortMonitor = new SerialPortMonitor(usbManager, dataReceiver);
+        SerialPortCreator serialPortCreator = new SerialPortCreator();
+        serialPortMonitor = new SerialPortMonitor(usbManager, dataReceiver, serialPortCreator);
     }
 
     @Override
@@ -112,7 +113,7 @@ public class AndroidMovementService extends Service implements MovementService {
     }
 
     public void sendCommand(String command) {
-        serialPortMonitor.trySendCommand(command);
+        serialPortMonitor.tryToSendCommand(command);
     }
 
     @Override

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
@@ -78,7 +78,7 @@ public class AndroidMovementService extends Service implements MovementService {
     private final SerialPortMonitor.DataReceiver dataReceiver = new SerialPortMonitor.DataReceiver() {
         @Override
         public void onReceive(String data) {
-
+            // TODO: forward feedback to the UI.
         }
     };
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/AndroidMovementService.java
@@ -35,7 +35,6 @@ public class AndroidMovementService extends Service implements MovementService {
     private UsbManager usbManager;
     private UsbSerialDevice serialPort;
     private boolean isSerialStarted;
-    private PendingIntent pendingIntent;
 
     private Toaster toaster;
 
@@ -48,7 +47,6 @@ public class AndroidMovementService extends Service implements MovementService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        pendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
@@ -76,6 +74,7 @@ public class AndroidMovementService extends Service implements MovementService {
             int deviceVID = device.getVendorId();
 
             if (isSupportedDeviceID(deviceVID)) {
+                PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
                 usbManager.requestPermission(device, pendingIntent);
                 supportedDeviceFound = true;
                 break;

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
@@ -179,7 +179,9 @@ public class BotActivity extends AppCompatActivity implements BotView {
 
     @Override
     protected void onDestroy() {
-        botServiceCreator.destroy();
+        if (botServiceCreator != null) {
+            botServiceCreator.destroy();
+        }
         super.onDestroy();
     }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/BotActivity.java
@@ -39,7 +39,7 @@ public class BotActivity extends AppCompatActivity implements BotView {
     private SelfDestructingMessageView debugView;
     private SwitchableView switchableView;
 
-    private MovementService movementService;
+    private AndroidMovementService androidMovementService;
     private boolean boundToMovementService;
     private CommandRepeater commandRepeater;
     private AutomationChecker automationChecker;
@@ -111,7 +111,7 @@ public class BotActivity extends AppCompatActivity implements BotView {
         @Override
         public void onCommandRepeated(String command) {
             if (boundToMovementService) {
-                movementService.sendCommand(command);
+                androidMovementService.sendCommand(command);
             }
         }
     };
@@ -119,7 +119,7 @@ public class BotActivity extends AppCompatActivity implements BotView {
     @Override
     protected void onStart() {
         super.onStart();
-        Intent intent = new Intent(this, MovementService.class);
+        Intent intent = new Intent(this, AndroidMovementService.class);
         bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
     }
 
@@ -187,8 +187,8 @@ public class BotActivity extends AppCompatActivity implements BotView {
 
         @Override
         public void onServiceConnected(ComponentName componentName, IBinder iBinder) {
-            MovementService.Binder binder = (MovementService.Binder) iBinder;
-            movementService = binder.getService();
+            AndroidMovementService.Binder binder = (AndroidMovementService.Binder) iBinder;
+            androidMovementService = binder.getService();
             boundToMovementService = true;
         }
 

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
@@ -1,6 +1,7 @@
 package com.novoda.tpbot.bot;
 
 interface MovementService {
+
     void onPermissionGranted();
 
     void onPermissionDenied();
@@ -8,4 +9,5 @@ interface MovementService {
     void onDeviceAttached();
 
     void onDeviceDetached();
+
 }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
@@ -82,6 +82,7 @@ public class MovementService extends Service {
             }
         }
         if (!supportedDeviceFound) {
+            Log.e(SERIAL_TAG, "Device is not in list of supported devices. See SUPPORTED_VENDOR_IDS");
             connection = null;
             device = null;
         }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementService.java
@@ -1,0 +1,11 @@
+package com.novoda.tpbot.bot;
+
+interface MovementService {
+    void onPermissionGranted();
+
+    void onPermissionDenied();
+
+    void onDeviceAttached();
+
+    void onDeviceDetached();
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementServiceIntentHandler.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementServiceIntentHandler.java
@@ -1,0 +1,63 @@
+package com.novoda.tpbot.bot;
+
+import android.content.Intent;
+import android.hardware.usb.UsbManager;
+import android.util.Log;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.novoda.tpbot.bot.AndroidMovementService.ACTION_USB_PERMISSION;
+
+class MovementServiceIntentHandler {
+
+    private static final Map<String, IntentHandler> actionMap = new HashMap<>();
+
+    static {
+        actionMap.put(ACTION_USB_PERMISSION, new IntentHandler() {
+            @Override
+            public void handle(Intent intent, MovementService movementService) {
+                boolean permissionGranted = intent.getExtras().getBoolean(UsbManager.EXTRA_PERMISSION_GRANTED);
+                if (permissionGranted) {
+                    movementService.onPermissionGranted();
+                } else {
+                    movementService.onPermissionDenied();
+                }
+            }
+        });
+
+        actionMap.put(UsbManager.ACTION_USB_DEVICE_ATTACHED, new IntentHandler() {
+            @Override
+            public void handle(Intent intent, MovementService movementService) {
+                movementService.onDeviceAttached();
+            }
+        });
+
+        actionMap.put(UsbManager.ACTION_USB_DEVICE_DETACHED, new IntentHandler() {
+            @Override
+            public void handle(Intent intent, MovementService movementService) {
+                movementService.onDeviceDetached();
+            }
+        });
+    }
+
+    static IntentHandler get(String action) {
+        if (actionMap.containsKey(action)) {
+            return actionMap.get(action);
+        } else {
+            return new LoggingIntentHelper();
+        }
+    }
+
+    interface IntentHandler {
+        void handle(Intent intent, MovementService movementService);
+    }
+
+    private static class LoggingIntentHelper implements IntentHandler {
+
+        @Override
+        public void handle(Intent intent, MovementService movementService) {
+            Log.d(getClass().getSimpleName(), "No associated " + IntentHandler.class.getSimpleName() + " for action: " + intent.getAction());
+        }
+    }
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementServiceIntentHandler.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/MovementServiceIntentHandler.java
@@ -2,7 +2,8 @@ package com.novoda.tpbot.bot;
 
 import android.content.Intent;
 import android.hardware.usb.UsbManager;
-import android.util.Log;
+
+import com.novoda.notils.exception.DeveloperError;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +46,7 @@ class MovementServiceIntentHandler {
         if (actionMap.containsKey(action)) {
             return actionMap.get(action);
         } else {
-            return new LoggingIntentHelper();
+            throw new DeveloperError("No associated " + IntentHandler.class.getSimpleName() + " for action: " + action);
         }
     }
 
@@ -53,11 +54,4 @@ class MovementServiceIntentHandler {
         void handle(Intent intent, MovementService movementService);
     }
 
-    private static class LoggingIntentHelper implements IntentHandler {
-
-        @Override
-        public void handle(Intent intent, MovementService movementService) {
-            Log.d(getClass().getSimpleName(), "No associated " + IntentHandler.class.getSimpleName() + " for action: " + intent.getAction());
-        }
-    }
 }

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SerialPortCreator.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SerialPortCreator.java
@@ -1,0 +1,14 @@
+package com.novoda.tpbot.bot;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+
+import com.felhr.usbserial.UsbSerialDevice;
+
+class SerialPortCreator {
+
+    UsbSerialDevice create(UsbDevice usbDevice, UsbDeviceConnection connection) {
+        return UsbSerialDevice.createUsbSerialDevice(usbDevice, connection);
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SerialPortMonitor.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SerialPortMonitor.java
@@ -1,0 +1,64 @@
+package com.novoda.tpbot.bot;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbManager;
+
+import com.felhr.usbserial.UsbSerialDevice;
+import com.felhr.usbserial.UsbSerialInterface;
+import com.novoda.notils.exception.DeveloperError;
+import com.novoda.notils.logger.simple.Log;
+
+import java.io.UnsupportedEncodingException;
+
+class SerialPortMonitor {
+
+    private final UsbManager usbManager;
+    private final DataReceiver dataReceiver;
+
+    SerialPortMonitor(UsbManager usbManager, DataReceiver dataReceiver) {
+        this.usbManager = usbManager;
+        this.dataReceiver = dataReceiver;
+    }
+
+    boolean tryToMonitorSerialPortFor(UsbDevice usbDevice) {
+        if (usbDevice == null || UsbSerialDevice.isCdcDevice(usbDevice)) {
+            Log.d(getClass().getSimpleName(), "CdcDevice is not supported");
+            return false;
+        }
+
+        UsbDeviceConnection deviceConnection = usbManager.openDevice(usbDevice);
+        UsbSerialDevice serialPort = UsbSerialDevice.createUsbSerialDevice(usbDevice, deviceConnection);
+
+        if (serialPort.open()) {
+            serialPort.setBaudRate(9600);
+            serialPort.setDataBits(UsbSerialInterface.DATA_BITS_8);
+            serialPort.setStopBits(UsbSerialInterface.STOP_BITS_1);
+            serialPort.setParity(UsbSerialInterface.PARITY_NONE);
+            serialPort.setFlowControl(UsbSerialInterface.FLOW_CONTROL_OFF);
+            serialPort.read(onDataReceivedListener);
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+    private UsbSerialInterface.UsbReadCallback onDataReceivedListener = new UsbSerialInterface.UsbReadCallback() {
+        @Override
+        public void onReceivedData(byte[] arg0) {
+            String data = null;
+            try {
+                data = new String(arg0, "UTF-8");
+                dataReceiver.onReceive(data);
+            } catch (UnsupportedEncodingException e) {
+                throw new DeveloperError("Error receiving data from USB serial.");
+            }
+        }
+    };
+
+    public interface DataReceiver {
+        void onReceive(String data);
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SerialPortMonitor.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SerialPortMonitor.java
@@ -60,6 +60,16 @@ class SerialPortMonitor {
         }
     };
 
+    boolean trySendCommand(String command) {
+        if (serialPort == null) {
+            Log.d(getClass().getSimpleName(), "Not connected to SerialPort, unable to send command: " + command);
+            return false;
+        }
+
+        serialPort.write(command.getBytes());
+        return true;
+    }
+
     void stopMonitoring() {
         if (serialPort != null) {
             serialPort.close();
@@ -70,16 +80,6 @@ class SerialPortMonitor {
             deviceConnection.close();
             deviceConnection = null;
         }
-    }
-
-    boolean trySendCommand(String command) {
-        if (serialPort == null) {
-            Log.d(getClass().getSimpleName(), "Not connected to SerialPort, unable to send command: " + command);
-            return false;
-        }
-
-        serialPort.write(command.getBytes());
-        return true;
     }
 
     interface DataReceiver {

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SupportedDeviceRetriever.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SupportedDeviceRetriever.java
@@ -6,7 +6,6 @@ import android.hardware.usb.UsbManager;
 import com.novoda.support.Optional;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -21,10 +20,9 @@ class SupportedDeviceRetriever {
     }
 
     Optional<UsbDevice> retrieveFirstSupportedUsbDevice() {
-        HashMap<String, UsbDevice> usbDevices = usbManager.getDeviceList();
+        Map<String, UsbDevice> usbDevices = usbManager.getDeviceList();
 
-        for (Map.Entry<String, UsbDevice> usbDeviceEntry : usbDevices.entrySet()) {
-            UsbDevice usbDevice = usbDeviceEntry.getValue();
+        for (UsbDevice usbDevice : usbDevices.values()) {
             int deviceVID = usbDevice.getVendorId();
 
             if (isSupportedDeviceID(deviceVID)) {

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SupportedDeviceRetriever.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/SupportedDeviceRetriever.java
@@ -1,0 +1,42 @@
+package com.novoda.tpbot.bot;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+
+import com.novoda.support.Optional;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class SupportedDeviceRetriever {
+
+    private static final List<Integer> SUPPORTED_VENDOR_IDS = Arrays.asList(9025, 10755, 4292); // TODO: read from devices_filter.xml
+
+    private final UsbManager usbManager;
+
+    SupportedDeviceRetriever(UsbManager usbManager) {
+        this.usbManager = usbManager;
+    }
+
+    Optional<UsbDevice> retrieveFirstSupportedUsbDevice() {
+        HashMap<String, UsbDevice> usbDevices = usbManager.getDeviceList();
+
+        for (Map.Entry<String, UsbDevice> usbDeviceEntry : usbDevices.entrySet()) {
+            UsbDevice usbDevice = usbDeviceEntry.getValue();
+            int deviceVID = usbDevice.getVendorId();
+
+            if (isSupportedDeviceID(deviceVID)) {
+                return Optional.of(usbDevice);
+            }
+        }
+
+        return Optional.absent();
+    }
+
+    private boolean isSupportedDeviceID(int deviceVID) {
+        return SUPPORTED_VENDOR_IDS.contains(deviceVID);
+    }
+
+}

--- a/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/UsbReceiver.java
+++ b/TelepresenceBot/mobile/src/main/java/com/novoda/tpbot/bot/UsbReceiver.java
@@ -8,7 +8,7 @@ import android.hardware.usb.UsbManager;
 public class UsbReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-        Intent movementService = new Intent(context.getApplicationContext(), MovementService.class);
+        Intent movementService = new Intent(context.getApplicationContext(), AndroidMovementService.class);
         if (usbConnected(intent)) {
             context.startService(movementService);
         } else if (usbDisconnected(intent)) {

--- a/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/bot/MovementServiceIntentHandlerTest.java
+++ b/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/bot/MovementServiceIntentHandlerTest.java
@@ -1,0 +1,81 @@
+package com.novoda.tpbot.bot;
+
+import android.content.Intent;
+import android.hardware.usb.UsbManager;
+import android.os.Bundle;
+
+import com.novoda.notils.exception.DeveloperError;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+public class MovementServiceIntentHandlerTest {
+
+    private static final String ACTION_USB_PERMISSION = "com.novoda.tpbot.USB_PERMISSION";
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    Intent intent;
+    @Mock
+    Bundle bundle;
+    @Mock
+    MovementService movementService;
+
+    @Before
+    public void setUp() {
+        given(intent.getExtras()).willReturn(bundle);
+    }
+
+    @Test
+    public void givenPermissionAction_andPermissionIsGranted_whenHandlingIntent_thenGrantsPermission() {
+        given(bundle.getBoolean(UsbManager.EXTRA_PERMISSION_GRANTED)).willReturn(true);
+        MovementServiceIntentHandler.IntentHandler handler = MovementServiceIntentHandler.get(ACTION_USB_PERMISSION);
+
+        handler.handle(intent, movementService);
+
+        verify(movementService).onPermissionGranted();
+    }
+
+    @Test
+    public void givenPermissionAction_andPermissionIsDenied_whenHandlingIntent_thenDeniesPermission() {
+        given(bundle.getBoolean(UsbManager.EXTRA_PERMISSION_GRANTED)).willReturn(false);
+        MovementServiceIntentHandler.IntentHandler handler = MovementServiceIntentHandler.get(ACTION_USB_PERMISSION);
+
+        handler.handle(intent, movementService);
+
+        verify(movementService).onPermissionDenied();
+    }
+
+    @Test
+    public void givenDeviceAttachedAction_whenHandlingIntent_thenAttachesDevice() {
+        MovementServiceIntentHandler.IntentHandler handler = MovementServiceIntentHandler.get(UsbManager.ACTION_USB_DEVICE_ATTACHED);
+
+        handler.handle(intent, movementService);
+
+        verify(movementService).onDeviceAttached();
+    }
+
+    @Test
+    public void givenDeviceDetachedAction_whenHandlingIntent_thenDetachesDevice() {
+        MovementServiceIntentHandler.IntentHandler handler = MovementServiceIntentHandler.get(UsbManager.ACTION_USB_DEVICE_DETACHED);
+
+        handler.handle(intent, movementService);
+
+        verify(movementService).onDeviceDetached();
+    }
+
+    @Test(expected = DeveloperError.class)
+    public void whenRetrievingHandler_withUnknownAction_thenThrowsDeveloperError() {
+        MovementServiceIntentHandler.get("unknown action");
+    }
+
+}

--- a/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/bot/SerialPortMonitorTest.java
+++ b/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/bot/SerialPortMonitorTest.java
@@ -1,0 +1,192 @@
+package com.novoda.tpbot.bot;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbManager;
+
+import com.felhr.usbserial.UsbSerialDevice;
+import com.felhr.usbserial.UsbSerialInterface;
+import com.novoda.notils.logger.simple.Log;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+public class SerialPortMonitorTest {
+
+    private static final String ANY_DATA = "any data";
+    private static final String ANY_COMMAND = "w";
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private UsbManager usbManager;
+    @Mock
+    private SerialPortMonitor.DataReceiver dataReceiver;
+    @Mock
+    private SerialPortCreator serialPortCreator;
+
+    @Mock
+    private UsbDevice usbDevice;
+    @Mock
+    private UsbSerialDevice usbSerialPort;
+    @Mock
+    private UsbDeviceConnection usbDeviceConnection;
+
+    private SerialPortMonitor serialPortMonitor;
+
+    @Before
+    public void setUp() {
+        Log.setShowLogs(false);
+        serialPortMonitor = new SerialPortMonitor(usbManager, dataReceiver, serialPortCreator);
+    }
+
+    @Test
+    public void givenUnableToOpenDevice_whenTryingToMonitorSerialPort_thenReturnsFalse() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(null);
+
+        boolean monitoring = serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        assertThat(monitoring).isFalse();
+    }
+
+    @Test
+    public void givenAbleToOpenDevice_butUnableToCreateSerialPort_whenTryingToMonitorSerialPort_thenReturnsFalse() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(null);
+
+        boolean monitoring = serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        assertThat(monitoring).isFalse();
+    }
+
+    @Test
+    public void givenAbleToOpenDevice_butUnableToCreateSerialPort_whenTryingToMonitorSerialPort_thenClosesDeviceConnection() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(null);
+
+        serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        verify(usbDeviceConnection).close();
+    }
+
+    @Test
+    public void givenUnableToOpenSerialPort_whenTryingToMonitorSerialPort_thenReturnsFalse() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(usbSerialPort);
+        given(usbSerialPort.open()).willReturn(false);
+
+        boolean monitoring = serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        assertThat(monitoring).isFalse();
+    }
+
+    @Test
+    public void givenUnableToOpenSerialPort_whenTryingToMonitorSerialPort_thenClosesDeviceConnection() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(usbSerialPort);
+        given(usbSerialPort.open()).willReturn(false);
+
+        serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        verify(usbDeviceConnection).close();
+    }
+
+    @Test
+    public void givenAbleToOpenSerialPort_whenTryingToMonitorSerialPort_thenReturnsTrue() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(usbSerialPort);
+        given(usbSerialPort.open()).willReturn(true);
+
+        boolean monitoring = serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        assertThat(monitoring).isTrue();
+    }
+
+    @Test
+    public void givenAbleToOpenSerialPort_whenTryingToMonitorSerialPort_andDataIsReceived_thenDataIsRecieved() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(usbSerialPort);
+        given(usbSerialPort.open()).willReturn(true);
+
+        serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        ArgumentCaptor<UsbSerialInterface.UsbReadCallback> argumentCaptor = ArgumentCaptor.forClass(UsbSerialInterface.UsbReadCallback.class);
+        verify(usbSerialPort).read(argumentCaptor.capture());
+        argumentCaptor.getValue().onReceivedData(ANY_DATA.getBytes());
+        verify(dataReceiver).onReceive(ANY_DATA);
+    }
+
+    @Test
+    public void givenUnableToOpenSerialPort_whenTryingToMonitorSerialPort_thenClosesSerialPort() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(usbSerialPort);
+        given(usbSerialPort.open()).willReturn(false);
+
+        serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+
+        verify(usbSerialPort).close();
+    }
+
+    @Test
+    public void givenSerialPortIsNotConnected_whenTryingToSendCommand_thenReturnsFalse() {
+
+        boolean commandSent = serialPortMonitor.tryToSendCommand(ANY_COMMAND);
+
+        assertThat(commandSent).isFalse();
+    }
+
+    @Test
+    public void givenSerialPortIsConnected_whenTryingToSendCommand_thenReturnsFalse() {
+        givenSerialPortIsConnected();
+
+        boolean commandSent = serialPortMonitor.tryToSendCommand(ANY_COMMAND);
+
+        assertThat(commandSent).isTrue();
+    }
+
+    @Test
+    public void givenSerialPortIsConnected_whenTryingToSendCommand_thenWritesCommandToSerialPort() {
+        givenSerialPortIsConnected();
+
+        serialPortMonitor.tryToSendCommand(ANY_COMMAND);
+
+        verify(usbSerialPort).write(ANY_COMMAND.getBytes());
+    }
+
+    @Test
+    public void givenSerialPortIsConnected_whenStopping_thenClosesSerialPort() {
+        givenSerialPortIsConnected();
+
+        serialPortMonitor.stopMonitoring();
+
+        verify(usbSerialPort).close();
+    }
+
+    @Test
+    public void givenSerialPortIsConnected_whenStopping_thenClosesDeviceConnection() {
+        givenSerialPortIsConnected();
+
+        serialPortMonitor.stopMonitoring();
+
+        verify(usbDeviceConnection).close();
+    }
+
+    private void givenSerialPortIsConnected() {
+        given(usbManager.openDevice(any(UsbDevice.class))).willReturn(usbDeviceConnection);
+        given(serialPortCreator.create(any(UsbDevice.class), any(UsbDeviceConnection.class))).willReturn(usbSerialPort);
+        given(usbSerialPort.open()).willReturn(true);
+
+        serialPortMonitor.tryToMonitorSerialPortFor(usbDevice);
+    }
+}

--- a/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/bot/SupportedDeviceRetrieverTest.java
+++ b/TelepresenceBot/mobile/src/test/java/com/novoda/tpbot/bot/SupportedDeviceRetrieverTest.java
@@ -1,0 +1,68 @@
+package com.novoda.tpbot.bot;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+
+import com.novoda.support.Optional;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+public class SupportedDeviceRetrieverTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    UsbManager usbManager;
+
+    private SupportedDeviceRetriever supportedDeviceRetriever;
+
+    @Before
+    public void setUp() {
+        supportedDeviceRetriever = new SupportedDeviceRetriever(usbManager);
+    }
+
+    @Test
+    public void givenEmptyDeviceList_whenRetrievingFirstSupportedDevice_thenReturnsAbsent() {
+        given(usbManager.getDeviceList()).willReturn(new HashMap<String, UsbDevice>());
+
+        Optional<UsbDevice> usbDevice = supportedDeviceRetriever.retrieveFirstSupportedUsbDevice();
+
+        assertThat(usbDevice.isPresent()).isFalse();
+    }
+
+    @Test
+    public void givenDeviceList_withMultipleSupportedDevices_whenRetrievingFirstSupportedDevice_thenReturnsFirstSupportedDevice() {
+        UsbDevice expectedUsbDevice = givenDeviceListWithMultipleSupportedDevices();
+
+        Optional<UsbDevice> usbDevice = supportedDeviceRetriever.retrieveFirstSupportedUsbDevice();
+
+        assertThat(usbDevice.get()).isEqualTo(expectedUsbDevice);
+    }
+
+    private UsbDevice givenDeviceListWithMultipleSupportedDevices() {
+        UsbDevice usbDeviceOne = Mockito.mock(UsbDevice.class);
+        given(usbDeviceOne.getVendorId()).willReturn(9025);
+        UsbDevice usbDeviceTwo = Mockito.mock(UsbDevice.class);
+        given(usbDeviceTwo.getVendorId()).willReturn(10755);
+
+        HashMap<String, UsbDevice> usbDevices = new HashMap<>();
+        usbDevices.put("one", usbDeviceOne);
+        usbDevices.put("two", usbDeviceTwo);
+
+        given(usbManager.getDeviceList()).willReturn(usbDevices);
+        return usbDeviceOne;
+    }
+
+}


### PR DESCRIPTION
#### Problem
In order for the `Bot` to work completely in the background, we need to move the `MovementService` to be a bound service that is destroyed in `onDestroy`. Unfortunately, I don't know how the `MovementService` works 😆 

#### Solution
Pull out testable collaborators for the `MovementService` and test them! In a follow-up PR we should be able to move everything to be in a bound service where the `BotService` forwards commands it receives to this `Service` 😄 