### PR TITLE
Add the conference list folder with three initial readme files

### DIFF
--- a/ConferenceTrainningList/Conferences.md
+++ b/ConferenceTrainningList/Conferences.md
@@ -1,0 +1,73 @@
+# Conference List 🎟
+
+## January
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| iOS Conf | 🇸🇬 | ios | ❌|
+
+## February
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## March
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## April
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## May
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## June
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## July
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## August
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## September
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## October
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## November
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |
+
+## December
+
+| Name | Country | Topics | Attended |
+| --- | --- | --- | --- |
+| Name | Country | Topics | ❌ || ✅ |

--- a/ConferenceTrainningList/howtocontribute.md
+++ b/ConferenceTrainningList/howtocontribute.md
@@ -1,0 +1,40 @@
+# How to Contribute
+
+## Add the conference to the appropriate month .md file
+
+If the conference moves months depending on the year add it to the month from last year or this year (if that has already been decided).
+
+### Template
+
+```
+## Name 🇫🇷
+
+[link](link)
+
+- topic
+- topic
+
+### Summary
+
+
+### Novodians
+
+- [ ] Novoda Attended
+- [ ] Novoda spoke
+```
+
+- Name: add name of conference and country they are or city (using emojis if you can for the country)
+- Link: If the conference has a link that will be expired at the end of an event add that one and also add twitter handler for that conference (if there is one)
+- Topic: Add keywords for different topics this conference handles (eg: IOS, Android, Testing, Design, Agile, etc) you can add as many as you think are relevant
+- Summary: Write a little bit why this conference is relevant for Novodians, why we should know about it. What is good about it or interesting and who is aimed to
+- Novodians: Has anyone at Novoda attended this conference? Check box and add who
+- Novodians: Has anyone at Novoda spoken at this conference? Check box and add who. Also add under it the topic they talked about and slides if you have them.
+
+
+## Add the conference to the Main Conference file
+
+Find the month table to add your conference and edit the table adding a row it following this template:
+
+```
+| Name | Country | Topics | ❌ || ✅ |
+```

--- a/ConferenceTrainningList/january.md
+++ b/ConferenceTrainningList/january.md
@@ -1,0 +1,16 @@
+# January
+
+## iOS Conf Singapore 🇸🇬
+
+[2019.iosconf.sg](https://2019.iosconf.sg/)
+
+- IOS
+
+### Summary
+
+Berta Devant has been in contact with the organizers about speaking there, even though she is not going to speak in the end. But after looking at the speakers and talking to the organizer she thinks highly of the technical level of this conference and would recommend any IOS developer to attend it. Probably one of the highest technical conference she has seen so far.
+
+### Novodians
+
+- [ ] Novoda Attended
+- [ ] Novoda spoke


### PR DESCRIPTION
As per the last speakers meeting we decided to get all the conferences we know about and have information about in one place to be easily maintained and to be able to make this public in the future. 

The PR adds the first three .md files 

- Conferences.md which is seperated by month and has one conference as a template and the rest of the months are empty 
- January.md to show what one month should look like and has one conference reviewed by me that shows what it would look like to have extra information about the conference besides dates. 
- How to contribute to set templates and what means what to get people to start adding conferences to the repo easily. 

Next: 
- Add the rest of the months .md files 
- Add the rest of the conferences 