### PR TITLE
Fix lines tool to include .h files

### DIFF
--- a/code-review-tools/ios/lines
+++ b/code-review-tools/ios/lines
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-find . -path ./Pods -prune -o -name "*\.m" -exec wc -l {} +
+find . -path ./Pods -prune -o -name "*\.h" -exec wc -l {} +
 
+H_TOTAL=$(find . -path ./Pods -prune -o -name "*\.h" | wc -l)
+printf "Total number of *.h files: %s \n" $H_TOTAL
+
+find . -path ./Pods -prune -o -name "*\.m" -exec wc -l {} +
 TOTAL=$(find . -path ./Pods -prune -o -name "*\.m" | wc -l)
 printf "Total number of *.m files: %s \n" $TOTAL
 


### PR DESCRIPTION
Should calculate the number of lines in header and implementation files for objective c