### PR TITLE
[espresso-support] Add idling resource

### DIFF
--- a/espresso-support/README.md
+++ b/espresso-support/README.md
@@ -30,6 +30,16 @@ public ViewTestRule<MovieItemView> rule = new ViewTestRule<>(R.layout.test_movie
 You can write BDD style tests here, highlighting the expected behaviour for your custom views, using a mixture of Espresso ViewActions and Mockito verifies:
 
 ```java
+@Before
+public void setUp() {
+    Espresso.registerIdlingResources(viewTestRule);
+}
+
+@After
+public void tearDown() {
+    Espresso.unregisterIdlingResources(viewTestRule);
+}
+
 @Test
 public void givenViewIsUpdatedWithDifferentMovie_whenClicking_thenListenerDoesNotGetFiredForOriginalMovie() {
     givenMovieItemViewIsBoundTo(EDWARD_SCISSORHANDS);

--- a/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -45,7 +45,7 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
 
     @Override
     public String getName() {
-        return "IdlingResourceName";
+        return ViewTestRule.class.getSimpleName() + "::IdlingResource";
     }
 
     @Override

--- a/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -2,15 +2,17 @@ package com.novoda.espresso;
 
 import android.content.Intent;
 import android.support.annotation.LayoutRes;
+import android.support.test.espresso.IdlingResource;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
-import com.novoda.espresso.ViewActivity;
-
-public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity> {
+public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity> implements IdlingResource {
 
     @LayoutRes
     private final int id;
+
+    private boolean isIdle = true;
+    private ResourceCallback callback;
 
     public ViewTestRule(@LayoutRes int id) {
         super(ViewActivity.class);
@@ -25,17 +27,35 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
     }
 
     public void bindViewUsing(final Binder<T> binder) {
+        isIdle = false;
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 T view = getView();
                 binder.bind(view);
+                callback.onTransitionToIdle();
+                isIdle = true;
             }
         });
     }
 
     public T getView() {
         return (T) getActivity().getView();
+    }
+
+    @Override
+    public String getName() {
+        return "IdlingResourceName";
+    }
+
+    @Override
+    public boolean isIdleNow() {
+        return isIdle;
+    }
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback callback) {
+        this.callback = callback;
     }
 
     public interface Binder<T> {

--- a/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
+++ b/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
@@ -1,5 +1,6 @@
 package com.novoda.movies;
 
+import android.support.test.espresso.Espresso;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -18,9 +19,7 @@ import org.mockito.junit.MockitoRule;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.support.test.espresso.matcher.ViewMatchers.*;
 import static com.novoda.espresso.AccessibilityViewMatchers.withUsageHintOnClick;
 import static com.novoda.espresso.AccessibilityViewMatchers.withUsageHintOnLongClick;
 import static org.hamcrest.CoreMatchers.is;
@@ -42,6 +41,7 @@ public class MovieItemViewTalkBackTest {
 
     @Before
     public void setUp() {
+        Espresso.registerIdlingResources(viewTestRule);
         MovieItemView view = viewTestRule.getView();
 
         view.attachListener(movieItemListener);
@@ -52,6 +52,7 @@ public class MovieItemViewTalkBackTest {
     @After
     public void tearDown() {
         viewTestRule.getView().detachListeners();
+        Espresso.unregisterIdlingResources(viewTestRule);
     }
 
     @Test

--- a/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTest.java
+++ b/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTest.java
@@ -1,5 +1,6 @@
 package com.novoda.movies;
 
+import android.support.test.espresso.Espresso;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -41,6 +42,8 @@ public class MovieItemViewTest {
 
     @Before
     public void setUp() {
+        Espresso.registerIdlingResources(viewTestRule);
+
         MovieItemView view = viewTestRule.getView();
 
         view.attachListener(movieItemListener);
@@ -51,6 +54,7 @@ public class MovieItemViewTest {
     @After
     public void tearDown() {
         viewTestRule.getView().detachListeners();
+        Espresso.unregisterIdlingResources(viewTestRule);
     }
 
     @Test


### PR DESCRIPTION
### Problem 

View binding happens on a different thread to test execution, so tests aren't waiting for the binding to complete.

This can mean that test asserts are executed before binding is complete which is especially an issue when verifying method calls on a mock.

### Solution

Implement Espresso's IdlingResource so we can block while view binding takes place.

### Paired with
@ataulm 