### PR TITLE
[espresso-support] Replace IdlingResource on ViewTestRule with Instrumentation.runOnMainSync

### DIFF
--- a/espresso-support/README.md
+++ b/espresso-support/README.md
@@ -30,16 +30,6 @@ public ViewTestRule<MovieItemView> rule = new ViewTestRule<>(R.layout.test_movie
 You can write BDD style tests here, highlighting the expected behaviour for your custom views, using a mixture of Espresso ViewActions and Mockito verifies:
 
 ```java
-@Before
-public void setUp() {
-    Espresso.registerIdlingResources(viewTestRule);
-}
-
-@After
-public void tearDown() {
-    Espresso.unregisterIdlingResources(viewTestRule);
-}
-
 @Test
 public void givenViewIsUpdatedWithDifferentMovie_whenClicking_thenListenerDoesNotGetFiredForOriginalMovie() {
     givenMovieItemViewIsBoundTo(EDWARD_SCISSORHANDS);

--- a/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -1,11 +1,15 @@
 package com.novoda.espresso;
 
+import android.app.Instrumentation;
 import android.content.Intent;
 import android.support.annotation.LayoutRes;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
 public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity> {
+
+    private final Instrumentation instrumentation;
 
     @LayoutRes
     private final int id;
@@ -13,6 +17,7 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
     public ViewTestRule(@LayoutRes int id) {
         super(ViewActivity.class);
         this.id = id;
+        instrumentation = InstrumentationRegistry.getInstrumentation();
     }
 
     @Override
@@ -23,7 +28,7 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
     }
 
     public void runOnUiThread(final UiThreadAction<T> uiThreadAction) {
-        getActivity().runOnUiThread(new Runnable() {
+        instrumentation.runOnMainSync(new Runnable() {
             @Override
             public void run() {
                 T view = getView();

--- a/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -2,17 +2,13 @@ package com.novoda.espresso;
 
 import android.content.Intent;
 import android.support.annotation.LayoutRes;
-import android.support.test.espresso.IdlingResource;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
-public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity> implements IdlingResource {
+public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity> {
 
     @LayoutRes
     private final int id;
-
-    private boolean isIdle = true;
-    private ResourceCallback callback;
 
     public ViewTestRule(@LayoutRes int id) {
         super(ViewActivity.class);
@@ -27,35 +23,17 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
     }
 
     public void runOnUiThread(final UiThreadAction<T> uiThreadAction) {
-        isIdle = false;
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 T view = getView();
                 uiThreadAction.run(view);
-                callback.onTransitionToIdle();
-                isIdle = true;
             }
         });
     }
 
     public T getView() {
         return (T) getActivity().getView();
-    }
-
-    @Override
-    public String getName() {
-        return ViewTestRule.class.getSimpleName() + "::IdlingResource";
-    }
-
-    @Override
-    public boolean isIdleNow() {
-        return isIdle;
-    }
-
-    @Override
-    public void registerIdleTransitionCallback(ResourceCallback callback) {
-        this.callback = callback;
     }
 
     public interface UiThreadAction<T> {

--- a/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
+++ b/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTalkBackTest.java
@@ -1,6 +1,5 @@
 package com.novoda.movies;
 
-import android.support.test.espresso.Espresso;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -41,7 +40,6 @@ public class MovieItemViewTalkBackTest {
 
     @Before
     public void setUp() {
-        Espresso.registerIdlingResources(viewTestRule);
         MovieItemView view = viewTestRule.getView();
 
         view.attachListener(movieItemListener);
@@ -52,7 +50,6 @@ public class MovieItemViewTalkBackTest {
     @After
     public void tearDown() {
         viewTestRule.getView().detachListeners();
-        Espresso.unregisterIdlingResources(viewTestRule);
     }
 
     @Test

--- a/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTest.java
+++ b/espresso-support/demo/src/androidTest/java/com/novoda/movies/MovieItemViewTest.java
@@ -1,6 +1,5 @@
 package com.novoda.movies;
 
-import android.support.test.espresso.Espresso;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -42,8 +41,6 @@ public class MovieItemViewTest {
 
     @Before
     public void setUp() {
-        Espresso.registerIdlingResources(viewTestRule);
-
         MovieItemView view = viewTestRule.getView();
 
         view.attachListener(movieItemListener);
@@ -54,7 +51,6 @@ public class MovieItemViewTest {
     @After
     public void tearDown() {
         viewTestRule.getView().detachListeners();
-        Espresso.unregisterIdlingResources(viewTestRule);
     }
 
     @Test


### PR DESCRIPTION
# Problem

Hastily implemented IdlingResource to ViewTestRule.bind method to make tests wait for the bind to complete before moving on.

Unfortunately, this doesn't stop lines in the tests from executing - I suppose there's specific methods that respect the idling resource.

# Solution

In any case, the binding of a view is not really a "resource". It turns out there's another method available on `Instrumentation` which allows you to run methods on the main thread (necessary if we want to bind views!) and here is the comment above:

```java
/**
 * Execute a call on the application's main thread, blocking until it is
 * complete.  Useful for doing things that are not thread-safe, such as
 * looking at or modifying the view hierarchy.
 * 
 * @param runner The code to run on the main thread.
 */
public void runOnMainSync(Runnable runner) {
    ...
}
```

We want to do that! This has the advantage over `activity.runOnUiThread(Runnable)` in that the test execution is blocked, so the test will wait for the view to be bound completely, even if the next line is just a `Log` statement.

Paired with @mr-archano (jk, he totes told me about this)
