### PR TITLE
[dungeon crawler] Fix the player only being able to move in one direction

### DIFF
--- a/dungeon-crawler/game_engine/src/main/java/com/novoda/dungeoncrawler/GameEngine.java
+++ b/dungeon-crawler/game_engine/src/main/java/com/novoda/dungeoncrawler/GameEngine.java
@@ -50,8 +50,8 @@ class GameEngine {
         long frameTime = clock.millis();
         if (frameTime - state.frameTime >= MIN_REDRAW_INTERVAL) {
             JoystickActuator.JoyState joyState = inputActuator.getInput();
-            int joyTilt = Math.abs(joyState.tilt);
-            int joyWobble = Math.abs(joyState.wobble);
+            int joyTilt = joyState.tilt;
+            int joyWobble = joyState.wobble;
             store.dispatch(Redux.GameActions.nextFrame(frameTime, joyTilt, joyWobble));
         }
     }


### PR DESCRIPTION
Before | After
--- | ---
![before](https://user-images.githubusercontent.com/1626673/41925995-f86ca482-7965-11e8-9b80-05940fd84297.gif) | ![after](https://user-images.githubusercontent.com/1626673/41925949-dd01fe86-7965-11e8-8f5e-86bca9ef8a93.gif)
