### PR TITLE
[MonkeyRunner] Remove the set of adb property from the child task

### DIFF
--- a/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
+++ b/monkey-runner/plugin/src/main/groovy/com/novoda/monkey/MonkeyConfigurationPlugin.groovy
@@ -49,7 +49,6 @@ class MonkeyConfigurationPlugin implements Plugin<Project> {
 
             def monkeyTask = project.task("runMonkeyDevice${index}", type: TargetedMonkey) {
                 packageName = extension.packageNameFilter
-                adb = android.command.adb
                 deviceId = device.id
                 logFileName = extension.logFileName
                 monkey = [events: extension.eventsCount, categories: extension.categories]
@@ -57,20 +56,17 @@ class MonkeyConfigurationPlugin implements Plugin<Project> {
 
             def uninstallApp = project.task("uninstallMonkeyDevice${index}", type: TargetedUninstall) {
                 packageName = extension.packageNameFilter
-                adb = android.command.adb
                 deviceId = device.id
             }
 
             if (extension.useMonkeyTrap) {
                 def showOverlayTask = project.task("showOverlayDevice${index}", type: NotificationBarOverlay) {
                     show = true
-                    adb = android.command.adb
                     deviceId = device.id
                 }
 
                 def hideOverlay = project.task("hideOverlayDevice${index}", type: NotificationBarOverlay) {
                     show = false
-                    adb = android.command.adb
                     deviceId = device.id
                 }
 


### PR DESCRIPTION
## Scope
This PR removes adb path set in the monkey-runner config task.

The reason behind is:
1. It fails to find `command.adb` in certain project (let's say CCleaner)
2. Setting up `adb` path is done anyway in the parent task and it works.

## Paired with
@takecare 