### PR TITLE
Prevent crash by ensuring rendering is done on the UI thread

### DIFF
--- a/game-of-life-multiplatform/android/src/main/java/com/novoda/gol/presentation/AndroidBoardView.kt
+++ b/game-of-life-multiplatform/android/src/main/java/com/novoda/gol/presentation/AndroidBoardView.kt
@@ -28,6 +28,8 @@ class AndroidBoardView @JvmOverloads constructor(
     }
 
     override fun renderBoard(boardEntity: BoardEntity) {
-        cellMatrixView.render(boardEntity)
+        cellMatrixView.post {
+            cellMatrixView.render(boardEntity)
+        }
     }
 }


### PR DESCRIPTION
Rendering the CellView is done on the background thread leading to a crash. 
Ensuring rendering is done on the main thread fixes this.

**Steps to reproduce:**
Launch Android app
Choose blinker pattern
Click "Start Simulation"
-> Crash

**Stacktrace:**
```
02-01 23:09:18.122  3526  3544 W System.err: io.reactivex.exceptions.OnErrorNotImplementedException: Only the original thread that created a view hierarchy can touch its views.
02-01 23:09:18.122  3526  3544 W System.err: 	at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:704)
02-01 23:09:18.122  3526  3544 W System.err: 	at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:701)
02-01 23:09:18.122  3526  3544 W System.err: 	at io.reactivex.internal.subscribers.LambdaSubscriber.onError(LambdaSubscriber.java:76)
02-01 23:09:18.122  3526  3544 W System.err: 	at io.reactivex.internal.subscribers.LambdaSubscriber.onNext(LambdaSubscriber.java:66)
02-01 23:09:18.122  3526  3544 W System.err: 	at io.reactivex.internal.operators.flowable.FlowableInterval$IntervalSubscriber.run(FlowableInterval.java:93)
02-01 23:09:18.122  3526  3544 W System.err: 	at io.reactivex.internal.schedulers.ScheduledDirectPeriodicTask.run(ScheduledDirectPeriodicTask.java:39)
02-01 23:09:18.122  3526  3544 W System.err: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:423)
02-01 23:09:18.122  3526  3544 W System.err: 	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:278)
02-01 23:09:18.122  3526  3544 W System.err: 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:270)
02-01 23:09:18.122  3526  3544 W System.err: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
02-01 23:09:18.122  3526  3544 W System.err: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
02-01 23:09:18.122  3526  3544 W System.err: 	at java.lang.Thread.run(Thread.java:818)
02-01 23:09:18.122  3526  3544 W System.err: Caused by: android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
02-01 23:09:18.123  3526  3544 W System.err: 	at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:6556)
02-01 23:09:18.123  3526  3544 W System.err: 	at android.view.ViewRootImpl.invalidateChildInParent(ViewRootImpl.java:942)
02-01 23:09:18.123  3526  3544 W System.err: 	at android.view.ViewGroup.invalidateChild(ViewGroup.java:5081)
02-01 23:09:18.123  3526  3544 W System.err: 	at android.view.View.invalidateInternal(View.java:12713)
02-01 23:09:18.123  3526  3544 W System.err: 	at android.view.View.invalidate(View.java:12677)
02-01 23:09:18.123  3526  3544 W System.err: 	at android.view.View.invalidate(View.java:12661)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.CellMatrixView.render(CellMatrixView.kt:30)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.AndroidBoardView.renderBoard(AndroidBoardView.kt:31)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.board.BoardPresenter$bind$1.invoke(BoardPresenter.kt:11)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.board.BoardPresenter$bind$1.invoke(BoardPresenter.kt:4)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.board.BoardModelImpl$$special$$inlined$observable$1.afterChange(Delegates.kt:57)
02-01 23:09:18.123  3526  3544 W System.err: 	at kotlin.properties.ObservableProperty.setValue(ObservableProperty.kt:36)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.board.BoardModelImpl.setBoard(BoardModelImpl.kt)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.board.BoardModelImpl.access$setBoard$p(BoardModelImpl.kt:13)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.board.BoardModelImpl$1.invoke(BoardModelImpl.kt:26)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.presentation.board.BoardModelImpl$1.invoke(BoardModelImpl.kt:13)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.GameLoopImpl$startWith$1.accept(GameLoop.kt:15)
02-01 23:09:18.123  3526  3544 W System.err: 	at com.novoda.gol.GameLoopImpl$startWith$1.accept(GameLoop.kt:7)
02-01 23:09:18.123  3526  3544 W System.err: 	at io.reactivex.internal.subscribers.LambdaSubscriber.onNext(LambdaSubscriber.java:62)
02-01 23:09:18.124  3526  3544 W System.err: 	... 8 more
02-01 23:09:18.124  3526  3544 E AndroidRuntime: FATAL EXCEPTION: RxComputationThreadPool-1
02-01 23:09:18.124  3526  3544 E AndroidRuntime: Process: com.novoda.gol, PID: 3526
02-01 23:09:18.124  3526  3544 E AndroidRuntime: io.reactivex.exceptions.OnErrorNotImplementedException: Only the original thread that created a view hierarchy can touch its views.
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:704)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:701)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at io.reactivex.internal.subscribers.LambdaSubscriber.onError(LambdaSubscriber.java:76)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at io.reactivex.internal.subscribers.LambdaSubscriber.onNext(LambdaSubscriber.java:66)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at io.reactivex.internal.operators.flowable.FlowableInterval$IntervalSubscriber.run(FlowableInterval.java:93)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at io.reactivex.internal.schedulers.ScheduledDirectPeriodicTask.run(ScheduledDirectPeriodicTask.java:39)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:423)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:278)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:270)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:818)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: Caused by: android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:6556)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at android.view.ViewRootImpl.invalidateChildInParent(ViewRootImpl.java:942)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at android.view.ViewGroup.invalidateChild(ViewGroup.java:5081)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at android.view.View.invalidateInternal(View.java:12713)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at android.view.View.invalidate(View.java:12677)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at android.view.View.invalidate(View.java:12661)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.CellMatrixView.render(CellMatrixView.kt:30)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.AndroidBoardView.renderBoard(AndroidBoardView.kt:31)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.board.BoardPresenter$bind$1.invoke(BoardPresenter.kt:11)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.board.BoardPresenter$bind$1.invoke(BoardPresenter.kt:4)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.board.BoardModelImpl$$special$$inlined$observable$1.afterChange(Delegates.kt:57)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at kotlin.properties.ObservableProperty.setValue(ObservableProperty.kt:36)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.board.BoardModelImpl.setBoard(BoardModelImpl.kt)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.board.BoardModelImpl.access$setBoard$p(BoardModelImpl.kt:13)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.board.BoardModelImpl$1.invoke(BoardModelImpl.kt:26)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.presentation.board.BoardModelImpl$1.invoke(BoardModelImpl.kt:13)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.GameLoopImpl$startWith$1.accept(GameLoop.kt:15)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at com.novoda.gol.GameLoopImpl$startWith$1.accept(GameLoop.kt:7)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	at io.reactivex.internal.subscribers.LambdaSubscriber.onNext(LambdaSubscriber.java:62)
02-01 23:09:18.124  3526  3544 E AndroidRuntime: 	... 8 more
02-01 23:09:18.126  1583  2135 W ActivityManager:   Force finishing activity com.novoda.gol/.GameOfLife
```