### PR TITLE
[piano-hero] Replace KeyListener with NoteListener and plug midi support into Piano...Activity

### DIFF
--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/AndroidThingsActivity.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/AndroidThingsActivity.java
@@ -7,19 +7,24 @@ import android.util.Log;
 
 public class AndroidThingsActivity extends AppCompatActivity {
 
+    private final SimplePitchNotationFormatter simplePitchNotationFormatter = new SimplePitchNotationFormatter();
     private MidiKeyboardDriver midiKeyboardDriver;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Log.d("!!!", "I'm running");
-
         midiKeyboardDriver = new MidiKeyboardDriver.KeyStationMini32(this);
-        midiKeyboardDriver.attachListener(new MidiKeyboardDriver.KeyListener() {
+        midiKeyboardDriver.attachListener(new NoteListener() {
 
             @Override
-            public void onKeyPressed(Note note) {
-                Log.d("!!!", "Note pressed " + note);
+            public void onPress(Note note) {
+                Log.d("!!!", "Note pressed " + simplePitchNotationFormatter.format(note));
+            }
+
+            @Override
+            public void onRelease(Note note) {
+                Log.d("!!!", "Note released " + simplePitchNotationFormatter.format(note));
             }
         });
         midiKeyboardDriver.open();
@@ -30,4 +35,5 @@ public class AndroidThingsActivity extends AppCompatActivity {
         super.onDestroy();
         midiKeyboardDriver.close();
     }
+
 }

--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/AndroidThingsActivity.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/AndroidThingsActivity.java
@@ -18,8 +18,8 @@ public class AndroidThingsActivity extends AppCompatActivity {
         midiKeyboardDriver.attachListener(new MidiKeyboardDriver.KeyListener() {
 
             @Override
-            public void onKeyPressed(MidiKeyboardDriver.Note note) {
-                Log.d("!!!", "note pressed " + note);
+            public void onKeyPressed(Note note) {
+                Log.d("!!!", "Note pressed " + note);
             }
         });
         midiKeyboardDriver.open();

--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/MidiKeyboardDriver.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/MidiKeyboardDriver.java
@@ -3,13 +3,14 @@ package com.novoda.pianohero;
 import android.content.Context;
 import android.hardware.usb.UsbDevice;
 import android.util.Log;
-import android.util.SparseArray;
 
 import jp.kshoji.driver.midi.device.MidiInputDevice;
 
 interface MidiKeyboardDriver {
 
     void attachListener(KeyListener keyListener);
+
+    void attachListener(NoteListener noteListener);
 
     void open();
 
@@ -21,55 +22,9 @@ interface MidiKeyboardDriver {
 
     }
 
-    enum Note {
-        C3,
-        D3,
-        E3,
-        F3,
-        G3,
-        A3,
-        B3,
-        C4,
-        D4,
-        E4,
-        F4,
-        G4,
-        A4,
-        B4,
-        C5,
-        D5,
-        E5,
-        F5,
-        G5,
-        NOT_IMPLED
-    }
-
     class KeyStationMini32 extends SimpleUsbMidiDriver implements MidiKeyboardDriver {
         private KeyListener keyListener;
-
-        private static final SparseArray<Note> NOTES_MAPPING = new SparseArray<>();
-
-        static {
-            NOTES_MAPPING.put(48, Note.C3);
-            NOTES_MAPPING.put(50, Note.D3);
-            NOTES_MAPPING.put(52, Note.E3);
-            NOTES_MAPPING.put(53, Note.F3);
-            NOTES_MAPPING.put(55, Note.G3);
-            NOTES_MAPPING.put(57, Note.A3);
-            NOTES_MAPPING.put(59, Note.B3);
-            NOTES_MAPPING.put(60, Note.C4);
-            NOTES_MAPPING.put(62, Note.D4);
-            NOTES_MAPPING.put(64, Note.E4);
-            NOTES_MAPPING.put(65, Note.F4);
-            NOTES_MAPPING.put(67, Note.G4);
-            NOTES_MAPPING.put(69, Note.A4);
-            NOTES_MAPPING.put(71, Note.B4);
-            NOTES_MAPPING.put(72, Note.C5);
-            NOTES_MAPPING.put(74, Note.D5);
-            NOTES_MAPPING.put(76, Note.E5);
-            NOTES_MAPPING.put(77, Note.F5);
-            NOTES_MAPPING.put(79, Note.G5);
-        }
+        private NoteListener noteListener;
 
         KeyStationMini32(Context context) {
             super(context);
@@ -78,6 +33,11 @@ interface MidiKeyboardDriver {
         @Override
         public void attachListener(KeyListener keyListener) {
             this.keyListener = keyListener;
+        }
+
+        @Override
+        public void attachListener(NoteListener noteListener) {
+            this.noteListener = noteListener;
         }
 
         @Override
@@ -91,19 +51,30 @@ interface MidiKeyboardDriver {
         }
 
         @Override
+        public void onMidiNoteOn(
+                MidiInputDevice midiInputDevice,
+                int cable,
+                int channel,
+                int note,
+                int velocity) {
+            Note wrappedNote = new Note(note);
+            if (noteListener != null) {
+                noteListener.onPress(wrappedNote);
+            }
+            if (keyListener != null) {
+                keyListener.onKeyPressed(wrappedNote);
+            }
+        }
+
+        @Override
         public void onMidiNoteOff(
                 MidiInputDevice midiInputDevice,
                 int cable,
                 int channel,
                 int note,
                 int velocity) {
-            if (keyListener == null) {
-                return;
-            }
-            if (NOTES_MAPPING.indexOfKey(note) < 0) {
-                keyListener.onKeyPressed(Note.NOT_IMPLED);
-            } else {
-                keyListener.onKeyPressed(NOTES_MAPPING.get(note));
+            if (noteListener != null) {
+                noteListener.onRelease(new Note(note));
             }
         }
     }

--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/MidiKeyboardDriver.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/MidiKeyboardDriver.java
@@ -1,14 +1,10 @@
 package com.novoda.pianohero;
 
 import android.content.Context;
-import android.hardware.usb.UsbDevice;
-import android.util.Log;
 
 import jp.kshoji.driver.midi.device.MidiInputDevice;
 
 interface MidiKeyboardDriver {
-
-    void attachListener(KeyListener keyListener);
 
     void attachListener(NoteListener noteListener);
 
@@ -16,14 +12,7 @@ interface MidiKeyboardDriver {
 
     void close();
 
-    interface KeyListener {
-
-        void onKeyPressed(Note note);
-
-    }
-
     class KeyStationMini32 extends SimpleUsbMidiDriver implements MidiKeyboardDriver {
-        private KeyListener keyListener;
         private NoteListener noteListener;
 
         KeyStationMini32(Context context) {
@@ -31,23 +20,8 @@ interface MidiKeyboardDriver {
         }
 
         @Override
-        public void attachListener(KeyListener keyListener) {
-            this.keyListener = keyListener;
-        }
-
-        @Override
         public void attachListener(NoteListener noteListener) {
             this.noteListener = noteListener;
-        }
-
-        @Override
-        public void onDeviceAttached(UsbDevice usbDevice) {
-            Log.d("!!!", "device attached");
-        }
-
-        @Override
-        public void onDeviceDetached(UsbDevice usbDevice) {
-            Log.d("!!!", "device detached");
         }
 
         @Override
@@ -57,12 +31,8 @@ interface MidiKeyboardDriver {
                 int channel,
                 int note,
                 int velocity) {
-            Note wrappedNote = new Note(note);
             if (noteListener != null) {
-                noteListener.onPress(wrappedNote);
-            }
-            if (keyListener != null) {
-                keyListener.onKeyPressed(wrappedNote);
+                noteListener.onPress(new Note(note));
             }
         }
 

--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/MidiKeyboardDriver.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/MidiKeyboardDriver.java
@@ -2,13 +2,10 @@ package com.novoda.pianohero;
 
 import android.content.Context;
 import android.hardware.usb.UsbDevice;
-import android.support.annotation.NonNull;
 import android.util.Log;
 import android.util.SparseArray;
 
 import jp.kshoji.driver.midi.device.MidiInputDevice;
-import jp.kshoji.driver.midi.device.MidiOutputDevice;
-import jp.kshoji.driver.midi.util.UsbMidiDriver;
 
 interface MidiKeyboardDriver {
 
@@ -47,7 +44,7 @@ interface MidiKeyboardDriver {
         NOT_IMPLED
     }
 
-    class KeyStationMini32 extends UsbMidiDriver implements MidiKeyboardDriver {
+    class KeyStationMini32 extends SimpleUsbMidiDriver implements MidiKeyboardDriver {
         private KeyListener keyListener;
 
         private static final SparseArray<Note> NOTES_MAPPING = new SparseArray<>();
@@ -74,58 +71,8 @@ interface MidiKeyboardDriver {
             NOTES_MAPPING.put(79, Note.G5);
         }
 
-        protected KeyStationMini32(@NonNull Context context) {
+        KeyStationMini32(Context context) {
             super(context);
-        }
-
-        @Override
-        public void onDeviceAttached(@NonNull UsbDevice usbDevice) {
-            Log.d("!!!", "device attached");
-        }
-
-        @Override
-        public void onMidiInputDeviceAttached(@NonNull MidiInputDevice midiInputDevice) {
-            // not used
-        }
-
-        @Override
-        public void onMidiOutputDeviceAttached(@NonNull MidiOutputDevice midiOutputDevice) {
-            // not used
-        }
-
-        @Override
-        public void onDeviceDetached(@NonNull UsbDevice usbDevice) {
-            Log.d("!!!", "device detached");
-        }
-
-        @Override
-        public void onMidiInputDeviceDetached(@NonNull MidiInputDevice midiInputDevice) {
-            // not used
-        }
-
-        @Override
-        public void onMidiOutputDeviceDetached(@NonNull MidiOutputDevice midiOutputDevice) {
-            // not used
-        }
-
-        @Override
-        public void onMidiMiscellaneousFunctionCodes(@NonNull MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
-            // not used
-        }
-
-        @Override
-        public void onMidiCableEvents(@NonNull MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
-            // not used
-        }
-
-        @Override
-        public void onMidiSystemCommonMessage(@NonNull MidiInputDevice midiInputDevice, int i, byte[] bytes) {
-            // not used
-        }
-
-        @Override
-        public void onMidiSystemExclusive(@NonNull MidiInputDevice midiInputDevice, int i, byte[] bytes) {
-            // not used
         }
 
         @Override
@@ -133,39 +80,19 @@ interface MidiKeyboardDriver {
             this.keyListener = keyListener;
         }
 
-        /**
-         * Note-on
-         * Code Index Number : 0x9
-         *
-         * @param midiInputDevice the Object which the event sent
-         * @param cable           the cable ID 0-15
-         * @param channel         the MIDI channel number 0-15
-         * @param note            0-127
-         * @param velocity        0-127
-         */
         @Override
-        public void onMidiNoteOn(
-                @NonNull MidiInputDevice midiInputDevice,
-                int cable,
-                int channel,
-                int note,
-                int velocity) {
-            // not used
+        public void onDeviceAttached(UsbDevice usbDevice) {
+            Log.d("!!!", "device attached");
         }
 
-        /**
-         * Note-off
-         * Code Index Number : 0x8
-         *
-         * @param midiInputDevice the Object which the event sent
-         * @param cable           the cable ID 0-15
-         * @param channel         0-15
-         * @param note            0-127
-         * @param velocity        0-127
-         */
+        @Override
+        public void onDeviceDetached(UsbDevice usbDevice) {
+            Log.d("!!!", "device detached");
+        }
+
         @Override
         public void onMidiNoteOff(
-                @NonNull MidiInputDevice midiInputDevice,
+                MidiInputDevice midiInputDevice,
                 int cable,
                 int channel,
                 int note,
@@ -178,86 +105,6 @@ interface MidiKeyboardDriver {
             } else {
                 keyListener.onKeyPressed(NOTES_MAPPING.get(note));
             }
-        }
-
-        @Override
-        public void onMidiPolyphonicAftertouch(@NonNull MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
-            // not used
-        }
-
-        @Override
-        public void onMidiControlChange(@NonNull MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
-            // not used
-        }
-
-        @Override
-        public void onMidiProgramChange(@NonNull MidiInputDevice midiInputDevice, int i, int i1, int i2) {
-            // not used
-        }
-
-        @Override
-        public void onMidiChannelAftertouch(@NonNull MidiInputDevice midiInputDevice, int i, int i1, int i2) {
-            // not used
-        }
-
-        @Override
-        public void onMidiPitchWheel(@NonNull MidiInputDevice midiInputDevice, int i, int i1, int i2) {
-            // not used
-        }
-
-        @Override
-        public void onMidiSingleByte(@NonNull MidiInputDevice midiInputDevice, int i, int i1) {
-            // not used
-        }
-
-        @Override
-        public void onMidiTimeCodeQuarterFrame(@NonNull MidiInputDevice midiInputDevice, int i, int i1) {
-            // not used
-        }
-
-        @Override
-        public void onMidiSongSelect(@NonNull MidiInputDevice midiInputDevice, int i, int i1) {
-            // not used
-        }
-
-        @Override
-        public void onMidiSongPositionPointer(@NonNull MidiInputDevice midiInputDevice, int i, int i1) {
-            // not used
-        }
-
-        @Override
-        public void onMidiTuneRequest(@NonNull MidiInputDevice midiInputDevice, int i) {
-            // not used
-        }
-
-        @Override
-        public void onMidiTimingClock(@NonNull MidiInputDevice midiInputDevice, int i) {
-            // not used
-        }
-
-        @Override
-        public void onMidiStart(@NonNull MidiInputDevice midiInputDevice, int i) {
-            // not used
-        }
-
-        @Override
-        public void onMidiContinue(@NonNull MidiInputDevice midiInputDevice, int i) {
-            // not used
-        }
-
-        @Override
-        public void onMidiStop(@NonNull MidiInputDevice midiInputDevice, int i) {
-            // not used
-        }
-
-        @Override
-        public void onMidiActiveSensing(@NonNull MidiInputDevice midiInputDevice, int i) {
-            // not used
-        }
-
-        @Override
-        public void onMidiReset(@NonNull MidiInputDevice midiInputDevice, int i) {
-            // not used
         }
     }
 }

--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/NotesPlayedDispatcher.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/NotesPlayedDispatcher.java
@@ -1,0 +1,31 @@
+package com.novoda.pianohero;
+
+import java.util.HashSet;
+import java.util.Set;
+
+class NotesPlayedDispatcher implements NoteListener {
+
+    private final Set<Note> notesOn = new HashSet<>();
+    private final GamePresenter presenter;
+
+    NotesPlayedDispatcher(GamePresenter presenter) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void onPress(Note note) {
+        notesOn.add(note);
+        dispatchNotesPlayed();
+    }
+
+    @Override
+    public void onRelease(Note note) {
+        notesOn.remove(note);
+        dispatchNotesPlayed();
+    }
+
+    private void dispatchNotesPlayed() {
+        presenter.onNotesPlayed(notesOn.toArray(new Note[notesOn.size()]));
+    }
+
+}

--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/SimpleUsbMidiDriver.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/SimpleUsbMidiDriver.java
@@ -1,0 +1,159 @@
+package com.novoda.pianohero;
+
+import android.content.Context;
+import android.hardware.usb.UsbDevice;
+
+import jp.kshoji.driver.midi.device.MidiInputDevice;
+import jp.kshoji.driver.midi.device.MidiOutputDevice;
+import jp.kshoji.driver.midi.util.UsbMidiDriver;
+
+@SuppressWarnings("NullableProblems")
+abstract class SimpleUsbMidiDriver extends UsbMidiDriver {
+
+    SimpleUsbMidiDriver(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void onDeviceAttached(UsbDevice usbDevice) {
+    }
+
+    @Override
+    public void onMidiInputDeviceAttached(MidiInputDevice midiInputDevice) {
+    }
+
+    @Override
+    public void onMidiOutputDeviceAttached(MidiOutputDevice midiOutputDevice) {
+    }
+
+    @Override
+    public void onDeviceDetached(UsbDevice usbDevice) {
+    }
+
+    @Override
+    public void onMidiInputDeviceDetached(MidiInputDevice midiInputDevice) {
+    }
+
+    @Override
+    public void onMidiOutputDeviceDetached(MidiOutputDevice midiOutputDevice) {
+    }
+
+    @Override
+    public void onMidiMiscellaneousFunctionCodes(MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
+    }
+
+    @Override
+    public void onMidiCableEvents(MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
+    }
+
+    @Override
+    public void onMidiSystemCommonMessage(MidiInputDevice midiInputDevice, int i, byte[] bytes) {
+    }
+
+    @Override
+    public void onMidiSystemExclusive(MidiInputDevice midiInputDevice, int i, byte[] bytes) {
+    }
+
+    /**
+     * Note-on
+     * Code Index Number : 0x9
+     *
+     * @param midiInputDevice the Object which the event sent
+     * @param cable           the cable ID 0-15
+     * @param channel         the MIDI channel number 0-15
+     * @param note            0-127
+     * @param velocity        0-127
+     */
+    @Override
+    public void onMidiNoteOn(
+            MidiInputDevice midiInputDevice,
+            int cable,
+            int channel,
+            int note,
+            int velocity) {
+    }
+
+    /**
+     * Note-off
+     * Code Index Number : 0x8
+     *
+     * @param midiInputDevice the Object which the event sent
+     * @param cable           the cable ID 0-15
+     * @param channel         0-15
+     * @param note            0-127
+     * @param velocity        0-127
+     */
+    @Override
+    public void onMidiNoteOff(
+            MidiInputDevice midiInputDevice,
+            int cable,
+            int channel,
+            int note,
+            int velocity) {
+    }
+
+    @Override
+    public void onMidiPolyphonicAftertouch(MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
+    }
+
+    @Override
+    public void onMidiControlChange(MidiInputDevice midiInputDevice, int i, int i1, int i2, int i3) {
+    }
+
+    @Override
+    public void onMidiProgramChange(MidiInputDevice midiInputDevice, int i, int i1, int i2) {
+    }
+
+    @Override
+    public void onMidiChannelAftertouch(MidiInputDevice midiInputDevice, int i, int i1, int i2) {
+    }
+
+    @Override
+    public void onMidiPitchWheel(MidiInputDevice midiInputDevice, int i, int i1, int i2) {
+    }
+
+    @Override
+    public void onMidiSingleByte(MidiInputDevice midiInputDevice, int i, int i1) {
+    }
+
+    @Override
+    public void onMidiTimeCodeQuarterFrame(MidiInputDevice midiInputDevice, int i, int i1) {
+    }
+
+    @Override
+    public void onMidiSongSelect(MidiInputDevice midiInputDevice, int i, int i1) {
+    }
+
+    @Override
+    public void onMidiSongPositionPointer(MidiInputDevice midiInputDevice, int i, int i1) {
+    }
+
+    @Override
+    public void onMidiTuneRequest(MidiInputDevice midiInputDevice, int i) {
+    }
+
+    @Override
+    public void onMidiTimingClock(MidiInputDevice midiInputDevice, int i) {
+    }
+
+    @Override
+    public void onMidiStart(MidiInputDevice midiInputDevice, int i) {
+    }
+
+    @Override
+    public void onMidiContinue(MidiInputDevice midiInputDevice, int i) {
+    }
+
+    @Override
+    public void onMidiStop(MidiInputDevice midiInputDevice, int i) {
+    }
+
+    @Override
+    public void onMidiActiveSensing(MidiInputDevice midiInputDevice, int i) {
+    }
+
+    @Override
+    public void onMidiReset(MidiInputDevice midiInputDevice, int i) {
+    }
+
+}

--- a/piano-hero/mobile/src/main/java/com/novoda/pianohero/SimpleUsbMidiDriver.java
+++ b/piano-hero/mobile/src/main/java/com/novoda/pianohero/SimpleUsbMidiDriver.java
@@ -2,6 +2,7 @@ package com.novoda.pianohero;
 
 import android.content.Context;
 import android.hardware.usb.UsbDevice;
+import android.util.Log;
 
 import jp.kshoji.driver.midi.device.MidiInputDevice;
 import jp.kshoji.driver.midi.device.MidiOutputDevice;
@@ -16,26 +17,32 @@ abstract class SimpleUsbMidiDriver extends UsbMidiDriver {
 
     @Override
     public void onDeviceAttached(UsbDevice usbDevice) {
+        Log.v("!!!", "device attached");
     }
 
     @Override
     public void onMidiInputDeviceAttached(MidiInputDevice midiInputDevice) {
+        Log.v("!!!", "midi input device attached");
     }
 
     @Override
     public void onMidiOutputDeviceAttached(MidiOutputDevice midiOutputDevice) {
+        Log.v("!!!", "midi output device attached");
     }
 
     @Override
     public void onDeviceDetached(UsbDevice usbDevice) {
+        Log.v("!!!", "device detached");
     }
 
     @Override
     public void onMidiInputDeviceDetached(MidiInputDevice midiInputDevice) {
+        Log.v("!!!", "midi input device detached");
     }
 
     @Override
     public void onMidiOutputDeviceDetached(MidiOutputDevice midiOutputDevice) {
+        Log.v("!!!", "midi output device detached");
     }
 
     @Override


### PR DESCRIPTION
This PR modifies the `KeyStationMini32` class to use `NoteListener` as a callback instead of `KeyListener` so we can plug it into `PianoC3ToB5Activity` to test if the game works.

It pulls out a `SimpleUsbMidiDriver` because it has so many unused methods too. It seems the driver doesn't work when you use it on a regular Android device to connect a digital piano - perhaps we'd have to check the MIDI feature thing and use the normal android feature where available, and the USB one otherwise.