### PR TITLE
Update for Espresso 3.0.1

### DIFF
--- a/espresso-support/build.gradle
+++ b/espresso-support/build.gradle
@@ -14,5 +14,8 @@ ext {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }

--- a/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -22,7 +22,7 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
 
     @Override
     protected Intent getActivityIntent() {
-        Intent intent = super.getActivityIntent();
+        Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.putExtra(ViewActivity.EXTRA_LAYOUT_ID, id);
         return intent;
     }

--- a/espresso-support/dependencies.gradle
+++ b/espresso-support/dependencies.gradle
@@ -15,8 +15,8 @@ ext {
                     bintrayRelease: 'com.novoda:bintray-release:0.4.0'
             ],
             accessibilitools   : 'com.novoda:accessibilitools:1.4.0',
-            androidTestRunner  : 'com.android.support.test:runner:0.5',
-            androidEspressoCore: 'com.android.support.test.espresso:espresso-core:2.2.2',
+            androidTestRunner  : 'com.android.support.test:runner:1.0.1',
+            androidEspressoCore: 'com.android.support.test.espresso:espresso-core:3.0.1',
             dexmaker           : "com.google.dexmaker:dexmaker:${versions.dexmaker}",
             dexmakerMockito    : "com.google.dexmaker:dexmaker-mockito:${versions.dexmaker}",
             jUnit              : 'junit:junit:4.12',


### PR DESCRIPTION
Fixes #323 

Updated dependencies to 3.0.1 version of Espresso and corresponding 1.0.1 of the test runner. Made the very small change needed to create the Intent rather than letting the superclass create it, which it no longer does (returns null).

Reran all the tests as per the README.