### PR TITLE
[SSS] Makefile for build and run commands

### DIFF
--- a/microservices-swift/Makefile
+++ b/microservices-swift/Makefile
@@ -1,0 +1,11 @@
+# BUILD FOR DEPLOYMENT
+create_docker_images: create_build_image create_run_image
+
+build_on_docker: create_build_image
+	docker run --volume $$PWD:/swift-project --workdir /swift-project myapp-build /swift-utils/tools-utils.sh build release
+run_on_docker: build_on_docker create_run_image
+	docker run -it --publish 8080:8080 myapp-run
+create_build_image:
+	docker build --tag myapp-build --file Dockerfile-tools .
+create_run_image:
+	docker build --tag myapp-run .

--- a/microservices-swift/Makefile
+++ b/microservices-swift/Makefile
@@ -1,11 +1,14 @@
-# BUILD FOR DEPLOYMENT
-create_docker_images: create_build_image create_run_image
+# CONSTANTS
+PORT=8080
+BUILD_IMAGE_TAG=boardgame-build
+RUN_IMAGE_TAG=boardgame-run
 
-build_on_docker: create_build_image
-	docker run --volume $$PWD:/swift-project --workdir /swift-project myapp-build /swift-utils/tools-utils.sh build release
+# BUILD FOR DEPLOYMENT
 run_on_docker: build_on_docker create_run_image
-	docker run -it --publish 8080:8080 myapp-run
+	docker run -it --publish $(PORT):$(PORT) $(RUN_IMAGE_TAG)
+build_on_docker: create_build_image
+	docker run --volume $$PWD:/swift-project --workdir /swift-project $(BUILD_IMAGE_TAG) /swift-utils/tools-utils.sh build release
 create_build_image:
-	docker build --tag myapp-build --file Dockerfile-tools .
+	docker build --tag $(BUILD_IMAGE_TAG) --file Dockerfile-tools .
 create_run_image:
-	docker build --tag myapp-run .
+	docker build --tag $(RUN_IMAGE_TAG) .

--- a/microservices-swift/Package.resolved
+++ b/microservices-swift/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Signals",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSignals.git",
+        "state": {
+          "branch": null,
+          "revision": "6d13339441e687695f9980303594304599a03560",
+          "version": "1.0.20"
+        }
+      },
+      {
         "package": "Socket",
         "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
         "state": {
@@ -134,6 +143,15 @@
           "branch": null,
           "revision": "5a2361ba1f005596a2bfa28de76ed4acf1e71c33",
           "version": "3.2.4-swift4"
+        }
+      },
+      {
+        "package": "OpenSSL",
+        "repositoryURL": "https://github.com/IBM-Swift/OpenSSL.git",
+        "state": {
+          "branch": null,
+          "revision": "6c7e2e3610037fbc05c0d846cec981518961d8bf",
+          "version": "2.2.2"
         }
       },
       {


### PR DESCRIPTION
This Makefile facilitates building and running artifacts that can be deployed in Linux machines. 

Examples: 

Run the server on a docker runtime image based on linux. 
```
$ make run_on_docker
```

Just create the linux artifact

```
$ make build_on_docker
```

