### PR TITLE
[Kotlin/Native] Upgrade Kotlin native 0.6.1

### DIFF
--- a/game-of-life-multiplatform/gradle.properties
+++ b/game-of-life-multiplatform/gradle.properties
@@ -17,4 +17,4 @@
 # org.gradle.parallel=true
 
 INCLUDE_ANDROID=true
-kotlin_native_version=0.6
+kotlin_native_version=0.6.1

--- a/game-of-life-multiplatform/ios/build.gradle
+++ b/game-of-life-multiplatform/ios/build.gradle
@@ -6,6 +6,7 @@ konanArtifacts {
 
     framework('KotlinGameOfLife') {
         enableMultiplatform true
+        enableDebug true
     }
     
 }


### PR DESCRIPTION
### Description
Update Kotlin/Native 0.6.1 which finally enables debugging kotlin code using `lldb` 🎉 

For example:
`breakpoint set --file AppPresenter.kt --line 12`
