### PR TITLE
[espresso-support] Allow to create the View programatically

### DIFF
--- a/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -1,11 +1,12 @@
 package com.novoda.espresso;
 
 import android.app.Instrumentation;
-import android.content.Intent;
 import android.support.annotation.LayoutRes;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ActivityTestRule;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 
 public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity> {
 
@@ -13,6 +14,7 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
 
     @LayoutRes
     private final int id;
+    private T view;
 
     public ViewTestRule(@LayoutRes int id) {
         super(ViewActivity.class);
@@ -21,10 +23,24 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
     }
 
     @Override
-    protected Intent getActivityIntent() {
-        Intent intent = new Intent(Intent.ACTION_MAIN);
-        intent.putExtra(ViewActivity.EXTRA_LAYOUT_ID, id);
-        return intent;
+    protected void afterActivityLaunched() {
+        instrumentation.runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                launchView();
+            }
+        });
+    }
+
+    protected void launchView() {
+        final ViewActivity activity = getActivity();
+        final ViewGroup parent = (ViewGroup) activity.findViewById(android.R.id.content);
+        view = createView(activity.getLayoutInflater(), parent);
+        activity.setContentView(view);
+    }
+
+    protected T createView(final LayoutInflater inflater, ViewGroup parent) {
+        return (T) inflater.inflate(id, parent, false);
     }
 
     public void runOnMainSynchronously(final Runner<T> runner) {
@@ -38,7 +54,7 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<ViewActivity>
     }
 
     public T getView() {
-        return (T) getActivity().getView();
+        return view;
     }
 
     public interface Runner<T> {

--- a/espresso-support/extras/src/main/java/com/novoda/espresso/ViewActivity.java
+++ b/espresso-support/extras/src/main/java/com/novoda/espresso/ViewActivity.java
@@ -1,35 +1,6 @@
 package com.novoda.espresso;
 
 import android.app.Activity;
-import android.os.Bundle;
-import android.view.View;
-import android.view.ViewGroup;
-
-import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
 public class ViewActivity extends Activity {
-
-    public static final String EXTRA_LAYOUT_ID = ViewActivity.class.getName() + ".EXTRA_LAYOUT_ID";
-
-    private View view;
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        int layout = getIntent().getIntExtra(EXTRA_LAYOUT_ID, 0);
-
-        view = getLayoutInflater().inflate(layout, null, false);
-        ViewGroup.LayoutParams params = createMatchParentParams();
-
-        setContentView(view, params);
-    }
-
-    private ViewGroup.LayoutParams createMatchParentParams() {
-        return new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT);
-    }
-
-    public View getView() {
-        return view;
-    }
-
 }


### PR DESCRIPTION
This allows to generate the view programatically and it doesn't introduce any BC.

This is usefull in some cases. For example, I'm using Flow so I instantiate all my Views by code. And I inject all the View dependecies before I add it to a parent. This way I know that my dependencies are warmed when `onAttachedToWindow` is called. With the previous code I couldn't test those views.