### PR TITLE
[espresso-support] Rename bindViewUsing to runOnUiThread

### DIFF
--- a/espresso-support/README.md
+++ b/espresso-support/README.md
@@ -51,9 +51,9 @@ public void givenViewIsUpdatedWithDifferentMovie_whenClicking_thenListenerDoesNo
 }
 
 private void givenMovieItemViewIsBoundTo(final Movie movie) {
-    viewTestRule.bindViewUsing(new ViewTestRule.Binder<MovieItemView>() {
+    viewTestRule.runOnUiThread(new ViewTestRule.UiThreadAction<MovieItemView>() {
         @Override
-        public void bind(MovieItemView view) {
+        public void run(MovieItemView view) {
             view.bind(movie);
         }
     });

--- a/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -26,13 +26,13 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
         return intent;
     }
 
-    public void bindViewUsing(final Binder<T> binder) {
+    public void runOnUiThread(final UiThreadAction<T> uiThreadAction) {
         isIdle = false;
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 T view = getView();
-                binder.bind(view);
+                uiThreadAction.run(view);
                 callback.onTransitionToIdle();
                 isIdle = true;
             }
@@ -58,9 +58,9 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
         this.callback = callback;
     }
 
-    public interface Binder<T> {
+    public interface UiThreadAction<T> {
 
-        void bind(T view);
+        void run(T view);
 
     }
 

--- a/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
+++ b/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
@@ -75,9 +75,9 @@ public class MovieItemViewTalkBackTest {
     }
 
     private void givenMovieItemViewIsBoundTo(final Movie movie) {
-        viewTestRule.bindViewUsing(new ViewTestRule.Binder<MovieItemView>() {
+        viewTestRule.runOnUiThread(new ViewTestRule.UiThreadAction<MovieItemView>() {
             @Override
-            public void bind(MovieItemView view) {
+            public void run(MovieItemView view) {
                 view.bind(movie);
             }
         });

--- a/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTest.java
+++ b/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTest.java
@@ -88,9 +88,9 @@ public class MovieItemViewTest {
     }
 
     private void givenMovieItemViewIsBoundTo(final Movie movie) {
-        viewTestRule.bindViewUsing(new ViewTestRule.Binder<MovieItemView>() {
+        viewTestRule.runOnUiThread(new ViewTestRule.UiThreadAction<MovieItemView>() {
             @Override
-            public void bind(MovieItemView view) {
+            public void run(MovieItemView view) {
                 view.bind(movie);
             }
         });


### PR DESCRIPTION
We started using this method to do things that weren't just binding to the view and realised the name is very prescriptive.

Make it generic!